### PR TITLE
CONTRIBUTING: Replace mailto:spdx-tech with Mailman link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
 # Contributing
 
-When contributing to this repository, please first discuss the change you wish to make via SPDX technical mailing list <spdx-tech@lists.spdx.org>
+When contributing to this repository, please first discuss the change you wish to make on [the SPDX technical mailing list][spdx-tech].
+
+[spdx-tech]: https://lists.spdx.org/mailman/listinfo/spdx-tech


### PR DESCRIPTION
To make it easier for potential contributors to discover the archives, subscribe to the list, etc.