### PR TITLE
chapters/appendix-I: Bump license list to v2.6 (via new script)

### DIFF
--- a/bin/pull-license-list.py
+++ b/bin/pull-license-list.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+#
+# Automatically update the license- and exception-list Markdown based
+# on the currently-live JSON.
+#
+# usage: ./bin/pull-license.py
+#
+# Script licensed under SPDX-License-Identifier: MIT
+
+import codecs
+import itertools
+import json
+import os.path
+import re
+import urllib.request
+
+
+VERSION_REGEXP = re.compile(
+    pattern='(.* SPDX License List, v)([^ ]*)( which was released )([^.]*)(\..*)',
+    flags=re.DOTALL)
+
+
+def get_json(url):
+    with urllib.request.urlopen(url=url) as response:
+        charset = response.headers.get_content_charset('UTF-8')
+        reader = codecs.getreader(charset)
+        return json.load(reader(response))
+
+
+def format_table(headers, rows):
+    widths = [
+        max(len(row[i]) for row in rows + [headers])
+        for i, _ in enumerate(headers)
+    ]
+    template = '| {} |\n'.format(' | '.join(
+        ('{' + '{}:{{{}}}'.format(2*i, 2*i + 1) + '}')
+        for i, _ in enumerate(headers)
+    ))
+    yield template.format(*itertools.chain(*zip(headers, widths)))
+    yield '|{}|\n'.format('|'.join('-' * (width + 2) for width in widths))
+    for row in rows:
+        yield template.format(*itertools.chain(*zip(row, widths)))
+    yield '\n'
+
+    
+def format_license_table(license_list):
+    yield from format_table(
+        headers=['Full Name of License', 'Short Identifier', 'OSI?'],
+        rows=[
+            [
+                license['name'],
+                '[{0}](https://spdx.org/licenses/{0}.html)'.format(
+                    license['licenseId']),
+                'Y' if license['isOsiApproved'] else '',
+            ]
+            for license in sorted(
+                license_list['licenses'],
+                key=lambda license: license['licenseId'].lower())
+            if not license.get('isDeprecatedLicenseId')
+        ],
+    )
+
+
+def format_deprecated_license_table(license_list):
+    yield from format_table(
+        headers=['Full Name of License', 'Deprecated SDPX Short Identifier'],
+        rows=[
+            [
+                license['name'],
+                '[{0}](https://spdx.org/licenses/{0}.html)'.format(
+                    license['licenseId']),
+            ]
+            for license in sorted(
+                license_list['licenses'],
+                key=lambda license: license['licenseId'].lower())
+            if license.get('isDeprecatedLicenseId')
+        ],
+    )
+
+
+def format_exception_table(exception_list):
+    yield from format_table(
+        headers=['Full Name of Exception', 'SPDX License Exception'],
+        rows=[
+            [
+                exception['name'].replace('\n', ' '),
+                '[{0}](https://spdx.org/licenses/{0}.html)'.format(
+                    exception['licenseExceptionId']),
+            ]
+            for exception in sorted(
+                exception_list['exceptions'],
+                key=lambda exception: exception['licenseExceptionId'].lower())
+            if not exception.get('isDeprecatedLicenseId')
+        ],
+    )
+
+
+if __name__ == '__main__':
+    license_list = get_json(url='https://spdx.org/licenses/licenses.json')
+    exception_list = get_json(url='https://spdx.org/licenses/exceptions.json')
+    for key in ['licenseListVersion', 'releaseDate']:
+        if license_list.get(key) != exception_list.get(key):
+            raise ValueError(
+                '{} mismatch: {} (license list) != {} (exception list)'
+                .format(
+                    key,
+                    license_list.get(key),
+                    exception_list.get(key)))
+    table_content = [
+        format_license_table(license_list=license_list),
+        format_exception_table(exception_list=exception_list),
+        format_deprecated_license_table(license_list=license_list),
+    ]
+    path = os.path.join('chapters', 'appendix-I-SPDX-license-list.md')
+    lines = []
+    with open(path, 'r') as f:
+        in_table = False
+        for line in f.readlines():
+            if in_table:
+                if not line.startswith('|'):
+                    in_table = False
+                    if table_content:
+                        lines.extend(table_content.pop(0))
+            elif line.startswith('|'):
+                in_table = True
+            else:
+                match = VERSION_REGEXP.match(line)
+                if match:
+                    leader, version, middle, release_date, tail = match.groups()
+                    lines.append('{}{}{}{}{}'.format(
+                        leader,
+                        license_list['licenseListVersion'],
+                        middle,
+                        license_list['releaseDate'],
+                        tail,
+                    ))
+                else:
+                    lines.append(line)
+    if in_table and table_content:
+        lines.extend(table_content.pop(0))
+    while lines[-1] == '\n':
+        lines.pop()
+    with open(path, 'w') as f:
+        for line in lines:
+            f.write(line)

--- a/bin/pull-license-list.py
+++ b/bin/pull-license-list.py
@@ -12,7 +12,12 @@ import itertools
 import json
 import os.path
 import re
+import sys
 import urllib.request
+
+
+if sys.version_info < (3, 6):
+    raise RuntimeError('this script requires Python 3.6+')
 
 
 VERSION_REGEXP = re.compile(
@@ -22,9 +27,7 @@ VERSION_REGEXP = re.compile(
 
 def get_json(url):
     with urllib.request.urlopen(url=url) as response:
-        charset = response.headers.get_content_charset('UTF-8')
-        reader = codecs.getreader(charset)
-        return json.load(reader(response))
+        return json.load(body)
 
 
 def format_table(headers, rows):

--- a/chapters/appendix-I-SPDX-license-list.md
+++ b/chapters/appendix-I-SPDX-license-list.md
@@ -12,748 +12,387 @@ The SPDX License List is a list of commonly found licenses and exceptions used f
 [matching]: https://spdx.org/spdx-license-list/matching-guidelines
 [new-license]: https://spdx.org/spdx-license-list/request-new-license
 
-The following table contains the full names and short identifiers for the SPDX License List, v2.5 which was released July 2016. For the full and most up-to-date version of the SPDX License List as well as other related information, please see [http://spdx.org/licenses/](http://spdx.org/licenses/)
+The following table contains the full names and short identifiers for the SPDX License List, v2.6 which was released 6 Jan 2016. For the full and most up-to-date version of the SPDX License List as well as other related information, please see [http://spdx.org/licenses/](http://spdx.org/licenses/)
 
 ## I.1 Licenses with Short Identifiers <a name="I.1"></a>
 
-| Full Name of License                                           | Short Identifier                         | OSI? |
-|----------------------------------------------------------------|------------------------------------------|------|
-| BSD Zero Clause License                                        | [0BSD][]                                 | Y    |
-| Attribution Assurance License                                  | [AAL][]                                  | Y    |
-| Abstyles License                                               | [Abstyles][]                             |      |
-| Adobe Systems Incorporated Source Code License Agreement       | [Adobe-2006][]                           |      |
-| Adobe Glyph List License                                       | [Adobe-Glyph][]                          |      |
-| Amazon Digital Services License                                | [ADSL][]                                 |      |
-| Academic Free License v1.1                                     | [AFL-1.1][]                              | Y    |
-| Academic Free License v1.2                                     | [AFL-1.2][]                              | Y    |
-| Academic Free License v2.0                                     | [AFL-2.0][]                              | Y    |
-| Academic Free License v2.1                                     | [AFL-2.1][]                              | Y    |
-| Academic Free License v3.0                                     | [AFL-3.0][]                              | Y    |
-| Afmparse License                                               | [Afmparse][]                             |      |
-| Affero General Public License v1.0                             | [AGPL-1.0][]                             |      |
-| GNU Affero General Public License v3.0                         | [AGPL-3.0][]                             | Y    |
-| Aladdin Free Public License                                    | [Aladdin][]                              |      |
-| AMD's plpa_map.c License                                       | [AMDPLPA][]                              |      |
-| Apple MIT License                                              | [AML][]                                  |      |
-| Academy of Motion Picture Arts and Sciences BSD                | [AMPAS][]                                |      |
-| ANTLR Software Rights Notice                                   | [ANTLR-PD][]                             |      |
-| Apache License 1.0                                             | [Apache-1.0][]                           |      |
-| Apache License 1.1                                             | [Apache-1.1][]                           | Y    |
-| Apache License 2.0                                             | [Apache-2.0][]                           | Y    |
-| Adobe Postscript AFM License                                   | [APAFML][]                               |      |
-| Adaptive Public License 1.0                                    | [APL-1.0][]                              | Y    |
-| Apple Public Source License 1.0                                | [APSL-1.0][]                             | Y    |
-| Apple Public Source License 1.1                                | [APSL-1.1][]                             | Y    |
-| Apple Public Source License 1.2                                | [APSL-1.2][]                             | Y    |
-| Apple Public Source License 2.0                                | [APSL-2.0][]                             | Y    |
-| Artistic License 1.0                                           | [Artistic-1.0][]                         | Y    |
-| Artistic License 1.0 w/clause 8                                | [Artistic-1.0-cl8][]                     | Y    |
-| Artistic License 1.0 (Perl)                                    | [Artistic-1.0-Perl][]                    | Y    |
-| Artistic License 2.0                                           | [Artistic-2.0][]                         | Y    |
-| Bahyph License                                                 | [Bahyph][]                               |      |
-| Barr License                                                   | [Barr][]                                 |      |
-| Beerware License                                               | [Beerware][]                             |      |
-| BitTorrent Open Source License v1.0                            | [BitTorrent-1.0][]                       |      |
-| BitTorrent Open Source License v1.1                            | [BitTorrent-1.1][]                       |      |
-| Borceux license                                                | [Borceux][]                              |      |
-| "BSD 2-clause ""Simplified"" License"                          | [BSD-2-Clause][]                         | Y    |
-| BSD 2-clause FreeBSD License                                   | [BSD-2-Clause-FreeBSD][]                 |      |
-| BSD 2-clause NetBSD License                                    | [BSD-2-Clause-NetBSD][]                  |      |
-| "BSD 3-clause ""New"" or ""Revised"" License"                  | [BSD-3-Clause][]                         | Y    |
-| BSD with attribution                                           | [BSD-3-Clause-Attribution][]             |      |
-| BSD 3-clause Clear License                                     | [BSD-3-Clause-Clear][]                   |      |
-| Lawrence Berkeley National Labs BSD variant license            | [BSD-3-Clause-LBNL][]                    |      |
-| BSD 3-Clause No Nuclear License                                | [BSD-3-Clause-No-Nuclear-License][]      |      |
-| BSD 3-Clause No Nuclear License 2014                           | [BSD-3-Clause-No-Nuclear-License-2014][] |      |
-| BSD 3-Clause No Nuclear Warranty                               | [BSD-3-Clause-No-Nuclear-Warranty][]     |      |
-| "BSD 4-clause ""Original"" or ""Old"" License"                 | [BSD-4-Clause][]                         |      |
-| BSD-4-Clause (University of California-Specific)               | [BSD-4-Clause-UC][]                      |      |
-| BSD Protection License                                         | [BSD-Protection][]                       |      |
-| BSD Source Code Attribution                                    | [BSD-Source-Code][]                      |      |
-| Boost Software License 1.0                                     | [BSL-1.0][]                              | Y    |
-| bzip2 and libbzip2 License v1.0.5                              | [bzip2-1.0.5][]                          |      |
-| bzip2 and libbzip2 License v1.0.6                              | [bzip2-1.0.6][]                          |      |
-| Caldera License                                                | [Caldera][]                              |      |
-| Computer Associates Trusted Open Source License 1.1            | [CATOSL-1.1][]                           | Y    |
-| Creative Commons Attribution 1.0                               | [CC-BY-1.0][]                            |      |
-| Creative Commons Attribution 2.0                               | [CC-BY-2.0][]                            |      |
-| Creative Commons Attribution 2.5                               | [CC-BY-2.5][]                            |      |
-| Creative Commons Attribution 3.0                               | [CC-BY-3.0][]                            |      |
-| Creative Commons Attribution 4.0                               | [CC-BY-4.0][]                            |      |
-| Creative Commons Attribution Non Commercial 1.0                | [CC-BY-NC-1.0][]                         |      |
-| Creative Commons Attribution Non Commercial 2.0                | [CC-BY-NC-2.0][]                         |      |
-| Creative Commons Attribution Non Commercial 2.5                | [CC-BY-NC-2.5][]                         |      |
-| Creative Commons Attribution Non Commercial 3.0                | [CC-BY-NC-3.0][]                         |      |
-| Creative Commons Attribution Non Commercial 4.0                | [CC-BY-NC-4.0][]                         |      |
-| Creative Commons Attribution Non Commercial No Derivatives 1.0 | [CC-BY-NC-ND-1.0][]                      |      |
-| Creative Commons Attribution Non Commercial No Derivatives 2.0 | [CC-BY-NC-ND-2.0][]                      |      |
-| Creative Commons Attribution Non Commercial No Derivatives 2.5 | [CC-BY-NC-ND-2.5][]                      |      |
-| Creative Commons Attribution Non Commercial No Derivatives 3.0 | [CC-BY-NC-ND-3.0][]                      |      |
-| Creative Commons Attribution Non Commercial No Derivatives 4.0 | [CC-BY-NC-ND-4.0][]                      |      |
-| Creative Commons Attribution Non Commercial Share Alike 1.0    | [CC-BY-NC-SA-1.0][]                      |      |
-| Creative Commons Attribution Non Commercial Share Alike 2.0    | [CC-BY-NC-SA-2.0][]                      |      |
-| Creative Commons Attribution Non Commercial Share Alike 2.5    | [CC-BY-NC-SA-2.5][]                      |      |
-| Creative Commons Attribution Non Commercial Share Alike 3.0    | [CC-BY-NC-SA-3.0][]                      |      |
-| Creative Commons Attribution Non Commercial Share Alike 4.0    | [CC-BY-NC-SA-4.0][]                      |      |
-| Creative Commons Attribution No Derivatives 1.0                | [CC-BY-ND-1.0][]                         |      |
-| Creative Commons Attribution No Derivatives 2.0                | [CC-BY-ND-2.0][]                         |      |
-| Creative Commons Attribution No Derivatives 2.5                | [CC-BY-ND-2.5][]                         |      |
-| Creative Commons Attribution No Derivatives 3.0                | [CC-BY-ND-3.0][]                         |      |
-| Creative Commons Attribution No Derivatives 4.0                | [CC-BY-ND-4.0][]                         |      |
-| Creative Commons Attribution Share Alike 1.0                   | [CC-BY-SA-1.0][]                         |      |
-| Creative Commons Attribution Share Alike 2.0                   | [CC-BY-SA-2.0][]                         |      |
-| Creative Commons Attribution Share Alike 2.5                   | [CC-BY-SA-2.5][]                         |      |
-| Creative Commons Attribution Share Alike 3.0                   | [CC-BY-SA-3.0][]                         |      |
-| Creative Commons Attribution Share Alike 4.0                   | [CC-BY-SA-4.0][]                         |      |
-| Creative Commons Zero v1.0 Universal                           | [CC0-1.0][]                              |      |
-| Common Development and Distribution License 1.0                | [CDDL-1.0][]                             | Y    |
-| Common Development and Distribution License 1.1                | [CDDL-1.1][]                             |      |
-| CeCILL Free Software License Agreement v1.0                    | [CECILL-1.0][]                           |      |
-| CeCILL Free Software License Agreement v1.1                    | [CECILL-1.1][]                           |      |
-| CeCILL Free Software License Agreement v2.0                    | [CECILL-2.0][]                           |      |
-| CeCILL Free Software License Agreement v2.1                    | [CECILL-2.1][]                           | Y    |
-| CeCILL-B Free Software License Agreement                       | [CECILL-B][]                             |      |
-| CeCILL-C Free Software License Agreement                       | [CECILL-C][]                             |      |
-| Clarified Artistic License                                     | [ClArtistic][]                           |      |
-| CNRI Jython License                                            | [CNRI-Jython][]                          |      |
-| CNRI Python License                                            | [CNRI-Python][]                          | Y    |
-| CNRI Python Open Source GPL Compatible License Agreement       | [CNRI-Python-GPL-Compatible][]           |      |
-| Condor Public License v1.1                                     | [Condor-1.1][]                           |      |
-| Common Public Attribution License 1.0                          | [CPAL-1.0][]                             | Y    |
-| Common Public License 1.0                                      | [CPL-1.0][]                              | Y    |
-| Code Project Open License 1.02                                 | [CPOL-1.02][]                            |      |
-| Crossword License                                              | [Crossword][]                            |      |
-| CrystalStacker License                                         | [CrystalStacker][]                       |      |
-| CUA Office Public License v1.0                                 | [CUA-OPL-1.0][]                          | Y    |
-| Cube License                                                   | [Cube][]                                 |      |
-| curl License                                                   | [curl][]                                 |      |
-| Deutsche Freie Software Lizenz                                 | [D-FSL-1.0][]                            |      |
-| diffmark license                                               | [diffmark][]                             |      |
-| DOC License                                                    | [DOC][]                                  |      |
-| Dotseqn License                                                | [Dotseqn][]                              |      |
-| DSDP License                                                   | [DSDP][]                                 |      |
-| dvipdfm License                                                | [dvipdfm][]                              |      |
-| Educational Community License v1.0                             | [ECL-1.0][]                              | Y    |
-| Educational Community License v2.0                             | [ECL-2.0][]                              | Y    |
-| Eiffel Forum License v1.0                                      | [EFL-1.0][]                              | Y    |
-| Eiffel Forum License v2.0                                      | [EFL-2.0][]                              | Y    |
-| eGenix.com Public License 1.1.0                                | [eGenix][]                               |      |
-| Entessa Public License v1.0                                    | [Entessa][]                              | Y    |
-| Eclipse Public License 1.0                                     | [EPL-1.0][]                              | Y    |
-| Erlang Public License v1.1                                     | [ErlPL-1.1][]                            |      |
-| EU DataGrid Software License                                   | [EUDatagrid][]                           | Y    |
-| European Union Public License 1.0                              | [EUPL-1.0][]                             |      |
-| European Union Public License 1.1                              | [EUPL-1.1][]                             | Y    |
-| Eurosym License                                                | [Eurosym][]                              |      |
-| Fair License                                                   | [Fair][]                                 | Y    |
-| Frameworx Open License 1.0                                     | [Frameworx-1.0][]                        | Y    |
-| FreeImage Public License v1.0                                  | [FreeImage][]                            |      |
-| FSF All Permissive License                                     | [FSFAP][]                                |      |
-| FSF Unlimited License                                          | [FSFUL][]                                |      |
-| FSF Unlimited License (with License Retention)                 | [FSFULLR][]                              |      |
-| Freetype Project License                                       | [FTL][]                                  |      |
-| GNU Free Documentation License v1.1                            | [GFDL-1.1][]                             |      |
-| GNU Free Documentation License v1.2                            | [GFDL-1.2][]                             |      |
-| GNU Free Documentation License v1.3                            | [GFDL-1.3][]                             |      |
-| Giftware License                                               | [Giftware][]                             |      |
-| GL2PS License                                                  | [GL2PS][]                                |      |
-| 3dfx Glide License                                             | [Glide][]                                |      |
-| Glulxe License                                                 | [Glulxe][]                               |      |
-| gnuplot License                                                | [gnuplot][]                              |      |
-| GNU General Public License v1.0 only                           | [GPL-1.0][]                              |      |
-| GNU General Public License v2.0 only                           | [GPL-2.0][]                              | Y    |
-| GNU General Public License v3.0 only                           | [GPL-3.0][]                              | Y    |
-| gSOAP Public License v1.3b                                     | [gSOAP-1.3b][]                           |      |
-| Haskell Language Report License                                | [HaskellReport][]                        |      |
-| Historic Permission Notice and Disclaimer                      | [HPND][]                                 | Y    |
-| IBM PowerPC Initialization and Boot Software                   | [IBM-pibs][]                             |      |
-| ICU License                                                    | [ICU][]                                  |      |
-| Independent JPEG Group License                                 | [IJG][]                                  |      |
-| ImageMagick License                                            | [ImageMagick][]                          |      |
-| iMatix Standard Function Library Agreement                     | [iMatix][]                               |      |
-| Imlib2 License                                                 | [Imlib2][]                               |      |
-| Info-ZIP License                                               | [Info-ZIP][]                             |      |
-| Intel Open Source License                                      | [Intel][]                                | Y    |
-| Intel ACPI Software License Agreement                          | [Intel-ACPI][]                           |      |
-| Interbase Public License v1.0                                  | [Interbase-1.0][]                        |      |
-| IPA Font License                                               | [IPA][]                                  | Y    |
-| IBM Public License v1.0                                        | [IPL-1.0][]                              | Y    |
-| ISC License                                                    | [ISC][]                                  | Y    |
-| JasPer License                                                 | [JasPer-2.0][]                           |      |
-| JSON License                                                   | [JSON][]                                 |      |
-| License Art Libre 1.2                                          | [LAL-1.2][]                              |      |
-| License Art Libre 1.3                                          | [LAL-1.3][]                              |      |
-| Latex2e License                                                | [Latex2e][]                              |      |
-| Leptonica License                                              | [Leptonica][]                            |      |
-| GNU Library General Public License v2 only                     | [LGPL-2.0][]                             | Y    |
-| GNU Lesser General Public License v2.1 only                    | [LGPL-2.1][]                             | Y    |
-| GNU Lesser General Public License v3.0 only                    | [LGPL-3.0][]                             | Y    |
-| Lesser General Public Licenses For Linguistic Resources        | [LGPLLR][]                               |      |
-| libpng License                                                 | [Libpng][]                               |      |
-| libtiff License                                                | [libtiff][]                              |      |
-| Licence Libre du Québec – Permissive version 1.1               | [LiLiQ-P-1.1][]                          | Y    |
-| Licence Libre du Québec – Réciprocité version 1.1              | [LiLiQ-R-1.1][]                          | Y    |
-| Licence Libre du Québec – Réciprocité forte version 1.1        | [LiLiQ-Rplus-1.1][]                      | Y    |
-| Lucent Public License Version 1.0                              | [LPL-1.0][]                              | Y    |
-| Lucent Public License v1.02                                    | [LPL-1.02][]                             | Y    |
-| LaTeX Project Public License v1.0                              | [LPPL-1.0][]                             |      |
-| LaTeX Project Public License v1.1                              | [LPPL-1.1][]                             |      |
-| LaTeX Project Public License v1.2                              | [LPPL-1.2][]                             |      |
-| LaTeX Project Public License 1.3a                              | [LPPL-1.3a][]                            |      |
-| LaTeX Project Public License v1.3c                             | [LPPL-1.3c][]                            | Y    |
-| MakeIndex License                                              | [MakeIndex][]                            |      |
-| MirOS Licence                                                  | [MirOS][]                                |      |
-| MIT License                                                    | [MIT][]                                  | Y    |
-| Enlightenment License (e16)                                    | [MIT-advertising][]                      |      |
-| CMU License                                                    | [MIT-CMU][]                              |      |
-| enna License                                                   | [MIT-enna][]                             |      |
-| feh License                                                    | [MIT-feh][]                              |      |
-| MIT +no-false-attribs license                                  | [MITNFA][]                               |      |
-| Motosoto License                                               | [Motosoto][]                             |      |
-| mpich2 License                                                 | [mpich2][]                               |      |
-| Mozilla Public License 1.0                                     | [MPL-1.0][]                              | Y    |
-| Mozilla Public License 1.1                                     | [MPL-1.1][]                              | Y    |
-| Mozilla Public License 2.0                                     | [MPL-2.0][]                              | Y    |
-| Mozilla Public License 2.0 (no copyleft exception)             | [MPL-2.0-no-copyleft-exception][]        | Y    |
-| Microsoft Public License                                       | [MS-PL][]                                | Y    |
-| Microsoft Reciprocal License                                   | [MS-RL][]                                | Y    |
-| Matrix Template Library License                                | [MTLL][]                                 |      |
-| Multics License                                                | [Multics][]                              |      |
-| Mup License                                                    | [Mup][]                                  |      |
-| NASA Open Source Agreement 1.3                                 | [NASA-1.3][]                             | Y    |
-| Naumen Public License                                          | [Naumen][]                               | Y    |
-| Net Boolean Public License v1                                  | [NBPL-1.0][]                             |      |
-| University of Illinois/NCSA Open Source License                | [NCSA][]                                 | Y    |
-| NetCDF license                                                 | [NetCDF][]                               |      |
-| Newsletr License                                               | [Newsletr][]                             |      |
-| Nethack General Public License                                 | [NGPL][]                                 | Y    |
-| Norwgian License for Open Government Data                      | [NLOD-1.0][]                             |      |
-| No Limit Public License                                        | [NLPL][]                                 |      |
-| Nokia Open Source License                                      | [Nokia][]                                | Y    |
-| Netizen Open Source License                                    | [NOSL][]                                 |      |
-| Noweb License                                                  | [Noweb][]                                |      |
-| Netscape Public License v1.0                                   | [NPL-1.0][]                              |      |
-| Netscape Public License v1.1                                   | [NPL-1.1][]                              | Y    |
-| Non-Profit Open Software License 3.0                           | [NPOSL-3.0][]                            | Y    |
-| NRL License                                                    | [NRL][]                                  |      |
-| NTP License                                                    | [NTP][]                                  | Y    |
-| Nunit License                                                  | [Nunit][]                                |      |
-| Open CASCADE Technology Public License                         | [OCCT-PL][]                              |      |
-| OCLC Research Public License 2.0                               | [OCLC-2.0][]                             | Y    |
-| ODC Open Database License v1.0                                 | [ODbL-1.0][]                             |      |
-| SIL Open Font License 1.0                                      | [OFL-1.0][]                              |      |
-| SIL Open Font License 1.1                                      | [OFL-1.1][]                              | Y    |
-| Open Group Test Suite License                                  | [OGTSL][]                                | Y    |
-| Open LDAP Public License v1.1                                  | [OLDAP-1.1][]                            |      |
-| Open LDAP Public License v1.2                                  | [OLDAP-1.2][]                            |      |
-| Open LDAP Public License v1.3                                  | [OLDAP-1.3][]                            |      |
-| Open LDAP Public License v1.4                                  | [OLDAP-1.4][]                            |      |
-| Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)      | [OLDAP-2.0][]                            |      |
-| Open LDAP Public License v2.0.1                                | [OLDAP-2.0.1][]                          |      |
-| Open LDAP Public License v2.1                                  | [OLDAP-2.1][]                            |      |
-| Open LDAP Public License v2.2                                  | [OLDAP-2.2][]                            |      |
-| Open LDAP Public License v2.2.1                                | [OLDAP-2.2.1][]                          |      |
-| Open LDAP Public License 2.2.2                                 | [OLDAP-2.2.2][]                          |      |
-| Open LDAP Public License v2.3                                  | [OLDAP-2.3][]                            |      |
-| Open LDAP Public License v2.4                                  | [OLDAP-2.4][]                            |      |
-| Open LDAP Public License v2.5                                  | [OLDAP-2.5][]                            |      |
-| Open LDAP Public License v2.6                                  | [OLDAP-2.6][]                            |      |
-| Open LDAP Public License v2.7                                  | [OLDAP-2.7][]                            |      |
-| Open LDAP Public License v2.8                                  | [OLDAP-2.8][]                            |      |
-| Open Market License                                            | [OML][]                                  |      |
-| OpenSSL License                                                | [OpenSSL][]                              |      |
-| Open Public License v1.0                                       | [OPL-1.0][]                              |      |
-| OSET Public License version 2.1                                | [OSET-PL-2.1][]                          | Y    |
-| Open Software License 1.0                                      | [OSL-1.0][]                              | Y    |
-| Open Software License 1.1                                      | [OSL-1.1][]                              |      |
-| Open Software License 2.0                                      | [OSL-2.0][]                              | Y    |
-| Open Software License 2.1                                      | [OSL-2.1][]                              | Y    |
-| Open Software License 3.0                                      | [OSL-3.0][]                              | Y    |
-| ODC Public Domain Dedication & License 1.0                     | [PDDL-1.0][]                             |      |
-| PHP License v3.0                                               | [PHP-3.0][]                              | Y    |
-| PHP License v3.01                                              | [PHP-3.01][]                             |      |
-| Plexus Classworlds License                                     | [Plexus][]                               |      |
-| PostgreSQL License                                             | [PostgreSQL][]                           | Y    |
-| psfrag License                                                 | [psfrag][]                               |      |
-| psutils License                                                | [psutils][]                              |      |
-| Python License 2.0                                             | [Python-2.0][]                           | Y    |
-| Qhull License                                                  | [Qhull][]                                |      |
-| Q Public License 1.0                                           | [QPL-1.0][]                              | Y    |
-| Rdisc License                                                  | [Rdisc][]                                |      |
-| Red Hat eCos Public License v1.1                               | [RHeCos-1.1][]                           |      |
-| Reciprocal Public License 1.1                                  | [RPL-1.1][]                              | Y    |
-| Reciprocal Public License 1.5                                  | [RPL-1.5][]                              | Y    |
-| RealNetworks Public Source License v1.0                        | [RPSL-1.0][]                             | Y    |
-| RSA Message-Digest License                                     | [RSA-MD][]                               |      |
-| Ricoh Source Code Public License                               | [RSCPL][]                                | Y    |
-| Ruby License                                                   | [Ruby][]                                 |      |
-| Sax Public Domain Notice                                       | [SAX-PD][]                               |      |
-| Saxpath License                                                | [Saxpath][]                              |      |
-| SCEA Shared Source License                                     | [SCEA][]                                 |      |
-| Sendmail License                                               | [Sendmail][]                             |      |
-| SGI Free Software License B v1.0                               | [SGI-B-1.0][]                            |      |
-| SGI Free Software License B v1.1                               | [SGI-B-1.1][]                            |      |
-| SGI Free Software License B v2.0                               | [SGI-B-2.0][]                            |      |
-| Simple Public License 2.0                                      | [SimPL-2.0][]                            | Y    |
-| Sun Industry Standards Source License v1.1                     | [SISSL][]                                | Y    |
-| Sun Industry Standards Source License v1.2                     | [SISSL-1.2][]                            |      |
-| Sleepycat License                                              | [Sleepycat][]                            | Y    |
-| Standard ML of New Jersey License                              | [SMLNJ][]                                |      |
-| Secure Messaging Protocol Public License                       | [SMPPL][]                                |      |
-| SNIA Public License 1.1                                        | [SNIA][]                                 |      |
-| Spencer License 86                                             | [Spencer-86][]                           |      |
-| Spencer License 94                                             | [Spencer-94][]                           |      |
-| Spencer License 99                                             | [Spencer-99][]                           |      |
-| Sun Public License v1.0                                        | [SPL-1.0][]                              | Y    |
-| SugarCRM Public License v1.1.3                                 | [SugarCRM-1.1.3][]                       |      |
-| Scheme Widget Library (SWL) Software License Agreement         | [SWL][]                                  |      |
-| TCL/TK License                                                 | [TCL][]                                  |      |
-| TMate Open Source License                                      | [TMate][]                                |      |
-| TORQUE v2.5+ Software License v1.1                             | [TORQUE-1.1][]                           |      |
-| Trusster Open Source License                                   | [TOSL][]                                 |      |
-| Unicode Terms of Use                                           | [Unicode-TOU][]                          |      |
-| The Unlicense                                                  | [Unlicense][]                            |      |
-| Universal Permissive Licenses v1.0                             | [UPL-1.0][]                              | Y    |
-| Vim License                                                    | [Vim][]                                  |      |
-| VOSTROM Public License for Open Source                         | [VOSTROM][]                              |      |
-| Vovida Software License v1.0                                   | [VSL-1.0][]                              | Y    |
-| W3C Software Notice and License (2002-12-31)                   | [W3C][]                                  | Y    |
-| W3C Software Notice and License (1998-07-20)                   | [W3C-19980720][]                         |      |
-| Sybase Open Watcom Public License 1.0                          | [Watcom-1.0][]                           | Y    |
-| Wsuipa License                                                 | [Wsuipa][]                               |      |
-| Do What The F*ck You Want To Public License                    | [WTFPL][]                                |      |
-| X11 License                                                    | [X11][]                                  |      |
-| Xerox License                                                  | [Xerox][]                                |      |
-| XFree86 License 1.1                                            | [XFree86-1.1][]                          |      |
-| xinetd License                                                 | [xinetd][]                               |      |
-| X.Net License                                                  | [Xnet][]                                 | Y    |
-| XPP License                                                    | [xpp][]                                  |      |
-| XSkat License                                                  | [XSkat][]                                |      |
-| Yahoo! Public License v1.0                                     | [YPL-1.0][]                              |      |
-| Yahoo! Public License v1.1                                     | [YPL-1.1][]                              |      |
-| Zed License                                                    | [Zed][]                                  |      |
-| Zend License v2.0                                              | [Zend-2.0][]                             |      |
-| Zimbra Public License v1.3                                     | [Zimbra-1.3][]                           |      |
-| Zimbra Public License v1.4                                     | [Zimbra-1.4][]                           |      |
-| zlib License                                                   | [Zlib][]                                 | Y    |
-| zlib/libpng License with Acknowledgement                       | [zlib-acknowledgement][]                 |      |
-| Zope Public License 1.1                                        | [ZPL-1.1][]                              |      |
-| Zope Public License 2.0                                        | [ZPL-2.0][]                              | Y    |
-| Zope Public License 2.1                                        | [ZPL-2.1][]                              |      |
+| Full Name of License                                           | Short Identifier                                                                                            | OSI? |
+|----------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|------|
+| BSD Zero Clause License                                        | [0BSD](https://spdx.org/licenses/0BSD.html)                                                                 | Y    |
+| Attribution Assurance License                                  | [AAL](https://spdx.org/licenses/AAL.html)                                                                   | Y    |
+| Abstyles License                                               | [Abstyles](https://spdx.org/licenses/Abstyles.html)                                                         |      |
+| Adobe Systems Incorporated Source Code License Agreement       | [Adobe-2006](https://spdx.org/licenses/Adobe-2006.html)                                                     |      |
+| Adobe Glyph List License                                       | [Adobe-Glyph](https://spdx.org/licenses/Adobe-Glyph.html)                                                   |      |
+| Amazon Digital Services License                                | [ADSL](https://spdx.org/licenses/ADSL.html)                                                                 |      |
+| Academic Free License v1.1                                     | [AFL-1.1](https://spdx.org/licenses/AFL-1.1.html)                                                           | Y    |
+| Academic Free License v1.2                                     | [AFL-1.2](https://spdx.org/licenses/AFL-1.2.html)                                                           | Y    |
+| Academic Free License v2.0                                     | [AFL-2.0](https://spdx.org/licenses/AFL-2.0.html)                                                           | Y    |
+| Academic Free License v2.1                                     | [AFL-2.1](https://spdx.org/licenses/AFL-2.1.html)                                                           | Y    |
+| Academic Free License v3.0                                     | [AFL-3.0](https://spdx.org/licenses/AFL-3.0.html)                                                           | Y    |
+| Afmparse License                                               | [Afmparse](https://spdx.org/licenses/Afmparse.html)                                                         |      |
+| Affero General Public License v1.0                             | [AGPL-1.0](https://spdx.org/licenses/AGPL-1.0.html)                                                         |      |
+| GNU Affero General Public License v3.0                         | [AGPL-3.0](https://spdx.org/licenses/AGPL-3.0.html)                                                         | Y    |
+| Aladdin Free Public License                                    | [Aladdin](https://spdx.org/licenses/Aladdin.html)                                                           |      |
+| AMD's plpa_map.c License                                       | [AMDPLPA](https://spdx.org/licenses/AMDPLPA.html)                                                           |      |
+| Apple MIT License                                              | [AML](https://spdx.org/licenses/AML.html)                                                                   |      |
+| Academy of Motion Picture Arts and Sciences BSD                | [AMPAS](https://spdx.org/licenses/AMPAS.html)                                                               |      |
+| ANTLR Software Rights Notice                                   | [ANTLR-PD](https://spdx.org/licenses/ANTLR-PD.html)                                                         |      |
+| Apache License 1.0                                             | [Apache-1.0](https://spdx.org/licenses/Apache-1.0.html)                                                     |      |
+| Apache License 1.1                                             | [Apache-1.1](https://spdx.org/licenses/Apache-1.1.html)                                                     | Y    |
+| Apache License 2.0                                             | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html)                                                     | Y    |
+| Adobe Postscript AFM License                                   | [APAFML](https://spdx.org/licenses/APAFML.html)                                                             |      |
+| Adaptive Public License 1.0                                    | [APL-1.0](https://spdx.org/licenses/APL-1.0.html)                                                           | Y    |
+| Apple Public Source License 1.0                                | [APSL-1.0](https://spdx.org/licenses/APSL-1.0.html)                                                         | Y    |
+| Apple Public Source License 1.1                                | [APSL-1.1](https://spdx.org/licenses/APSL-1.1.html)                                                         | Y    |
+| Apple Public Source License 1.2                                | [APSL-1.2](https://spdx.org/licenses/APSL-1.2.html)                                                         | Y    |
+| Apple Public Source License 2.0                                | [APSL-2.0](https://spdx.org/licenses/APSL-2.0.html)                                                         | Y    |
+| Artistic License 1.0                                           | [Artistic-1.0](https://spdx.org/licenses/Artistic-1.0.html)                                                 | Y    |
+| Artistic License 1.0 w/clause 8                                | [Artistic-1.0-cl8](https://spdx.org/licenses/Artistic-1.0-cl8.html)                                         | Y    |
+| Artistic License 1.0 (Perl)                                    | [Artistic-1.0-Perl](https://spdx.org/licenses/Artistic-1.0-Perl.html)                                       | Y    |
+| Artistic License 2.0                                           | [Artistic-2.0](https://spdx.org/licenses/Artistic-2.0.html)                                                 | Y    |
+| Bahyph License                                                 | [Bahyph](https://spdx.org/licenses/Bahyph.html)                                                             |      |
+| Barr License                                                   | [Barr](https://spdx.org/licenses/Barr.html)                                                                 |      |
+| Beerware License                                               | [Beerware](https://spdx.org/licenses/Beerware.html)                                                         |      |
+| BitTorrent Open Source License v1.0                            | [BitTorrent-1.0](https://spdx.org/licenses/BitTorrent-1.0.html)                                             |      |
+| BitTorrent Open Source License v1.1                            | [BitTorrent-1.1](https://spdx.org/licenses/BitTorrent-1.1.html)                                             |      |
+| Borceux license                                                | [Borceux](https://spdx.org/licenses/Borceux.html)                                                           |      |
+| BSD 2-clause "Simplified" License                              | [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html)                                                 | Y    |
+| BSD 2-clause FreeBSD License                                   | [BSD-2-Clause-FreeBSD](https://spdx.org/licenses/BSD-2-Clause-FreeBSD.html)                                 |      |
+| BSD 2-clause NetBSD License                                    | [BSD-2-Clause-NetBSD](https://spdx.org/licenses/BSD-2-Clause-NetBSD.html)                                   |      |
+| BSD 3-clause "New" or "Revised" License                        | [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html)                                                 | Y    |
+| BSD with attribution                                           | [BSD-3-Clause-Attribution](https://spdx.org/licenses/BSD-3-Clause-Attribution.html)                         |      |
+| BSD 3-clause Clear License                                     | [BSD-3-Clause-Clear](https://spdx.org/licenses/BSD-3-Clause-Clear.html)                                     |      |
+| Lawrence Berkeley National Labs BSD variant license            | [BSD-3-Clause-LBNL](https://spdx.org/licenses/BSD-3-Clause-LBNL.html)                                       |      |
+| BSD 3-Clause No Nuclear License                                | [BSD-3-Clause-No-Nuclear-License](https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.html)           |      |
+| BSD 3-Clause No Nuclear License 2014                           | [BSD-3-Clause-No-Nuclear-License-2014](https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.html) |      |
+| BSD 3-Clause No Nuclear Warranty                               | [BSD-3-Clause-No-Nuclear-Warranty](https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.html)         |      |
+| BSD 4-clause "Original" or "Old" License                       | [BSD-4-Clause](https://spdx.org/licenses/BSD-4-Clause.html)                                                 |      |
+| BSD-4-Clause (University of California-Specific)               | [BSD-4-Clause-UC](https://spdx.org/licenses/BSD-4-Clause-UC.html)                                           |      |
+| BSD Protection License                                         | [BSD-Protection](https://spdx.org/licenses/BSD-Protection.html)                                             |      |
+| BSD Source Code Attribution                                    | [BSD-Source-Code](https://spdx.org/licenses/BSD-Source-Code.html)                                           |      |
+| Boost Software License 1.0                                     | [BSL-1.0](https://spdx.org/licenses/BSL-1.0.html)                                                           | Y    |
+| bzip2 and libbzip2 License v1.0.5                              | [bzip2-1.0.5](https://spdx.org/licenses/bzip2-1.0.5.html)                                                   |      |
+| bzip2 and libbzip2 License v1.0.6                              | [bzip2-1.0.6](https://spdx.org/licenses/bzip2-1.0.6.html)                                                   |      |
+| Caldera License                                                | [Caldera](https://spdx.org/licenses/Caldera.html)                                                           |      |
+| Computer Associates Trusted Open Source License 1.1            | [CATOSL-1.1](https://spdx.org/licenses/CATOSL-1.1.html)                                                     | Y    |
+| Creative Commons Attribution 1.0                               | [CC-BY-1.0](https://spdx.org/licenses/CC-BY-1.0.html)                                                       |      |
+| Creative Commons Attribution 2.0                               | [CC-BY-2.0](https://spdx.org/licenses/CC-BY-2.0.html)                                                       |      |
+| Creative Commons Attribution 2.5                               | [CC-BY-2.5](https://spdx.org/licenses/CC-BY-2.5.html)                                                       |      |
+| Creative Commons Attribution 3.0                               | [CC-BY-3.0](https://spdx.org/licenses/CC-BY-3.0.html)                                                       |      |
+| Creative Commons Attribution 4.0                               | [CC-BY-4.0](https://spdx.org/licenses/CC-BY-4.0.html)                                                       |      |
+| Creative Commons Attribution Non Commercial 1.0                | [CC-BY-NC-1.0](https://spdx.org/licenses/CC-BY-NC-1.0.html)                                                 |      |
+| Creative Commons Attribution Non Commercial 2.0                | [CC-BY-NC-2.0](https://spdx.org/licenses/CC-BY-NC-2.0.html)                                                 |      |
+| Creative Commons Attribution Non Commercial 2.5                | [CC-BY-NC-2.5](https://spdx.org/licenses/CC-BY-NC-2.5.html)                                                 |      |
+| Creative Commons Attribution Non Commercial 3.0                | [CC-BY-NC-3.0](https://spdx.org/licenses/CC-BY-NC-3.0.html)                                                 |      |
+| Creative Commons Attribution Non Commercial 4.0                | [CC-BY-NC-4.0](https://spdx.org/licenses/CC-BY-NC-4.0.html)                                                 |      |
+| Creative Commons Attribution Non Commercial No Derivatives 1.0 | [CC-BY-NC-ND-1.0](https://spdx.org/licenses/CC-BY-NC-ND-1.0.html)                                           |      |
+| Creative Commons Attribution Non Commercial No Derivatives 2.0 | [CC-BY-NC-ND-2.0](https://spdx.org/licenses/CC-BY-NC-ND-2.0.html)                                           |      |
+| Creative Commons Attribution Non Commercial No Derivatives 2.5 | [CC-BY-NC-ND-2.5](https://spdx.org/licenses/CC-BY-NC-ND-2.5.html)                                           |      |
+| Creative Commons Attribution Non Commercial No Derivatives 3.0 | [CC-BY-NC-ND-3.0](https://spdx.org/licenses/CC-BY-NC-ND-3.0.html)                                           |      |
+| Creative Commons Attribution Non Commercial No Derivatives 4.0 | [CC-BY-NC-ND-4.0](https://spdx.org/licenses/CC-BY-NC-ND-4.0.html)                                           |      |
+| Creative Commons Attribution Non Commercial Share Alike 1.0    | [CC-BY-NC-SA-1.0](https://spdx.org/licenses/CC-BY-NC-SA-1.0.html)                                           |      |
+| Creative Commons Attribution Non Commercial Share Alike 2.0    | [CC-BY-NC-SA-2.0](https://spdx.org/licenses/CC-BY-NC-SA-2.0.html)                                           |      |
+| Creative Commons Attribution Non Commercial Share Alike 2.5    | [CC-BY-NC-SA-2.5](https://spdx.org/licenses/CC-BY-NC-SA-2.5.html)                                           |      |
+| Creative Commons Attribution Non Commercial Share Alike 3.0    | [CC-BY-NC-SA-3.0](https://spdx.org/licenses/CC-BY-NC-SA-3.0.html)                                           |      |
+| Creative Commons Attribution Non Commercial Share Alike 4.0    | [CC-BY-NC-SA-4.0](https://spdx.org/licenses/CC-BY-NC-SA-4.0.html)                                           |      |
+| Creative Commons Attribution No Derivatives 1.0                | [CC-BY-ND-1.0](https://spdx.org/licenses/CC-BY-ND-1.0.html)                                                 |      |
+| Creative Commons Attribution No Derivatives 2.0                | [CC-BY-ND-2.0](https://spdx.org/licenses/CC-BY-ND-2.0.html)                                                 |      |
+| Creative Commons Attribution No Derivatives 2.5                | [CC-BY-ND-2.5](https://spdx.org/licenses/CC-BY-ND-2.5.html)                                                 |      |
+| Creative Commons Attribution No Derivatives 3.0                | [CC-BY-ND-3.0](https://spdx.org/licenses/CC-BY-ND-3.0.html)                                                 |      |
+| Creative Commons Attribution No Derivatives 4.0                | [CC-BY-ND-4.0](https://spdx.org/licenses/CC-BY-ND-4.0.html)                                                 |      |
+| Creative Commons Attribution Share Alike 1.0                   | [CC-BY-SA-1.0](https://spdx.org/licenses/CC-BY-SA-1.0.html)                                                 |      |
+| Creative Commons Attribution Share Alike 2.0                   | [CC-BY-SA-2.0](https://spdx.org/licenses/CC-BY-SA-2.0.html)                                                 |      |
+| Creative Commons Attribution Share Alike 2.5                   | [CC-BY-SA-2.5](https://spdx.org/licenses/CC-BY-SA-2.5.html)                                                 |      |
+| Creative Commons Attribution Share Alike 3.0                   | [CC-BY-SA-3.0](https://spdx.org/licenses/CC-BY-SA-3.0.html)                                                 |      |
+| Creative Commons Attribution Share Alike 4.0                   | [CC-BY-SA-4.0](https://spdx.org/licenses/CC-BY-SA-4.0.html)                                                 |      |
+| Creative Commons Zero v1.0 Universal                           | [CC0-1.0](https://spdx.org/licenses/CC0-1.0.html)                                                           |      |
+| Common Development and Distribution License 1.0                | [CDDL-1.0](https://spdx.org/licenses/CDDL-1.0.html)                                                         | Y    |
+| Common Development and Distribution License 1.1                | [CDDL-1.1](https://spdx.org/licenses/CDDL-1.1.html)                                                         |      |
+| CeCILL Free Software License Agreement v1.0                    | [CECILL-1.0](https://spdx.org/licenses/CECILL-1.0.html)                                                     |      |
+| CeCILL Free Software License Agreement v1.1                    | [CECILL-1.1](https://spdx.org/licenses/CECILL-1.1.html)                                                     |      |
+| CeCILL Free Software License Agreement v2.0                    | [CECILL-2.0](https://spdx.org/licenses/CECILL-2.0.html)                                                     |      |
+| CeCILL Free Software License Agreement v2.1                    | [CECILL-2.1](https://spdx.org/licenses/CECILL-2.1.html)                                                     | Y    |
+| CeCILL-B Free Software License Agreement                       | [CECILL-B](https://spdx.org/licenses/CECILL-B.html)                                                         |      |
+| CeCILL-C Free Software License Agreement                       | [CECILL-C](https://spdx.org/licenses/CECILL-C.html)                                                         |      |
+| Clarified Artistic License                                     | [ClArtistic](https://spdx.org/licenses/ClArtistic.html)                                                     |      |
+| CNRI Jython License                                            | [CNRI-Jython](https://spdx.org/licenses/CNRI-Jython.html)                                                   |      |
+| CNRI Python License                                            | [CNRI-Python](https://spdx.org/licenses/CNRI-Python.html)                                                   | Y    |
+| CNRI Python Open Source GPL Compatible License Agreement       | [CNRI-Python-GPL-Compatible](https://spdx.org/licenses/CNRI-Python-GPL-Compatible.html)                     |      |
+| Condor Public License v1.1                                     | [Condor-1.1](https://spdx.org/licenses/Condor-1.1.html)                                                     |      |
+| Common Public Attribution License 1.0                          | [CPAL-1.0](https://spdx.org/licenses/CPAL-1.0.html)                                                         | Y    |
+| Common Public License 1.0                                      | [CPL-1.0](https://spdx.org/licenses/CPL-1.0.html)                                                           | Y    |
+| Code Project Open License 1.02                                 | [CPOL-1.02](https://spdx.org/licenses/CPOL-1.02.html)                                                       |      |
+| Crossword License                                              | [Crossword](https://spdx.org/licenses/Crossword.html)                                                       |      |
+| CrystalStacker License                                         | [CrystalStacker](https://spdx.org/licenses/CrystalStacker.html)                                             |      |
+| CUA Office Public License v1.0                                 | [CUA-OPL-1.0](https://spdx.org/licenses/CUA-OPL-1.0.html)                                                   | Y    |
+| Cube License                                                   | [Cube](https://spdx.org/licenses/Cube.html)                                                                 |      |
+| curl License                                                   | [curl](https://spdx.org/licenses/curl.html)                                                                 |      |
+| Deutsche Freie Software Lizenz                                 | [D-FSL-1.0](https://spdx.org/licenses/D-FSL-1.0.html)                                                       |      |
+| diffmark license                                               | [diffmark](https://spdx.org/licenses/diffmark.html)                                                         |      |
+| DOC License                                                    | [DOC](https://spdx.org/licenses/DOC.html)                                                                   |      |
+| Dotseqn License                                                | [Dotseqn](https://spdx.org/licenses/Dotseqn.html)                                                           |      |
+| DSDP License                                                   | [DSDP](https://spdx.org/licenses/DSDP.html)                                                                 |      |
+| dvipdfm License                                                | [dvipdfm](https://spdx.org/licenses/dvipdfm.html)                                                           |      |
+| Educational Community License v1.0                             | [ECL-1.0](https://spdx.org/licenses/ECL-1.0.html)                                                           | Y    |
+| Educational Community License v2.0                             | [ECL-2.0](https://spdx.org/licenses/ECL-2.0.html)                                                           | Y    |
+| Eiffel Forum License v1.0                                      | [EFL-1.0](https://spdx.org/licenses/EFL-1.0.html)                                                           | Y    |
+| Eiffel Forum License v2.0                                      | [EFL-2.0](https://spdx.org/licenses/EFL-2.0.html)                                                           | Y    |
+| eGenix.com Public License 1.1.0                                | [eGenix](https://spdx.org/licenses/eGenix.html)                                                             |      |
+| Entessa Public License v1.0                                    | [Entessa](https://spdx.org/licenses/Entessa.html)                                                           | Y    |
+| Eclipse Public License 1.0                                     | [EPL-1.0](https://spdx.org/licenses/EPL-1.0.html)                                                           | Y    |
+| Erlang Public License v1.1                                     | [ErlPL-1.1](https://spdx.org/licenses/ErlPL-1.1.html)                                                       |      |
+| EU DataGrid Software License                                   | [EUDatagrid](https://spdx.org/licenses/EUDatagrid.html)                                                     | Y    |
+| European Union Public License 1.0                              | [EUPL-1.0](https://spdx.org/licenses/EUPL-1.0.html)                                                         |      |
+| European Union Public License 1.1                              | [EUPL-1.1](https://spdx.org/licenses/EUPL-1.1.html)                                                         | Y    |
+| Eurosym License                                                | [Eurosym](https://spdx.org/licenses/Eurosym.html)                                                           |      |
+| Fair License                                                   | [Fair](https://spdx.org/licenses/Fair.html)                                                                 | Y    |
+| Frameworx Open License 1.0                                     | [Frameworx-1.0](https://spdx.org/licenses/Frameworx-1.0.html)                                               | Y    |
+| FreeImage Public License v1.0                                  | [FreeImage](https://spdx.org/licenses/FreeImage.html)                                                       |      |
+| FSF All Permissive License                                     | [FSFAP](https://spdx.org/licenses/FSFAP.html)                                                               |      |
+| FSF Unlimited License                                          | [FSFUL](https://spdx.org/licenses/FSFUL.html)                                                               |      |
+| FSF Unlimited License (with License Retention)                 | [FSFULLR](https://spdx.org/licenses/FSFULLR.html)                                                           |      |
+| Freetype Project License                                       | [FTL](https://spdx.org/licenses/FTL.html)                                                                   |      |
+| GNU Free Documentation License v1.1                            | [GFDL-1.1](https://spdx.org/licenses/GFDL-1.1.html)                                                         |      |
+| GNU Free Documentation License v1.2                            | [GFDL-1.2](https://spdx.org/licenses/GFDL-1.2.html)                                                         |      |
+| GNU Free Documentation License v1.3                            | [GFDL-1.3](https://spdx.org/licenses/GFDL-1.3.html)                                                         |      |
+| Giftware License                                               | [Giftware](https://spdx.org/licenses/Giftware.html)                                                         |      |
+| GL2PS License                                                  | [GL2PS](https://spdx.org/licenses/GL2PS.html)                                                               |      |
+| 3dfx Glide License                                             | [Glide](https://spdx.org/licenses/Glide.html)                                                               |      |
+| Glulxe License                                                 | [Glulxe](https://spdx.org/licenses/Glulxe.html)                                                             |      |
+| gnuplot License                                                | [gnuplot](https://spdx.org/licenses/gnuplot.html)                                                           |      |
+| GNU General Public License v1.0 only                           | [GPL-1.0](https://spdx.org/licenses/GPL-1.0.html)                                                           |      |
+| GNU General Public License v2.0 only                           | [GPL-2.0](https://spdx.org/licenses/GPL-2.0.html)                                                           | Y    |
+| GNU General Public License v3.0 only                           | [GPL-3.0](https://spdx.org/licenses/GPL-3.0.html)                                                           | Y    |
+| gSOAP Public License v1.3b                                     | [gSOAP-1.3b](https://spdx.org/licenses/gSOAP-1.3b.html)                                                     |      |
+| Haskell Language Report License                                | [HaskellReport](https://spdx.org/licenses/HaskellReport.html)                                               |      |
+| Historic Permission Notice and Disclaimer                      | [HPND](https://spdx.org/licenses/HPND.html)                                                                 | Y    |
+| IBM PowerPC Initialization and Boot Software                   | [IBM-pibs](https://spdx.org/licenses/IBM-pibs.html)                                                         |      |
+| ICU License                                                    | [ICU](https://spdx.org/licenses/ICU.html)                                                                   |      |
+| Independent JPEG Group License                                 | [IJG](https://spdx.org/licenses/IJG.html)                                                                   |      |
+| ImageMagick License                                            | [ImageMagick](https://spdx.org/licenses/ImageMagick.html)                                                   |      |
+| iMatix Standard Function Library Agreement                     | [iMatix](https://spdx.org/licenses/iMatix.html)                                                             |      |
+| Imlib2 License                                                 | [Imlib2](https://spdx.org/licenses/Imlib2.html)                                                             |      |
+| Info-ZIP License                                               | [Info-ZIP](https://spdx.org/licenses/Info-ZIP.html)                                                         |      |
+| Intel Open Source License                                      | [Intel](https://spdx.org/licenses/Intel.html)                                                               | Y    |
+| Intel ACPI Software License Agreement                          | [Intel-ACPI](https://spdx.org/licenses/Intel-ACPI.html)                                                     |      |
+| Interbase Public License v1.0                                  | [Interbase-1.0](https://spdx.org/licenses/Interbase-1.0.html)                                               |      |
+| IPA Font License                                               | [IPA](https://spdx.org/licenses/IPA.html)                                                                   | Y    |
+| IBM Public License v1.0                                        | [IPL-1.0](https://spdx.org/licenses/IPL-1.0.html)                                                           | Y    |
+| ISC License                                                    | [ISC](https://spdx.org/licenses/ISC.html)                                                                   | Y    |
+| JasPer License                                                 | [JasPer-2.0](https://spdx.org/licenses/JasPer-2.0.html)                                                     |      |
+| JSON License                                                   | [JSON](https://spdx.org/licenses/JSON.html)                                                                 |      |
+| Licence Art Libre 1.2                                          | [LAL-1.2](https://spdx.org/licenses/LAL-1.2.html)                                                           |      |
+| Licence Art Libre 1.3                                          | [LAL-1.3](https://spdx.org/licenses/LAL-1.3.html)                                                           |      |
+| Latex2e License                                                | [Latex2e](https://spdx.org/licenses/Latex2e.html)                                                           |      |
+| Leptonica License                                              | [Leptonica](https://spdx.org/licenses/Leptonica.html)                                                       |      |
+| GNU Library General Public License v2 only                     | [LGPL-2.0](https://spdx.org/licenses/LGPL-2.0.html)                                                         | Y    |
+| GNU Lesser General Public License v2.1 only                    | [LGPL-2.1](https://spdx.org/licenses/LGPL-2.1.html)                                                         | Y    |
+| GNU Lesser General Public License v3.0 only                    | [LGPL-3.0](https://spdx.org/licenses/LGPL-3.0.html)                                                         | Y    |
+| Lesser General Public License For Linguistic Resources         | [LGPLLR](https://spdx.org/licenses/LGPLLR.html)                                                             |      |
+| libpng License                                                 | [Libpng](https://spdx.org/licenses/Libpng.html)                                                             |      |
+| libtiff License                                                | [libtiff](https://spdx.org/licenses/libtiff.html)                                                           |      |
+| Licence Libre du Québec – Permissive version 1.1               | [LiLiQ-P-1.1](https://spdx.org/licenses/LiLiQ-P-1.1.html)                                                   | Y    |
+| Licence Libre du Québec – Réciprocité version 1.1              | [LiLiQ-R-1.1](https://spdx.org/licenses/LiLiQ-R-1.1.html)                                                   | Y    |
+| Licence Libre du Québec – Réciprocité forte version 1.1        | [LiLiQ-Rplus-1.1](https://spdx.org/licenses/LiLiQ-Rplus-1.1.html)                                           | Y    |
+| Lucent Public License Version 1.0                              | [LPL-1.0](https://spdx.org/licenses/LPL-1.0.html)                                                           | Y    |
+| Lucent Public License v1.02                                    | [LPL-1.02](https://spdx.org/licenses/LPL-1.02.html)                                                         | Y    |
+| LaTeX Project Public License v1.0                              | [LPPL-1.0](https://spdx.org/licenses/LPPL-1.0.html)                                                         |      |
+| LaTeX Project Public License v1.1                              | [LPPL-1.1](https://spdx.org/licenses/LPPL-1.1.html)                                                         |      |
+| LaTeX Project Public License v1.2                              | [LPPL-1.2](https://spdx.org/licenses/LPPL-1.2.html)                                                         |      |
+| LaTeX Project Public License v1.3a                             | [LPPL-1.3a](https://spdx.org/licenses/LPPL-1.3a.html)                                                       |      |
+| LaTeX Project Public License v1.3c                             | [LPPL-1.3c](https://spdx.org/licenses/LPPL-1.3c.html)                                                       | Y    |
+| MakeIndex License                                              | [MakeIndex](https://spdx.org/licenses/MakeIndex.html)                                                       |      |
+| MirOS Licence                                                  | [MirOS](https://spdx.org/licenses/MirOS.html)                                                               | Y    |
+| MIT License                                                    | [MIT](https://spdx.org/licenses/MIT.html)                                                                   | Y    |
+| Enlightenment License (e16)                                    | [MIT-advertising](https://spdx.org/licenses/MIT-advertising.html)                                           |      |
+| CMU License                                                    | [MIT-CMU](https://spdx.org/licenses/MIT-CMU.html)                                                           |      |
+| enna License                                                   | [MIT-enna](https://spdx.org/licenses/MIT-enna.html)                                                         |      |
+| feh License                                                    | [MIT-feh](https://spdx.org/licenses/MIT-feh.html)                                                           |      |
+| MIT +no-false-attribs license                                  | [MITNFA](https://spdx.org/licenses/MITNFA.html)                                                             |      |
+| Motosoto License                                               | [Motosoto](https://spdx.org/licenses/Motosoto.html)                                                         | Y    |
+| mpich2 License                                                 | [mpich2](https://spdx.org/licenses/mpich2.html)                                                             |      |
+| Mozilla Public License 1.0                                     | [MPL-1.0](https://spdx.org/licenses/MPL-1.0.html)                                                           | Y    |
+| Mozilla Public License 1.1                                     | [MPL-1.1](https://spdx.org/licenses/MPL-1.1.html)                                                           | Y    |
+| Mozilla Public License 2.0                                     | [MPL-2.0](https://spdx.org/licenses/MPL-2.0.html)                                                           | Y    |
+| Mozilla Public License 2.0 (no copyleft exception)             | [MPL-2.0-no-copyleft-exception](https://spdx.org/licenses/MPL-2.0-no-copyleft-exception.html)               | Y    |
+| Microsoft Public License                                       | [MS-PL](https://spdx.org/licenses/MS-PL.html)                                                               | Y    |
+| Microsoft Reciprocal License                                   | [MS-RL](https://spdx.org/licenses/MS-RL.html)                                                               | Y    |
+| Matrix Template Library License                                | [MTLL](https://spdx.org/licenses/MTLL.html)                                                                 |      |
+| Multics License                                                | [Multics](https://spdx.org/licenses/Multics.html)                                                           | Y    |
+| Mup License                                                    | [Mup](https://spdx.org/licenses/Mup.html)                                                                   |      |
+| NASA Open Source Agreement 1.3                                 | [NASA-1.3](https://spdx.org/licenses/NASA-1.3.html)                                                         | Y    |
+| Naumen Public License                                          | [Naumen](https://spdx.org/licenses/Naumen.html)                                                             | Y    |
+| Net Boolean Public License v1                                  | [NBPL-1.0](https://spdx.org/licenses/NBPL-1.0.html)                                                         |      |
+| University of Illinois/NCSA Open Source License                | [NCSA](https://spdx.org/licenses/NCSA.html)                                                                 | Y    |
+| Net-SNMP License                                               | [Net-SNMP](https://spdx.org/licenses/Net-SNMP.html)                                                         |      |
+| NetCDF license                                                 | [NetCDF](https://spdx.org/licenses/NetCDF.html)                                                             |      |
+| Newsletr License                                               | [Newsletr](https://spdx.org/licenses/Newsletr.html)                                                         |      |
+| Nethack General Public License                                 | [NGPL](https://spdx.org/licenses/NGPL.html)                                                                 | Y    |
+| Norwegian Licence for Open Government Data                     | [NLOD-1.0](https://spdx.org/licenses/NLOD-1.0.html)                                                         |      |
+| No Limit Public License                                        | [NLPL](https://spdx.org/licenses/NLPL.html)                                                                 |      |
+| Nokia Open Source License                                      | [Nokia](https://spdx.org/licenses/Nokia.html)                                                               | Y    |
+| Netizen Open Source License                                    | [NOSL](https://spdx.org/licenses/NOSL.html)                                                                 |      |
+| Noweb License                                                  | [Noweb](https://spdx.org/licenses/Noweb.html)                                                               |      |
+| Netscape Public License v1.0                                   | [NPL-1.0](https://spdx.org/licenses/NPL-1.0.html)                                                           |      |
+| Netscape Public License v1.1                                   | [NPL-1.1](https://spdx.org/licenses/NPL-1.1.html)                                                           |      |
+| Non-Profit Open Software License 3.0                           | [NPOSL-3.0](https://spdx.org/licenses/NPOSL-3.0.html)                                                       | Y    |
+| NRL License                                                    | [NRL](https://spdx.org/licenses/NRL.html)                                                                   |      |
+| NTP License                                                    | [NTP](https://spdx.org/licenses/NTP.html)                                                                   | Y    |
+| Nunit License                                                  | [Nunit](https://spdx.org/licenses/Nunit.html)                                                               |      |
+| Open CASCADE Technology Public License                         | [OCCT-PL](https://spdx.org/licenses/OCCT-PL.html)                                                           |      |
+| OCLC Research Public License 2.0                               | [OCLC-2.0](https://spdx.org/licenses/OCLC-2.0.html)                                                         | Y    |
+| ODC Open Database License v1.0                                 | [ODbL-1.0](https://spdx.org/licenses/ODbL-1.0.html)                                                         |      |
+| SIL Open Font License 1.0                                      | [OFL-1.0](https://spdx.org/licenses/OFL-1.0.html)                                                           |      |
+| SIL Open Font License 1.1                                      | [OFL-1.1](https://spdx.org/licenses/OFL-1.1.html)                                                           | Y    |
+| Open Group Test Suite License                                  | [OGTSL](https://spdx.org/licenses/OGTSL.html)                                                               | Y    |
+| Open LDAP Public License v1.1                                  | [OLDAP-1.1](https://spdx.org/licenses/OLDAP-1.1.html)                                                       |      |
+| Open LDAP Public License v1.2                                  | [OLDAP-1.2](https://spdx.org/licenses/OLDAP-1.2.html)                                                       |      |
+| Open LDAP Public License v1.3                                  | [OLDAP-1.3](https://spdx.org/licenses/OLDAP-1.3.html)                                                       |      |
+| Open LDAP Public License v1.4                                  | [OLDAP-1.4](https://spdx.org/licenses/OLDAP-1.4.html)                                                       |      |
+| Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)      | [OLDAP-2.0](https://spdx.org/licenses/OLDAP-2.0.html)                                                       |      |
+| Open LDAP Public License v2.0.1                                | [OLDAP-2.0.1](https://spdx.org/licenses/OLDAP-2.0.1.html)                                                   |      |
+| Open LDAP Public License v2.1                                  | [OLDAP-2.1](https://spdx.org/licenses/OLDAP-2.1.html)                                                       |      |
+| Open LDAP Public License v2.2                                  | [OLDAP-2.2](https://spdx.org/licenses/OLDAP-2.2.html)                                                       |      |
+| Open LDAP Public License v2.2.1                                | [OLDAP-2.2.1](https://spdx.org/licenses/OLDAP-2.2.1.html)                                                   |      |
+| Open LDAP Public License  2.2.2                                | [OLDAP-2.2.2](https://spdx.org/licenses/OLDAP-2.2.2.html)                                                   |      |
+| Open LDAP Public License v2.3                                  | [OLDAP-2.3](https://spdx.org/licenses/OLDAP-2.3.html)                                                       |      |
+| Open LDAP Public License v2.4                                  | [OLDAP-2.4](https://spdx.org/licenses/OLDAP-2.4.html)                                                       |      |
+| Open LDAP Public License v2.5                                  | [OLDAP-2.5](https://spdx.org/licenses/OLDAP-2.5.html)                                                       |      |
+| Open LDAP Public License v2.6                                  | [OLDAP-2.6](https://spdx.org/licenses/OLDAP-2.6.html)                                                       |      |
+| Open LDAP Public License v2.7                                  | [OLDAP-2.7](https://spdx.org/licenses/OLDAP-2.7.html)                                                       |      |
+| Open LDAP Public License v2.8                                  | [OLDAP-2.8](https://spdx.org/licenses/OLDAP-2.8.html)                                                       |      |
+| Open Market License                                            | [OML](https://spdx.org/licenses/OML.html)                                                                   |      |
+| OpenSSL License                                                | [OpenSSL](https://spdx.org/licenses/OpenSSL.html)                                                           |      |
+| Open Public License v1.0                                       | [OPL-1.0](https://spdx.org/licenses/OPL-1.0.html)                                                           |      |
+| OSET Public License version 2.1                                | [OSET-PL-2.1](https://spdx.org/licenses/OSET-PL-2.1.html)                                                   | Y    |
+| Open Software License 1.0                                      | [OSL-1.0](https://spdx.org/licenses/OSL-1.0.html)                                                           | Y    |
+| Open Software License 1.1                                      | [OSL-1.1](https://spdx.org/licenses/OSL-1.1.html)                                                           |      |
+| Open Software License 2.0                                      | [OSL-2.0](https://spdx.org/licenses/OSL-2.0.html)                                                           | Y    |
+| Open Software License 2.1                                      | [OSL-2.1](https://spdx.org/licenses/OSL-2.1.html)                                                           | Y    |
+| Open Software License 3.0                                      | [OSL-3.0](https://spdx.org/licenses/OSL-3.0.html)                                                           | Y    |
+| ODC Public Domain Dedication & License 1.0                     | [PDDL-1.0](https://spdx.org/licenses/PDDL-1.0.html)                                                         |      |
+| PHP License v3.0                                               | [PHP-3.0](https://spdx.org/licenses/PHP-3.0.html)                                                           | Y    |
+| PHP License v3.01                                              | [PHP-3.01](https://spdx.org/licenses/PHP-3.01.html)                                                         |      |
+| Plexus Classworlds License                                     | [Plexus](https://spdx.org/licenses/Plexus.html)                                                             |      |
+| PostgreSQL License                                             | [PostgreSQL](https://spdx.org/licenses/PostgreSQL.html)                                                     | Y    |
+| psfrag License                                                 | [psfrag](https://spdx.org/licenses/psfrag.html)                                                             |      |
+| psutils License                                                | [psutils](https://spdx.org/licenses/psutils.html)                                                           |      |
+| Python License 2.0                                             | [Python-2.0](https://spdx.org/licenses/Python-2.0.html)                                                     | Y    |
+| Qhull License                                                  | [Qhull](https://spdx.org/licenses/Qhull.html)                                                               |      |
+| Q Public License 1.0                                           | [QPL-1.0](https://spdx.org/licenses/QPL-1.0.html)                                                           | Y    |
+| Rdisc License                                                  | [Rdisc](https://spdx.org/licenses/Rdisc.html)                                                               |      |
+| Red Hat eCos Public License v1.1                               | [RHeCos-1.1](https://spdx.org/licenses/RHeCos-1.1.html)                                                     |      |
+| Reciprocal Public License 1.1                                  | [RPL-1.1](https://spdx.org/licenses/RPL-1.1.html)                                                           | Y    |
+| Reciprocal Public License 1.5                                  | [RPL-1.5](https://spdx.org/licenses/RPL-1.5.html)                                                           | Y    |
+| RealNetworks Public Source License v1.0                        | [RPSL-1.0](https://spdx.org/licenses/RPSL-1.0.html)                                                         | Y    |
+| RSA Message-Digest License                                     | [RSA-MD](https://spdx.org/licenses/RSA-MD.html)                                                             |      |
+| Ricoh Source Code Public License                               | [RSCPL](https://spdx.org/licenses/RSCPL.html)                                                               | Y    |
+| Ruby License                                                   | [Ruby](https://spdx.org/licenses/Ruby.html)                                                                 |      |
+| Sax Public Domain Notice                                       | [SAX-PD](https://spdx.org/licenses/SAX-PD.html)                                                             |      |
+| Saxpath License                                                | [Saxpath](https://spdx.org/licenses/Saxpath.html)                                                           |      |
+| SCEA Shared Source License                                     | [SCEA](https://spdx.org/licenses/SCEA.html)                                                                 |      |
+| Sendmail License                                               | [Sendmail](https://spdx.org/licenses/Sendmail.html)                                                         |      |
+| SGI Free Software License B v1.0                               | [SGI-B-1.0](https://spdx.org/licenses/SGI-B-1.0.html)                                                       |      |
+| SGI Free Software License B v1.1                               | [SGI-B-1.1](https://spdx.org/licenses/SGI-B-1.1.html)                                                       |      |
+| SGI Free Software License B v2.0                               | [SGI-B-2.0](https://spdx.org/licenses/SGI-B-2.0.html)                                                       |      |
+| Simple Public License 2.0                                      | [SimPL-2.0](https://spdx.org/licenses/SimPL-2.0.html)                                                       | Y    |
+| Sun Industry Standards Source License v1.1                     | [SISSL](https://spdx.org/licenses/SISSL.html)                                                               | Y    |
+| Sun Industry Standards Source License v1.2                     | [SISSL-1.2](https://spdx.org/licenses/SISSL-1.2.html)                                                       |      |
+| Sleepycat License                                              | [Sleepycat](https://spdx.org/licenses/Sleepycat.html)                                                       | Y    |
+| Standard ML of New Jersey License                              | [SMLNJ](https://spdx.org/licenses/SMLNJ.html)                                                               |      |
+| Secure Messaging Protocol Public License                       | [SMPPL](https://spdx.org/licenses/SMPPL.html)                                                               |      |
+| SNIA Public License 1.1                                        | [SNIA](https://spdx.org/licenses/SNIA.html)                                                                 |      |
+| Spencer License 86                                             | [Spencer-86](https://spdx.org/licenses/Spencer-86.html)                                                     |      |
+| Spencer License 94                                             | [Spencer-94](https://spdx.org/licenses/Spencer-94.html)                                                     |      |
+| Spencer License 99                                             | [Spencer-99](https://spdx.org/licenses/Spencer-99.html)                                                     |      |
+| Sun Public License v1.0                                        | [SPL-1.0](https://spdx.org/licenses/SPL-1.0.html)                                                           | Y    |
+| SugarCRM Public License v1.1.3                                 | [SugarCRM-1.1.3](https://spdx.org/licenses/SugarCRM-1.1.3.html)                                             |      |
+| Scheme Widget Library (SWL) Software License Agreement         | [SWL](https://spdx.org/licenses/SWL.html)                                                                   |      |
+| TCL/TK License                                                 | [TCL](https://spdx.org/licenses/TCL.html)                                                                   |      |
+| TCP Wrappers License                                           | [TCP-wrappers](https://spdx.org/licenses/TCP-wrappers.html)                                                 |      |
+| TMate Open Source License                                      | [TMate](https://spdx.org/licenses/TMate.html)                                                               |      |
+| TORQUE v2.5+ Software License v1.1                             | [TORQUE-1.1](https://spdx.org/licenses/TORQUE-1.1.html)                                                     |      |
+| Trusster Open Source License                                   | [TOSL](https://spdx.org/licenses/TOSL.html)                                                                 |      |
+| Unicode License Agreement - Data Files and Software (2015)     | [Unicode-DFS-2015](https://spdx.org/licenses/Unicode-DFS-2015.html)                                         |      |
+| Unicode License Agreement - Data Files and Software (2016)     | [Unicode-DFS-2016](https://spdx.org/licenses/Unicode-DFS-2016.html)                                         |      |
+| Unicode Terms of Use                                           | [Unicode-TOU](https://spdx.org/licenses/Unicode-TOU.html)                                                   |      |
+| The Unlicense                                                  | [Unlicense](https://spdx.org/licenses/Unlicense.html)                                                       |      |
+| Universal Permissive License v1.0                              | [UPL-1.0](https://spdx.org/licenses/UPL-1.0.html)                                                           | Y    |
+| Vim License                                                    | [Vim](https://spdx.org/licenses/Vim.html)                                                                   |      |
+| VOSTROM Public License for Open Source                         | [VOSTROM](https://spdx.org/licenses/VOSTROM.html)                                                           |      |
+| Vovida Software License v1.0                                   | [VSL-1.0](https://spdx.org/licenses/VSL-1.0.html)                                                           | Y    |
+| W3C Software Notice and License (2002-12-31)                   | [W3C](https://spdx.org/licenses/W3C.html)                                                                   | Y    |
+| W3C Software Notice and License (1998-07-20)                   | [W3C-19980720](https://spdx.org/licenses/W3C-19980720.html)                                                 |      |
+| W3C Software Notice and Document License (2015-05-13)          | [W3C-20150513](https://spdx.org/licenses/W3C-20150513.html)                                                 |      |
+| Sybase Open Watcom Public License 1.0                          | [Watcom-1.0](https://spdx.org/licenses/Watcom-1.0.html)                                                     | Y    |
+| Wsuipa License                                                 | [Wsuipa](https://spdx.org/licenses/Wsuipa.html)                                                             |      |
+| Do What The F*ck You Want To Public License                    | [WTFPL](https://spdx.org/licenses/WTFPL.html)                                                               |      |
+| X11 License                                                    | [X11](https://spdx.org/licenses/X11.html)                                                                   |      |
+| Xerox License                                                  | [Xerox](https://spdx.org/licenses/Xerox.html)                                                               |      |
+| XFree86 License 1.1                                            | [XFree86-1.1](https://spdx.org/licenses/XFree86-1.1.html)                                                   |      |
+| xinetd License                                                 | [xinetd](https://spdx.org/licenses/xinetd.html)                                                             |      |
+| X.Net License                                                  | [Xnet](https://spdx.org/licenses/Xnet.html)                                                                 | Y    |
+| XPP License                                                    | [xpp](https://spdx.org/licenses/xpp.html)                                                                   |      |
+| XSkat License                                                  | [XSkat](https://spdx.org/licenses/XSkat.html)                                                               |      |
+| Yahoo! Public License v1.0                                     | [YPL-1.0](https://spdx.org/licenses/YPL-1.0.html)                                                           |      |
+| Yahoo! Public License v1.1                                     | [YPL-1.1](https://spdx.org/licenses/YPL-1.1.html)                                                           |      |
+| Zed License                                                    | [Zed](https://spdx.org/licenses/Zed.html)                                                                   |      |
+| Zend License v2.0                                              | [Zend-2.0](https://spdx.org/licenses/Zend-2.0.html)                                                         |      |
+| Zimbra Public License v1.3                                     | [Zimbra-1.3](https://spdx.org/licenses/Zimbra-1.3.html)                                                     |      |
+| Zimbra Public License v1.4                                     | [Zimbra-1.4](https://spdx.org/licenses/Zimbra-1.4.html)                                                     |      |
+| zlib License                                                   | [Zlib](https://spdx.org/licenses/Zlib.html)                                                                 | Y    |
+| zlib/libpng License with Acknowledgement                       | [zlib-acknowledgement](https://spdx.org/licenses/zlib-acknowledgement.html)                                 |      |
+| Zope Public License 1.1                                        | [ZPL-1.1](https://spdx.org/licenses/ZPL-1.1.html)                                                           |      |
+| Zope Public License 2.0                                        | [ZPL-2.0](https://spdx.org/licenses/ZPL-2.0.html)                                                           | Y    |
+| Zope Public License 2.1                                        | [ZPL-2.1](https://spdx.org/licenses/ZPL-2.1.html)                                                           |      |
 
 ## I.2 Exceptions List <a name="I.2"></a>
 
-| Full Name of Exception                | SPDX LicenseException         |
-|---------------------------------------|-------------------------------|
-| 389 Directory Server Exception        | [389-exception][]             |
-| Autoconf exception 2.0                | [Autoconf-exception-2.0][]    |
-| Autoconf exception 3.0                | [Autoconf-exception-3.0][]    |
-| Bison exception 2.2                   | [Bison-exception-2.2][]       |
-| Classpath exception 2.0               | [Classpath-exception-2.0][]   |
-| CLISP exception 2.0                   | [CLISP-exception-2.0][]       |
-| DigiRule FOSS License Exception       | [DigiRule-FOSS-exception][]   |
-| eCos exception 2.0                    | [eCos-exception-2.0][]        |
-| Fawkes Runtime Exception              | [Fawkes-Runtime-exception][]  |
-| FLTK exception                        | [FLTK-exception][]            |
-| Font exception 2.0                    | [Font-exception-2.0][]        |
-| FreeRTOS Exception 2.0                | [freertos-exception-2.0][]    |
-| GCC Runtime Library exception 2.0     | [GCC-exception-2.0][]         |
-| GCC Runtime Library exception 3.1     | [GCC-exception-3.1][]         |
-| GNU JavaMail exception                | [gnu-javamail-exception][]    |
-| i2p GPL+Java Exception                | [i2p-gpl-java-exception][]    |
-| Libtool Exception                     | [Libtool-exception][]         |
-| LZMA exception                        | [LZMA-exception][]            |
-| Macros and Inline Functions Exception | [mif-exception][]             |
-| Nokia Qt LGPL exception 1.1           | [Nokia-Qt-exception-1.1][]    |
-| Open CASCADE Exception 1.0            | [OCCT-exception-1.0][]        |
-| OpenVPN OpenSSL Exception             | [openvpn-openssl-exception][] |
-| Qwt exception 1.0                     | [Qwt-exception-1.0][]         |
-| U-Boot exception 2.0                  | [u-boot-exception-2.0][]      |
-| WxWindows Library Exception 3.1       | [WxWindows-exception-3.1][]   |
+| Full Name of Exception                | SPDX License Exception                                                                |
+|---------------------------------------|---------------------------------------------------------------------------------------|
+| 389 Directory Server Exception        | [389-exception](https://spdx.org/licenses/389-exception.html)                         |
+| Autoconf exception 2.0                | [Autoconf-exception-2.0](https://spdx.org/licenses/Autoconf-exception-2.0.html)       |
+| Autoconf exception 3.0                | [Autoconf-exception-3.0](https://spdx.org/licenses/Autoconf-exception-3.0.html)       |
+| Bison exception 2.2                   | [Bison-exception-2.2](https://spdx.org/licenses/Bison-exception-2.2.html)             |
+| Classpath exception 2.0               | [Classpath-exception-2.0](https://spdx.org/licenses/Classpath-exception-2.0.html)     |
+| CLISP exception 2.0                   | [CLISP-exception-2.0](https://spdx.org/licenses/CLISP-exception-2.0.html)             |
+| DigiRule FOSS License Exception       | [DigiRule-FOSS-exception](https://spdx.org/licenses/DigiRule-FOSS-exception.html)     |
+| eCos exception 2.0                    | [eCos-exception-2.0](https://spdx.org/licenses/eCos-exception-2.0.html)               |
+| Fawkes Runtime Exception              | [Fawkes-Runtime-exception](https://spdx.org/licenses/Fawkes-Runtime-exception.html)   |
+| FLTK exception                        | [FLTK-exception](https://spdx.org/licenses/FLTK-exception.html)                       |
+| Font exception 2.0                    | [Font-exception-2.0](https://spdx.org/licenses/Font-exception-2.0.html)               |
+| FreeRTOS Exception 2.0                | [freertos-exception-2.0](https://spdx.org/licenses/freertos-exception-2.0.html)       |
+| GCC Runtime Library exception 2.0     | [GCC-exception-2.0](https://spdx.org/licenses/GCC-exception-2.0.html)                 |
+| GCC Runtime Library exception 3.1     | [GCC-exception-3.1](https://spdx.org/licenses/GCC-exception-3.1.html)                 |
+| GNU JavaMail exception                | [gnu-javamail-exception](https://spdx.org/licenses/gnu-javamail-exception.html)       |
+| i2p GPL+Java Exception                | [i2p-gpl-java-exception](https://spdx.org/licenses/i2p-gpl-java-exception.html)       |
+| Libtool Exception                     | [Libtool-exception](https://spdx.org/licenses/Libtool-exception.html)                 |
+| LZMA exception                        | [LZMA-exception](https://spdx.org/licenses/LZMA-exception.html)                       |
+| Macros and Inline Functions Exception | [mif-exception](https://spdx.org/licenses/mif-exception.html)                         |
+| Nokia Qt LGPL exception 1.1           | [Nokia-Qt-exception-1.1](https://spdx.org/licenses/Nokia-Qt-exception-1.1.html)       |
+| Open CASCADE Exception 1.0            | [OCCT-exception-1.0](https://spdx.org/licenses/OCCT-exception-1.0.html)               |
+| OpenVPN OpenSSL Exception             | [openvpn-openssl-exception](https://spdx.org/licenses/openvpn-openssl-exception.html) |
+| Qwt exception 1.0                     | [Qwt-exception-1.0](https://spdx.org/licenses/Qwt-exception-1.0.html)                 |
+| U-Boot exception 2.0                  | [u-boot-exception-2.0](https://spdx.org/licenses/u-boot-exception-2.0.html)           |
+| WxWindows Library Exception 3.1       | [WxWindows-exception-3.1](https://spdx.org/licenses/WxWindows-exception-3.1.html)     |
 
 ## I.3 Deprecated Licenses <a name="I.3"></a>
 
-| Full Name of License                                            | Deprecated SPDX License Identifier     |
-|-----------------------------------------------------------------|----------------------------------------|
-| eCos license version 2.0                                        | [eCos-2.0][]                           |
-| GNU General Public License v1.0 or later                        | [GPL-1.0+][]                           |
-| GNU General Public License v2.0 or later                        | [GPL-2.0+][]                           |
-| GNU General Public License v2.0 w/Autoconf exception            | [GPL-2.0-with-autoconf-exception][]    |
-| GNU General Public License v2.0 w/Bison exception               | [GPL-2.0-with-bison-exception][]       |
-| GNU General Public License v2.0 w/Classpath exception           | [GPL-2.0-with-classpath-exception][]   |
-| GNU General Public License v2.0 w/Font exception                | [GPL-2.0-with-font-exception][]        |
-| GNU General Public License v2.0 w/GCC Runtime Library exception | [GPL-2.0-with-GCC-exception][]         |
-| GNU General Public License v3.0 or later                        | [GPL-3.0+][]                           |
-| GNU General Public License v3.0 w/Autoconf exception            | [GPL-3.0-with-autoconf-exception][]    |
-| GNU General Public License v3.0 w/GCC Runtime Library exception | [GPL-3.0-with-GCC-exception][]         |
-| GNU Lesser General Public License v2.1 or later                 | [LGPL-2.1+][]                          |
-| GNU Lesser General Public License v3.0 or later                 | [LGPL-3.0+][]                          |
-| GNU Library General Public License v2 or later                  | [LGPL-2.0+][]                          |
-| Standard ML of New Jersey License                               | [StandardML-NJ][]                      |
-| wxWindows Library License                                       | [WXwindows][]                          |
-
-[0BSD]: https://spdx.org/licenses/0BSD.html
-[AAL]: https://spdx.org/licenses/AAL.html
-[Abstyles]: https://spdx.org/licenses/Abstyles.html
-[Adobe-2006]: https://spdx.org/licenses/Adobe-2006.html
-[Adobe-Glyph]: https://spdx.org/licenses/Adobe-Glyph.html
-[ADSL]: https://spdx.org/licenses/ADSL.html
-[AFL-1.1]: https://spdx.org/licenses/AFL-1.1.html
-[AFL-1.2]: https://spdx.org/licenses/AFL-1.2.html
-[AFL-2.0]: https://spdx.org/licenses/AFL-2.0.html
-[AFL-2.1]: https://spdx.org/licenses/AFL-2.1.html
-[AFL-3.0]: https://spdx.org/licenses/AFL-3.0.html
-[Afmparse]: https://spdx.org/licenses/Afmparse.html
-[AGPL-1.0]: https://spdx.org/licenses/AGPL-1.0.html
-[AGPL-3.0]: https://spdx.org/licenses/AGPL-3.0.html
-[Aladdin]: https://spdx.org/licenses/Aladdin.html
-[AMDPLPA]: https://spdx.org/licenses/AMDPLPA.html
-[AML]: https://spdx.org/licenses/AML.html
-[AMPAS]: https://spdx.org/licenses/AMPAS.html
-[ANTLR-PD]: https://spdx.org/licenses/ANTLR-PD.html
-[Apache-1.0]: https://spdx.org/licenses/Apache-1.0.html
-[Apache-1.1]: https://spdx.org/licenses/Apache-1.1.html
-[Apache-2.0]: https://spdx.org/licenses/Apache-2.0.html
-[APAFML]: https://spdx.org/licenses/APAFML.html
-[APL-1.0]: https://spdx.org/licenses/APL-1.0.html
-[APSL-1.0]: https://spdx.org/licenses/APSL-1.0.html
-[APSL-1.1]: https://spdx.org/licenses/APSL-1.1.html
-[APSL-1.2]: https://spdx.org/licenses/APSL-1.2.html
-[APSL-2.0]: https://spdx.org/licenses/APSL-2.0.html
-[Artistic-1.0-cl8]: https://spdx.org/licenses/Artistic-1.0-cl8.html
-[Artistic-1.0-Perl]: https://spdx.org/licenses/Artistic-1.0-Perl.html
-[Artistic-1.0]: https://spdx.org/licenses/Artistic-1.0.html
-[Artistic-2.0]: https://spdx.org/licenses/Artistic-2.0.html
-[Bahyph]: https://spdx.org/licenses/Bahyph.html
-[Barr]: https://spdx.org/licenses/Barr.html
-[Beerware]: https://spdx.org/licenses/Beerware.html
-[BitTorrent-1.0]: https://spdx.org/licenses/BitTorrent-1.0.html
-[BitTorrent-1.1]: https://spdx.org/licenses/BitTorrent-1.1.html
-[Borceux]: https://spdx.org/licenses/Borceux.html
-[BSD-2-Clause-FreeBSD]: https://spdx.org/licenses/BSD-2-Clause-FreeBSD.html
-[BSD-2-Clause-NetBSD]: https://spdx.org/licenses/BSD-2-Clause-NetBSD.html
-[BSD-2-Clause]: https://spdx.org/licenses/BSD-2-Clause.html
-[BSD-3-Clause-Attribution]: https://spdx.org/licenses/BSD-3-Clause-Attribution.html
-[BSD-3-Clause-Clear]: https://spdx.org/licenses/BSD-3-Clause-Clear.html
-[BSD-3-Clause-LBNL]: https://spdx.org/licenses/BSD-3-Clause-LBNL.html
-[BSD-3-Clause-No-Nuclear-License-2014]: https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.html
-[BSD-3-Clause-No-Nuclear-License]: https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.html
-[BSD-3-Clause-No-Nuclear-Warranty]: https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.html
-[BSD-3-Clause]: https://spdx.org/licenses/BSD-3-Clause.html
-[BSD-4-Clause-UC]: https://spdx.org/licenses/BSD-4-Clause-UC.html
-[BSD-4-Clause]: https://spdx.org/licenses/BSD-4-Clause.html
-[BSD-Protection]: https://spdx.org/licenses/BSD-Protection.html
-[BSD-Source-Code]: https://spdx.org/licenses/BSD-Source-Code.html
-[BSL-1.0]: https://spdx.org/licenses/BSL-1.0.html
-[bzip2-1.0.5]: https://spdx.org/licenses/bzip2-1.0.5.html
-[bzip2-1.0.6]: https://spdx.org/licenses/bzip2-1.0.6.html
-[Caldera]: https://spdx.org/licenses/Caldera.html
-[CATOSL-1.1]: https://spdx.org/licenses/CATOSL-1.1.html
-[CC-BY-1.0]: https://spdx.org/licenses/CC-BY-1.0.html
-[CC-BY-2.0]: https://spdx.org/licenses/CC-BY-2.0.html
-[CC-BY-2.5]: https://spdx.org/licenses/CC-BY-2.5.html
-[CC-BY-3.0]: https://spdx.org/licenses/CC-BY-3.0.html
-[CC-BY-4.0]: https://spdx.org/licenses/CC-BY-4.0.html
-[CC-BY-NC-1.0]: https://spdx.org/licenses/CC-BY-NC-1.0.html
-[CC-BY-NC-2.0]: https://spdx.org/licenses/CC-BY-NC-2.0.html
-[CC-BY-NC-2.5]: https://spdx.org/licenses/CC-BY-NC-2.5.html
-[CC-BY-NC-3.0]: https://spdx.org/licenses/CC-BY-NC-3.0.html
-[CC-BY-NC-4.0]: https://spdx.org/licenses/CC-BY-NC-4.0.html
-[CC-BY-NC-ND-1.0]: https://spdx.org/licenses/CC-BY-NC-ND-1.0.html
-[CC-BY-NC-ND-2.0]: https://spdx.org/licenses/CC-BY-NC-ND-2.0.html
-[CC-BY-NC-ND-2.5]: https://spdx.org/licenses/CC-BY-NC-ND-2.5.html
-[CC-BY-NC-ND-3.0]: https://spdx.org/licenses/CC-BY-NC-ND-3.0.html
-[CC-BY-NC-ND-4.0]: https://spdx.org/licenses/CC-BY-NC-ND-4.0.html
-[CC-BY-NC-SA-1.0]: https://spdx.org/licenses/CC-BY-NC-SA-1.0.html
-[CC-BY-NC-SA-2.0]: https://spdx.org/licenses/CC-BY-NC-SA-2.0.html
-[CC-BY-NC-SA-2.5]: https://spdx.org/licenses/CC-BY-NC-SA-2.5.html
-[CC-BY-NC-SA-3.0]: https://spdx.org/licenses/CC-BY-NC-SA-3.0.html
-[CC-BY-NC-SA-4.0]: https://spdx.org/licenses/CC-BY-NC-SA-4.0.html
-[CC-BY-ND-1.0]: https://spdx.org/licenses/CC-BY-ND-1.0.html
-[CC-BY-ND-2.0]: https://spdx.org/licenses/CC-BY-ND-2.0.html
-[CC-BY-ND-2.5]: https://spdx.org/licenses/CC-BY-ND-2.5.html
-[CC-BY-ND-3.0]: https://spdx.org/licenses/CC-BY-ND-3.0.html
-[CC-BY-ND-4.0]: https://spdx.org/licenses/CC-BY-ND-4.0.html
-[CC-BY-SA-1.0]: https://spdx.org/licenses/CC-BY-SA-1.0.html
-[CC-BY-SA-2.0]: https://spdx.org/licenses/CC-BY-SA-2.0.html
-[CC-BY-SA-2.5]: https://spdx.org/licenses/CC-BY-SA-2.5.html
-[CC-BY-SA-3.0]: https://spdx.org/licenses/CC-BY-SA-3.0.html
-[CC-BY-SA-4.0]: https://spdx.org/licenses/CC-BY-SA-4.0.html
-[CC0-1.0]: https://spdx.org/licenses/CC0-1.0.html
-[CDDL-1.0]: https://spdx.org/licenses/CDDL-1.0.html
-[CDDL-1.1]: https://spdx.org/licenses/CDDL-1.1.html
-[CECILL-1.0]: https://spdx.org/licenses/CECILL-1.0.html
-[CECILL-1.1]: https://spdx.org/licenses/CECILL-1.1.html
-[CECILL-2.0]: https://spdx.org/licenses/CECILL-2.0.html
-[CECILL-2.1]: https://spdx.org/licenses/CECILL-2.1.html
-[CECILL-B]: https://spdx.org/licenses/CECILL-B.html
-[CECILL-C]: https://spdx.org/licenses/CECILL-C.html
-[ClArtistic]: https://spdx.org/licenses/ClArtistic.html
-[CNRI-Jython]: https://spdx.org/licenses/CNRI-Jython.html
-[CNRI-Python-GPL-Compatible]: https://spdx.org/licenses/CNRI-Python-GPL-Compatible.html
-[CNRI-Python]: https://spdx.org/licenses/CNRI-Python.html
-[Condor-1.1]: https://spdx.org/licenses/Condor-1.1.html
-[CPAL-1.0]: https://spdx.org/licenses/CPAL-1.0.html
-[CPL-1.0]: https://spdx.org/licenses/CPL-1.0.html
-[CPOL-1.02]: https://spdx.org/licenses/CPOL-1.02.html
-[Crossword]: https://spdx.org/licenses/Crossword.html
-[CrystalStacker]: https://spdx.org/licenses/CrystalStacker.html
-[CUA-OPL-1.0]: https://spdx.org/licenses/CUA-OPL-1.0.html
-[Cube]: https://spdx.org/licenses/Cube.html
-[curl]: https://spdx.org/licenses/curl.html
-[D-FSL-1.0]: https://spdx.org/licenses/D-FSL-1.0.html
-[diffmark]: https://spdx.org/licenses/diffmark.html
-[DOC]: https://spdx.org/licenses/DOC.html
-[Dotseqn]: https://spdx.org/licenses/Dotseqn.html
-[DSDP]: https://spdx.org/licenses/DSDP.html
-[dvipdfm]: https://spdx.org/licenses/dvipdfm.html
-[ECL-1.0]: https://spdx.org/licenses/ECL-1.0.html
-[ECL-2.0]: https://spdx.org/licenses/ECL-2.0.html
-[EFL-1.0]: https://spdx.org/licenses/EFL-1.0.html
-[EFL-2.0]: https://spdx.org/licenses/EFL-2.0.html
-[eGenix]: https://spdx.org/licenses/eGenix.html
-[Entessa]: https://spdx.org/licenses/Entessa.html
-[EPL-1.0]: https://spdx.org/licenses/EPL-1.0.html
-[ErlPL-1.1]: https://spdx.org/licenses/ErlPL-1.1.html
-[EUDatagrid]: https://spdx.org/licenses/EUDatagrid.html
-[EUPL-1.0]: https://spdx.org/licenses/EUPL-1.0.html
-[EUPL-1.1]: https://spdx.org/licenses/EUPL-1.1.html
-[Eurosym]: https://spdx.org/licenses/Eurosym.html
-[Fair]: https://spdx.org/licenses/Fair.html
-[Frameworx-1.0]: https://spdx.org/licenses/Frameworx-1.0.html
-[FreeImage]: https://spdx.org/licenses/FreeImage.html
-[FSFAP]: https://spdx.org/licenses/FSFAP.html
-[FSFUL]: https://spdx.org/licenses/FSFUL.html
-[FSFULLR]: https://spdx.org/licenses/FSFULLR.html
-[FTL]: https://spdx.org/licenses/FTL.html
-[GFDL-1.1]: https://spdx.org/licenses/GFDL-1.1.html
-[GFDL-1.2]: https://spdx.org/licenses/GFDL-1.2.html
-[GFDL-1.3]: https://spdx.org/licenses/GFDL-1.3.html
-[Giftware]: https://spdx.org/licenses/Giftware.html
-[GL2PS]: https://spdx.org/licenses/GL2PS.html
-[Glide]: https://spdx.org/licenses/Glide.html
-[Glulxe]: https://spdx.org/licenses/Glulxe.html
-[gnuplot]: https://spdx.org/licenses/gnuplot.html
-[GPL-1.0]: https://spdx.org/licenses/GPL-1.0.html
-[GPL-2.0]: https://spdx.org/licenses/GPL-2.0.html
-[GPL-3.0]: https://spdx.org/licenses/GPL-3.0.html
-[gSOAP-1.3b]: https://spdx.org/licenses/gSOAP-1.3b.html
-[HaskellReport]: https://spdx.org/licenses/HaskellReport.html
-[HPND]: https://spdx.org/licenses/HPND.html
-[IBM-pibs]: https://spdx.org/licenses/IBM-pibs.html
-[ICU]: https://spdx.org/licenses/ICU.html
-[IJG]: https://spdx.org/licenses/IJG.html
-[ImageMagick]: https://spdx.org/licenses/ImageMagick.html
-[iMatix]: https://spdx.org/licenses/iMatix.html
-[Imlib2]: https://spdx.org/licenses/Imlib2.html
-[Info-ZIP]: https://spdx.org/licenses/Info-ZIP.html
-[Intel-ACPI]: https://spdx.org/licenses/Intel-ACPI.html
-[Intel]: https://spdx.org/licenses/Intel.html
-[Interbase-1.0]: https://spdx.org/licenses/Interbase-1.0.html
-[IPA]: https://spdx.org/licenses/IPA.html
-[IPL-1.0]: https://spdx.org/licenses/IPL-1.0.html
-[ISC]: https://spdx.org/licenses/ISC.html
-[JasPer-2.0]: https://spdx.org/licenses/JasPer-2.0.html
-[JSON]: https://spdx.org/licenses/JSON.html
-[LAL-1.2]: https://spdx.org/licenses/LAL-1.2.html
-[LAL-1.3]: https://spdx.org/licenses/LAL-1.3.html
-[Latex2e]: https://spdx.org/licenses/Latex2e.html
-[Leptonica]: https://spdx.org/licenses/Leptonica.html
-[LGPL-2.0]: https://spdx.org/licenses/LGPL-2.0.html
-[LGPL-2.1]: https://spdx.org/licenses/LGPL-2.1.html
-[LGPL-3.0]: https://spdx.org/licenses/LGPL-3.0.html
-[LGPLLR]: https://spdx.org/licenses/LGPLLR.html
-[Libpng]: https://spdx.org/licenses/Libpng.html
-[libtiff]: https://spdx.org/licenses/libtiff.html
-[LiLiQ-P-1.1]: https://spdx.org/licenses/LiLiQ-P-1.1.html
-[LiLiQ-R-1.1]: https://spdx.org/licenses/LiLiQ-R-1.1.html
-[LiLiQ-Rplus-1.1]: https://spdx.org/licenses/LiLiQ-Rplus-1.1.html
-[LPL-1.0]: https://spdx.org/licenses/LPL-1.0.html
-[LPL-1.02]: https://spdx.org/licenses/LPL-1.02.html
-[LPPL-1.0]: https://spdx.org/licenses/LPPL-1.0.html
-[LPPL-1.1]: https://spdx.org/licenses/LPPL-1.1.html
-[LPPL-1.2]: https://spdx.org/licenses/LPPL-1.2.html
-[LPPL-1.3a]: https://spdx.org/licenses/LPPL-1.3a.html
-[LPPL-1.3c]: https://spdx.org/licenses/LPPL-1.3c.html
-[MakeIndex]: https://spdx.org/licenses/MakeIndex.html
-[MirOS]: https://spdx.org/licenses/MirOS.html
-[MIT-advertising]: https://spdx.org/licenses/MIT-advertising.html
-[MIT-CMU]: https://spdx.org/licenses/MIT-CMU.html
-[MIT-enna]: https://spdx.org/licenses/MIT-enna.html
-[MIT-feh]: https://spdx.org/licenses/MIT-feh.html
-[MIT]: https://spdx.org/licenses/MIT.html
-[MITNFA]: https://spdx.org/licenses/MITNFA.html
-[Motosoto]: https://spdx.org/licenses/Motosoto.html
-[mpich2]: https://spdx.org/licenses/mpich2.html
-[MPL-1.0]: https://spdx.org/licenses/MPL-1.0.html
-[MPL-1.1]: https://spdx.org/licenses/MPL-1.1.html
-[MPL-2.0-no-copyleft-exception]: https://spdx.org/licenses/MPL-2.0-no-copyleft-exception.html
-[MPL-2.0]: https://spdx.org/licenses/MPL-2.0.html
-[MS-PL]: https://spdx.org/licenses/MS-PL.html
-[MS-RL]: https://spdx.org/licenses/MS-RL.html
-[MTLL]: https://spdx.org/licenses/MTLL.html
-[Multics]: https://spdx.org/licenses/Multics.html
-[Mup]: https://spdx.org/licenses/Mup.html
-[NASA-1.3]: https://spdx.org/licenses/NASA-1.3.html
-[Naumen]: https://spdx.org/licenses/Naumen.html
-[NBPL-1.0]: https://spdx.org/licenses/NBPL-1.0.html
-[NCSA]: https://spdx.org/licenses/NCSA.html
-[NetCDF]: https://spdx.org/licenses/NetCDF.html
-[Newsletr]: https://spdx.org/licenses/Newsletr.html
-[NGPL]: https://spdx.org/licenses/NGPL.html
-[NLOD-1.0]: https://spdx.org/licenses/NLOD-1.0.html
-[NLPL]: https://spdx.org/licenses/NLPL.html
-[Nokia]: https://spdx.org/licenses/Nokia.html
-[NOSL]: https://spdx.org/licenses/NOSL.html
-[Noweb]: https://spdx.org/licenses/Noweb.html
-[NPL-1.0]: https://spdx.org/licenses/NPL-1.0.html
-[NPL-1.1]: https://spdx.org/licenses/NPL-1.1.html
-[NPOSL-3.0]: https://spdx.org/licenses/NPOSL-3.0.html
-[NRL]: https://spdx.org/licenses/NRL.html
-[NTP]: https://spdx.org/licenses/NTP.html
-[Nunit]: https://spdx.org/licenses/Nunit.html
-[OCCT-PL]: https://spdx.org/licenses/OCCT-PL.html
-[OCLC-2.0]: https://spdx.org/licenses/OCLC-2.0.html
-[ODbL-1.0]: https://spdx.org/licenses/ODbL-1.0.html
-[OFL-1.0]: https://spdx.org/licenses/OFL-1.0.html
-[OFL-1.1]: https://spdx.org/licenses/OFL-1.1.html
-[OGTSL]: https://spdx.org/licenses/OGTSL.html
-[OLDAP-1.1]: https://spdx.org/licenses/OLDAP-1.1.html
-[OLDAP-1.2]: https://spdx.org/licenses/OLDAP-1.2.html
-[OLDAP-1.3]: https://spdx.org/licenses/OLDAP-1.3.html
-[OLDAP-1.4]: https://spdx.org/licenses/OLDAP-1.4.html
-[OLDAP-2.0.1]: https://spdx.org/licenses/OLDAP-2.0.1.html
-[OLDAP-2.0]: https://spdx.org/licenses/OLDAP-2.0.html
-[OLDAP-2.1]: https://spdx.org/licenses/OLDAP-2.1.html
-[OLDAP-2.2.1]: https://spdx.org/licenses/OLDAP-2.2.1.html
-[OLDAP-2.2.2]: https://spdx.org/licenses/OLDAP-2.2.2.html
-[OLDAP-2.2]: https://spdx.org/licenses/OLDAP-2.2.html
-[OLDAP-2.3]: https://spdx.org/licenses/OLDAP-2.3.html
-[OLDAP-2.4]: https://spdx.org/licenses/OLDAP-2.4.html
-[OLDAP-2.5]: https://spdx.org/licenses/OLDAP-2.5.html
-[OLDAP-2.6]: https://spdx.org/licenses/OLDAP-2.6.html
-[OLDAP-2.7]: https://spdx.org/licenses/OLDAP-2.7.html
-[OLDAP-2.8]: https://spdx.org/licenses/OLDAP-2.8.html
-[OML]: https://spdx.org/licenses/OML.html
-[OpenSSL]: https://spdx.org/licenses/OpenSSL.html
-[OPL-1.0]: https://spdx.org/licenses/OPL-1.0.html
-[OSET-PL-2.1]: https://spdx.org/licenses/OSET-PL-2.1.html
-[OSL-1.0]: https://spdx.org/licenses/OSL-1.0.html
-[OSL-1.1]: https://spdx.org/licenses/OSL-1.1.html
-[OSL-2.0]: https://spdx.org/licenses/OSL-2.0.html
-[OSL-2.1]: https://spdx.org/licenses/OSL-2.1.html
-[OSL-3.0]: https://spdx.org/licenses/OSL-3.0.html
-[PDDL-1.0]: https://spdx.org/licenses/PDDL-1.0.html
-[PHP-3.0]: https://spdx.org/licenses/PHP-3.0.html
-[PHP-3.01]: https://spdx.org/licenses/PHP-3.01.html
-[Plexus]: https://spdx.org/licenses/Plexus.html
-[PostgreSQL]: https://spdx.org/licenses/PostgreSQL.html
-[psfrag]: https://spdx.org/licenses/psfrag.html
-[psutils]: https://spdx.org/licenses/psutils.html
-[Python-2.0]: https://spdx.org/licenses/Python-2.0.html
-[Qhull]: https://spdx.org/licenses/Qhull.html
-[QPL-1.0]: https://spdx.org/licenses/QPL-1.0.html
-[Rdisc]: https://spdx.org/licenses/Rdisc.html
-[README]: https://spdx.org/licenses/README.html
-[RHeCos-1.1]: https://spdx.org/licenses/RHeCos-1.1.html
-[RPL-1.1]: https://spdx.org/licenses/RPL-1.1.html
-[RPL-1.5]: https://spdx.org/licenses/RPL-1.5.html
-[RPSL-1.0]: https://spdx.org/licenses/RPSL-1.0.html
-[RSA-MD]: https://spdx.org/licenses/RSA-MD.html
-[RSCPL]: https://spdx.org/licenses/RSCPL.html
-[Ruby]: https://spdx.org/licenses/Ruby.html
-[SAX-PD]: https://spdx.org/licenses/SAX-PD.html
-[Saxpath]: https://spdx.org/licenses/Saxpath.html
-[SCEA]: https://spdx.org/licenses/SCEA.html
-[Sendmail]: https://spdx.org/licenses/Sendmail.html
-[SGI-B-1.0]: https://spdx.org/licenses/SGI-B-1.0.html
-[SGI-B-1.1]: https://spdx.org/licenses/SGI-B-1.1.html
-[SGI-B-2.0]: https://spdx.org/licenses/SGI-B-2.0.html
-[SimPL-2.0]: https://spdx.org/licenses/SimPL-2.0.html
-[SISSL-1.2]: https://spdx.org/licenses/SISSL-1.2.html
-[SISSL]: https://spdx.org/licenses/SISSL.html
-[Sleepycat]: https://spdx.org/licenses/Sleepycat.html
-[SMLNJ]: https://spdx.org/licenses/SMLNJ.html
-[SMPPL]: https://spdx.org/licenses/SMPPL.html
-[SNIA]: https://spdx.org/licenses/SNIA.html
-[Spencer-86]: https://spdx.org/licenses/Spencer-86.html
-[Spencer-94]: https://spdx.org/licenses/Spencer-94.html
-[Spencer-99]: https://spdx.org/licenses/Spencer-99.html
-[SPL-1.0]: https://spdx.org/licenses/SPL-1.0.html
-[SugarCRM-1.1.3]: https://spdx.org/licenses/SugarCRM-1.1.3.html
-[SWL]: https://spdx.org/licenses/SWL.html
-[TCL]: https://spdx.org/licenses/TCL.html
-[TMate]: https://spdx.org/licenses/TMate.html
-[TORQUE-1.1]: https://spdx.org/licenses/TORQUE-1.1.html
-[TOSL]: https://spdx.org/licenses/TOSL.html
-[Unicode-TOU]: https://spdx.org/licenses/Unicode-TOU.html
-[Unlicense]: https://spdx.org/licenses/Unlicense.html
-[UPL-1.0]: https://spdx.org/licenses/UPL-1.0.html
-[Vim]: https://spdx.org/licenses/Vim.html
-[VOSTROM]: https://spdx.org/licenses/VOSTROM.html
-[VSL-1.0]: https://spdx.org/licenses/VSL-1.0.html
-[W3C-19980720]: https://spdx.org/licenses/W3C-19980720.html
-[W3C]: https://spdx.org/licenses/W3C.html
-[Watcom-1.0]: https://spdx.org/licenses/Watcom-1.0.html
-[Wsuipa]: https://spdx.org/licenses/Wsuipa.html
-[WTFPL]: https://spdx.org/licenses/WTFPL.html
-[X11]: https://spdx.org/licenses/X11.html
-[Xerox]: https://spdx.org/licenses/Xerox.html
-[XFree86-1.1]: https://spdx.org/licenses/XFree86-1.1.html
-[xinetd]: https://spdx.org/licenses/xinetd.html
-[Xnet]: https://spdx.org/licenses/Xnet.html
-[xpp]: https://spdx.org/licenses/xpp.html
-[XSkat]: https://spdx.org/licenses/XSkat.html
-[YPL-1.0]: https://spdx.org/licenses/YPL-1.0.html
-[YPL-1.1]: https://spdx.org/licenses/YPL-1.1.html
-[Zed]: https://spdx.org/licenses/Zed.html
-[Zend-2.0]: https://spdx.org/licenses/Zend-2.0.html
-[Zimbra-1.3]: https://spdx.org/licenses/Zimbra-1.3.html
-[Zimbra-1.4]: https://spdx.org/licenses/Zimbra-1.4.html
-[zlib-acknowledgement]: https://spdx.org/licenses/zlib-acknowledgement.html
-[Zlib]: https://spdx.org/licenses/Zlib.html
-[ZPL-1.1]: https://spdx.org/licenses/ZPL-1.1.html
-[ZPL-2.0]: https://spdx.org/licenses/ZPL-2.0.html
-[ZPL-2.1]: https://spdx.org/licenses/ZPL-2.1.html
-[389-exception]: https://spdx.org/licenses/389-exception.html
-[Autoconf-exception-2.0]: https://spdx.org/licenses/Autoconf-exception-2.0.html
-[Autoconf-exception-3.0]: https://spdx.org/licenses/Autoconf-exception-3.0.html
-[Bison-exception-2.2]: https://spdx.org/licenses/Bison-exception-2.2.html
-[Classpath-exception-2.0]: https://spdx.org/licenses/Classpath-exception-2.0.html
-[CLISP-exception-2.0]: https://spdx.org/licenses/CLISP-exception-2.0.html
-[DigiRule-FOSS-exception]: https://spdx.org/licenses/DigiRule-FOSS-exception.html
-[eCos-exception-2.0]: https://spdx.org/licenses/eCos-exception-2.0.html
-[Fawkes-Runtime-exception]: https://spdx.org/licenses/Fawkes-Runtime-exception.html
-[FLTK-exception]: https://spdx.org/licenses/FLTK-exception.html
-[Font-exception-2.0]: https://spdx.org/licenses/Font-exception-2.0.html
-[freertos-exception-2.0]: https://spdx.org/licenses/freertos-exception-2.0.html
-[GCC-exception-2.0]: https://spdx.org/licenses/GCC-exception-2.0.html
-[GCC-exception-3.1]: https://spdx.org/licenses/GCC-exception-3.1.html
-[gnu-javamail-exception]: https://spdx.org/licenses/gnu-javamail-exception.html
-[i2p-gpl-java-exception]: https://spdx.org/licenses/i2p-gpl-java-exception.html
-[Libtool-exception]: https://spdx.org/licenses/Libtool-exception.html
-[LZMA-exception]: https://spdx.org/licenses/LZMA-exception.html
-[mif-exception]: https://spdx.org/licenses/mif-exception.html
-[Nokia-Qt-exception-1.1]: https://spdx.org/licenses/Nokia-Qt-exception-1.1.html
-[OCCT-exception-1.0]: https://spdx.org/licenses/OCCT-exception-1.0.html
-[openvpn-openssl-exception]: https://spdx.org/licenses/openvpn-openssl-exception.html
-[Qwt-exception-1.0]: https://spdx.org/licenses/Qwt-exception-1.0.html
-[u-boot-exception-2.0]: https://spdx.org/licenses/u-boot-exception-2.0.html
-[WxWindows-exception-3.1]: https://spdx.org/licenses/WxWindows-exception-3.1.html
-
-[eCos-2.0]: https://spdx.org/licenses/eCos-2.0.html
-[GPL-1.0+]: https://spdx.org/licenses/GPL-1.0+.html
-[GPL-2.0+]: https://spdx.org/licenses/GPL-2.0+.html
-[GPL-2.0-with-autoconf-exception]: https://spdx.org/licenses/GPL-2.0-with-autoconf-exception.html
-[GPL-2.0-with-bison-exception]: https://spdx.org/licenses/GPL-2.0-with-bison-exception.html
-[GPL-2.0-with-classpath-exception]: https://spdx.org/licenses/GPL-2.0-with-classpath-exception.html
-[GPL-2.0-with-font-exception]: https://spdx.org/licenses/GPL-2.0-with-font-exception.html
-[GPL-2.0-with-GCC-exception]: https://spdx.org/licenses/GPL-2.0-with-GCC-exception.html
-[GPL-3.0+]: https://spdx.org/licenses/GPL-3.0+.html
-[GPL-3.0-with-autoconf-exception]: https://spdx.org/licenses/GPL-3.0-with-autoconf-exception.html
-[GPL-3.0-with-GCC-exception]: https://spdx.org/licenses/GPL-3.0-with-GCC-exception.html
-[LGPL-2.1+]: https://spdx.org/licenses/LGPL-2.1+.html
-[LGPL-3.0+]: https://spdx.org/licenses/LGPL-3.0+.html
-[LGPL-2.0+]: https://spdx.org/licenses/LGPL-2.0+.html
-[StandardML-NJ]: https://spdx.org/licenses/StandardML-NJ.html
-[WXwindows]: https://spdx.org/licenses/WXwindows.html
+| Full Name of License                                            | Deprecated SDPX Short Identifier                                                                    |
+|-----------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
+| eCos license version 2.0                                        | [eCos-2.0](https://spdx.org/licenses/eCos-2.0.html)                                                 |
+| GNU General Public License v1.0 or later                        | [GPL-1.0+](https://spdx.org/licenses/GPL-1.0+.html)                                                 |
+| GNU General Public License v2.0 or later                        | [GPL-2.0+](https://spdx.org/licenses/GPL-2.0+.html)                                                 |
+| GNU General Public License v2.0 w/Autoconf exception            | [GPL-2.0-with-autoconf-exception](https://spdx.org/licenses/GPL-2.0-with-autoconf-exception.html)   |
+| GNU General Public License v2.0 w/Bison exception               | [GPL-2.0-with-bison-exception](https://spdx.org/licenses/GPL-2.0-with-bison-exception.html)         |
+| GNU General Public License v2.0 w/Classpath exception           | [GPL-2.0-with-classpath-exception](https://spdx.org/licenses/GPL-2.0-with-classpath-exception.html) |
+| GNU General Public License v2.0 w/Font exception                | [GPL-2.0-with-font-exception](https://spdx.org/licenses/GPL-2.0-with-font-exception.html)           |
+| GNU General Public License v2.0 w/GCC Runtime Library exception | [GPL-2.0-with-GCC-exception](https://spdx.org/licenses/GPL-2.0-with-GCC-exception.html)             |
+| GNU General Public License v3.0 or later                        | [GPL-3.0+](https://spdx.org/licenses/GPL-3.0+.html)                                                 |
+| GNU General Public License v3.0 w/Autoconf exception            | [GPL-3.0-with-autoconf-exception](https://spdx.org/licenses/GPL-3.0-with-autoconf-exception.html)   |
+| GNU General Public License v3.0 w/GCC Runtime Library exception | [GPL-3.0-with-GCC-exception](https://spdx.org/licenses/GPL-3.0-with-GCC-exception.html)             |
+| GNU Library General Public License v2 or later                  | [LGPL-2.0+](https://spdx.org/licenses/LGPL-2.0+.html)                                               |
+| GNU Lesser General Public License v2.1 or later                 | [LGPL-2.1+](https://spdx.org/licenses/LGPL-2.1+.html)                                               |
+| GNU Lesser General Public License v3.0 or later                 | [LGPL-3.0+](https://spdx.org/licenses/LGPL-3.0+.html)                                               |
+| Standard ML of New Jersey License                               | [StandardML-NJ](https://spdx.org/licenses/StandardML-NJ.html)                                       |
+| wxWindows Library License                                       | [WXwindows](https://spdx.org/licenses/WXwindows.html)                                               |


### PR DESCRIPTION
Add `pull-license-list.py` to automatically pull the current license and exception JSON into Markdown tables.  Using JavaScript might have been more idiomatic than the Python script, but it's faster for me to write the Python; someone who is more familiar with JavaScript can translate the script and incorperate it into the build tooling later if we decide against carrying the auto-generated tables in this repository.

Two things made the auto-generation more difficult than it needed to be:

* Newlines in exception names (spdx/license-list-data#10).
* [edit: addressed [below][1]] No charset declaration in JSON served from spdx.org:

        $ curl -sI https://spdx.org/licenses/licenses.json | grep -i content-type
        Content-Type: application/json

    it should have been `Content-Type: application/json; charset=utf-8`.  I don't know if there is a repository with the Nginx config used for spdx.org, so I haven't filed an issue for this last one.

Fixes #6.

[1]: https://github.com/spdx/spdx-spec/pull/10#issuecomment-343275781