### PR TITLE
Add RDF OWL ontology to spec repository

### DIFF
--- a/ontology/spdx-ontology.owl.xml
+++ b/ontology/spdx-ontology.owl.xml
@@ -1,0 +1,3001 @@
+<?xml version="1.0"?>
+
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY foaf "http://xmlns.com/foaf/0.1/" >
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+    <!ENTITY ns "http://www.w3.org/2003/06/sw-vocab-status/ns#" >
+]>
+
+
+<rdf:RDF xmlns="http://www.semanticweb.org/gary/ontologies/2014/6/untitled-ontology-6#"
+     xml:base="http://www.semanticweb.org/gary/ontologies/2014/6/untitled-ontology-6"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:ns="http://www.w3.org/2003/06/sw-vocab-status/ns#"
+     xmlns:foaf="http://xmlns.com/foaf/0.1/"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <owl:Ontology rdf:about="http://www.semanticweb.org/spdx/ontologies/2014/6/SPDX-2.1">
+        <rdfs:label>SPDX 2.1</rdfs:label>
+        <owl:versionInfo>2.1</owl:versionInfo>
+        <rdfs:comment>This specification describes the SPDX® language, defined as a dictionary of named properties and classes using W3C&apos;s RDF Technology.
+
+SPDX® is a designed to allow the exchange of data about software packages. This information includes general information about the package, licensing information about the package as a whole, a manifest of files contained in the package and licensing information related to the contained files.
+
+Known issues:
+ - File fileType cardinality should be 0 or more instead of required one.</rdfs:comment>
+    </owl:Ontology>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotation properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://www.w3.org/2002/07/owl#deprecatedClass -->
+
+    <owl:AnnotationProperty rdf:about="&owl;deprecatedClass"/>
+    
+
+
+    <!-- http://www.w3.org/2002/07/owl#deprecatedProperty -->
+
+    <owl:AnnotationProperty rdf:about="&owl;deprecatedProperty"/>
+    
+
+
+    <!-- http://www.w3.org/2003/06/sw-vocab-status/ns#term_status -->
+
+    <owl:AnnotationProperty rdf:about="&ns;term_status">
+        <ns:term_status>stable</ns:term_status>
+        <rdfs:comment>The AnyLicenseInfo class includes all resources that represent licensing information.</rdfs:comment>
+        <rdfs:isDefinedBy>http://spdx.org/rdf/terms#</rdfs:isDefinedBy>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://spdx.org/rdf/terms#agent -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#agent">
+        <rdfs:comment xml:lang="en">Agent (eg. person, group, software or physical artifact)..</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Annotation"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#algorithm -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#algorithm">
+        <rdfs:comment xml:lang="en">Identifies the algorithm used to produce the subject Checksum.
+Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.
+</rdfs:comment>
+        <ns:term_status>stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Checksum"/>
+        <rdfs:range>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#algorithm"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_md5"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#algorithm"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#algorithm"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha256"/>
+                    </owl:Restriction>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:range>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#annotation -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#annotation">
+        <ns:term_status>stable</ns:term_status>
+        <rdfs:comment xml:lang="en">Provide additional information about an SpdxElement.
+</rdfs:comment>
+        <rdfs:range rdf:resource="http://spdx.org/rdf/terms#Annotation"/>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#SpdxElement"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#annotationType -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#annotationType">
+        <rdfs:comment xml:lang="en">Type of the annotation.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Annotation"/>
+        <rdfs:range>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#annotationType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#annotationType_other"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#annotationType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#annotationType_review"/>
+                    </owl:Restriction>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:range>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#artifactOf -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#artifactOf">
+        <owl:deprecatedProperty xml:lang="en">Deprecated as of version 2.1</owl:deprecatedProperty>
+        <rdfs:comment xml:lang="en">Indicates the project in which the SpdxElement originated.
+Tools must preserve doap:homepage and doap:name properties and the URI (if one is known) of doap:Project resources that are values of this property. All other properties of doap:Projects are not directly supported by SPDX and may be dropped when translating to or from some SPDX formats.</rdfs:comment>
+        <ns:term_status>stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#SpdxElement"/>
+        <rdfs:range rdf:resource="http://usefulinc.com/ns/doap#Project"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#checksum -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#checksum">
+        <rdfs:comment xml:lang="en">The checksum property provides a mechanism that can be used to verify that the contents of a File or Package have not changed.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range rdf:resource="http://spdx.org/rdf/terms#Checksum"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://spdx.org/rdf/terms#File"/>
+                    <rdf:Description rdf:about="http://spdx.org/rdf/terms#Package"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#copyrightText -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#copyrightText">
+        <rdfs:comment>The text of copyright declarations recited in the Package or File.</rdfs:comment>
+        <ns:term_status>stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#SpdxItem"/>
+        <rdfs:range>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#copyrightText"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#noassertion"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#copyrightText"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#none"/>
+                    </owl:Restriction>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:range>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#creationInfo -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#creationInfo">
+        <ns:term_status>stable</ns:term_status>
+        <rdfs:comment xml:lang="en">The creationInfo property relates an SpdxDocument to a set of information about the creation of the SpdxDocument.</rdfs:comment>
+        <rdfs:range rdf:resource="http://spdx.org/rdf/terms#CreationInfo"/>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#SpdxDocument"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#dataLicense -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#dataLicense">
+        <rdf:type rdf:resource="&owl;FunctionalProperty"/>
+        <rdfs:comment xml:lang="en">The licensing under which the creator of this SPDX document allows related data to be reproduced.
+The only valid value for this property is http://spdx.org/licenses/CC0-1.0. This is to alleviate any concern that content (the data) in an SPDX file is subject to any form of intellectual property right that could restrict the re-use of the information or the creation of another SPDX file for the same project(s). This approach avoids intellectual property and related restrictions over the SPDX file, however individuals can still contract one to one to restrict release of specific collections of SPDX files (which map to software bill of materials) and the identification of the supplier of SPDX files.</rdfs:comment>
+        <ns:term_status>stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#SpdxDocument"/>
+        <rdfs:range>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#dataLicense"/>
+                <owl:hasValue rdf:resource="http://spdx.org/licenses/CC0-1.0"/>
+            </owl:Restriction>
+        </rdfs:range>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#describesFile -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#describesFile">
+        <rdfs:comment xml:lang="en">The describesFile property relates an SpdxDocument to the file which it describes.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range rdf:resource="http://spdx.org/rdf/terms#File"/>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#SpdxDocument"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#describesPackage -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#describesPackage">
+        <rdfs:comment xml:lang="en">The describesPackage property relates an SpdxDocument to the package which it describes.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range rdf:resource="http://spdx.org/rdf/terms#Package"/>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#SpdxDocument"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#downloadLocation -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#downloadLocation">
+        <rdfs:comment xml:lang="en">The URI at which this package is available for download. Private (i.e., not publicly reachable) URIs are acceptable as values of this property.
+The values http://spdx.org/rdf/terms#none and http://spdx.org/rdf/terms#noassertion may be used to specify that the package is not downloadable or that no attempt was made to determine its download location, respectively.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Package"/>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#SpdxDocument"/>
+        <rdfs:range>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#downloadLocation"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#noassertion"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#downloadLocation"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#none"/>
+                    </owl:Restriction>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:range>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#externalDocumentRef -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#externalDocumentRef">
+        <rdfs:comment xml:lang="en">Any external SPDX documents referenced within an SPDX document.  This property is primarily used to verify the external SPDX document reference through use of the checksum.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#externalRef -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#externalRef">
+        <rdfs:comment xml:lang="en">An External Reference allows a Package to reference an external source of
+additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range rdf:resource="http://spdx.org/rdf/terms#ExternalRef"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#fileType -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#fileType">
+        <ns:term_status>stable</ns:term_status>
+        <rdfs:comment>The type of the file.</rdfs:comment>
+        <rdfs:range>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#fileType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#fileType_archive"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#fileType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#fileType_binary"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#fileType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#fileType_other"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#fileType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#fileType_source"/>
+                    </owl:Restriction>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:range>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#hasExtractedLicensingInfo -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#hasExtractedLicensingInfo">
+        <rdfs:comment xml:lang="en">Indicates that a particular ExtractedLicensingInfo was defined in the subject SpdxDocument.
+</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#ExtractedLicenseInfo"/>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#SpdxDocument"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#hasFile -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#hasFile">
+        <rdfs:comment xml:lang="en">Indicates that a particular file belongs to a package.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range rdf:resource="http://spdx.org/rdf/terms#File"/>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Package"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#licenseConcluded -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#licenseConcluded">
+        <rdf:type rdf:resource="&owl;FunctionalProperty"/>
+        <rdfs:comment xml:lang="en">The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the package.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#SpdxItem"/>
+        <rdfs:range>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://spdx.org/rdf/terms#AnyLicenseInfo"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#licenseConcluded"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#noassertion"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#licenseConcluded"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#none"/>
+                    </owl:Restriction>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:range>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#licenseDeclared -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#licenseDeclared">
+        <rdfs:comment xml:lang="en">The licensing that the creators of the software in the package, or the packager, have declared. Declarations by the original software creator should be preferred, if they exist.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range rdf:resource="http://spdx.org/rdf/terms#AnyLicenseInfo"/>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#SpdxItem"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#licenseException -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#licenseException">
+        <rdfs:comment xml:lang="en">An exception to a license.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range rdf:resource="http://spdx.org/rdf/terms#LicenseException"/>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#WithExceptionOperator"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#licenseInfoFromFiles -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#licenseInfoFromFiles">
+        <rdfs:comment xml:lang="en">The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Package"/>
+        <rdfs:range>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://spdx.org/rdf/terms#SimpleLicenseingInfo"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#licenseInfoFromFiles"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#noassertion"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#licenseInfoFromFiles"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#none"/>
+                    </owl:Restriction>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:range>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#licenseInfoInFile -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#licenseInfoInFile">
+        <rdfs:comment xml:lang="en">Licensing information that was discovered directly in the subject file.  This is also considered a declared license for the file.</rdfs:comment>
+        <ns:term_status>deprecated</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#File"/>
+        <rdfs:subPropertyOf rdf:resource="http://spdx.org/rdf/terms#licenseInfoFromFiles"/>
+        <rdfs:range>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://spdx.org/rdf/terms#SimpleLicenseingInfo"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#licenseInfoInFile"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#noassertion"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#licenseInfoInFile"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#none"/>
+                    </owl:Restriction>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:range>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#member -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#member">
+        <rdfs:comment xml:lang="en">A license, or other licensing information, that is a member of the subject license set.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range rdf:resource="http://spdx.org/rdf/terms#AnyLicenseInfo"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://spdx.org/rdf/terms#ConjunctiveLicenseSet"/>
+                    <rdf:Description rdf:about="http://spdx.org/rdf/terms#DisjunctiveLicenseSet"/>
+                    <rdf:Description rdf:about="http://spdx.org/rdf/terms#WithExceptionOperator"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#originator -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#originator">
+        <rdfs:comment xml:lang="en">The name and, optionally, contact information of the person or organization that originally created the package.
+Values of this property must conform to the agent and tool syntax.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Package"/>
+        <rdfs:range>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#originator"/>
+                <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#none"/>
+            </owl:Restriction>
+        </rdfs:range>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#packageVerificationCode -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#packageVerificationCode">
+        <rdfs:comment xml:lang="en">A manifest based verification code (the algorithm is defined in section 4.7 of the full specification) of the package. This allows consumers of this data and/or database to determine if a package they have in hand is identical to the package from which the data was produced. This algorithm works even if the SPDX document is included in the package.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range rdf:resource="http://spdx.org/rdf/terms#PackageVerificationCode"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#range -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#range">
+        <rdfs:comment xml:lang="en">This field defines the byte range in the original host file (in X.2) that the snippet information applies to</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Snippet"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2009/pointers#CompoundPointer"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#referenceCategory -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#referenceCategory">
+        <rdfs:comment xml:lang="en">Category for the external reference</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#referenceCategory"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#referenceCategory_other"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#referenceCategory"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#referenceCategory_packageManager"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#referenceCategory"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#referenceCategory_security"/>
+                    </owl:Restriction>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:range>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#referenceType -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#referenceType">
+        <rdfs:comment xml:lang="en">Type of the external reference.  These are definined in an appendix in the SPDX specification.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#referencesFile -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#referencesFile">
+        <rdfs:comment xml:lang="en">Indicates that a particular file belongs as part of the set of analyzed files in the SpdxDocument.</rdfs:comment>
+        <owl:deprecatedProperty xml:lang="en">This property has been replaced by a relationship between the SPDX document and file with a &quot;contains&quot; relationship type.</owl:deprecatedProperty>
+        <ns:term_status xml:lang="en">deprecated</ns:term_status>
+        <rdfs:range rdf:resource="http://spdx.org/rdf/terms#File"/>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#SpdxDocument"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relatedSpdxElement -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#relatedSpdxElement">
+        <rdfs:comment xml:lang="en">A related SpdxElement.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Relationship"/>
+        <rdfs:range rdf:resource="http://spdx.org/rdf/terms#SpdxElement"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationship -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#relationship">
+        <rdfs:comment xml:lang="en">Defines a relationship between two SPDX elements. The SPDX element may be a Package, File, or SpdxDocument.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range rdf:resource="http://spdx.org/rdf/terms#Relationship"/>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#SpdxElement"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#relationshipType">
+        <rdfs:comment xml:lang="en">Describes the type of relationship between two SPDX elements.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Relationship"/>
+        <rdfs:range>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_ancestorOf"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_containedBy"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_contains"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_copyOf"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_descendantOf"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_distributionArtifact"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_expandedFromArchive"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_fileAdded"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_fileDeleted"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_fileModified"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_generatedFrom"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_generates"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_patchApplied"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_patchFor"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_variantOf"/>
+                    </owl:Restriction>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:range>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#reviewed -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#reviewed">
+        <rdfs:comment xml:lang="en">The review property relates a SpdxDocument to the review history.</rdfs:comment>
+        <owl:deprecatedProperty xml:lang="en">This property has been deprecated since SPDX version 2.0.  It has been replaced by an Annotation with an annotation type review.</owl:deprecatedProperty>
+        <ns:term_status xml:lang="en">deprecated</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#SpdxDocument"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#snippetFromFile -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#snippetFromFile">
+        <rdfs:comment xml:lang="en">File containing the SPDX element (e.g. the file contaning a snippet).</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range rdf:resource="http://spdx.org/rdf/terms#File"/>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Snippet"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#spdxDocument -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#spdxDocument">
+        <rdfs:comment xml:lang="en">A propoerty containing an SPDX document.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range rdf:resource="http://spdx.org/rdf/terms#SpdxDocument"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#supplier -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#supplier">
+        <rdfs:comment xml:lang="en">The name and, optionally, contact information of the person or organization who was the immediate supplier of this package to the recipient. The supplier may be different than originator when the software has been repackaged.
+Values of this property must conform to the agent and tool syntax.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Package"/>
+        <rdfs:range>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#supplier"/>
+                <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#none"/>
+            </owl:Restriction>
+        </rdfs:range>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#usedBy -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#usedBy">
+        <rdfs:comment xml:lang="en">Describes how the related relatedSpdxElement is used by this SpdxElement.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Relationship"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.semanticweb.org/spdx/ontologies/2014/6/SPDX-2.1#licenseInfoInSnippets -->
+
+    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/spdx/ontologies/2014/6/SPDX-2.1#licenseInfoInSnippets">
+        <rdfs:comment xml:lang="en">Licensing information that was discovered directly in the subject snippet.  This is also considered a declared license for the snippet.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:subPropertyOf rdf:resource="http://spdx.org/rdf/terms#licenseInfoFromFiles"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/2000/01/rdf-schema#member -->
+
+    <owl:ObjectProperty rdf:about="&rdfs;member"/>
+    
+
+
+    <!-- http://www.w3.org/2009/pointers#endPointer -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/2009/pointers#endPointer">
+        <rdfs:comment xml:lang="en">Pointer to the end point of the range.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://www.w3.org/2009/pointers#CompoundPointer"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2009/pointers#SinglePointer"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/2009/pointers#reference -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/2009/pointers#reference">
+        <rdfs:comment xml:lang="en">Scope within which a single pointer operates.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://www.w3.org/2009/pointers#SinglePointer"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/2009/pointers#startPointer -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/2009/pointers#startPointer">
+        <rdfs:comment xml:lang="en">Pointer to the start point of the range in a compound pointer.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://www.w3.org/2009/pointers#CompoundPointer"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2009/pointers#SinglePointer"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Data properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://spdx.org/rdf/terms#annotationDate -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#annotationDate">
+        <ns:term_status>stable</ns:term_status>
+        <rdfs:comment xml:lang="en">Identify when the comment was made.  This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.</rdfs:comment>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Annotation"/>
+        <rdfs:subPropertyOf rdf:resource="http://spdx.org/rdf/terms#date"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#annotator -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#annotator">
+        <rdfs:comment xml:lang="en">This field identifies the person, organization or tool that has commented on a file, package, or entire document. </rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#checksumValue -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#checksumValue">
+        <rdf:type rdf:resource="&owl;FunctionalProperty"/>
+        <ns:term_status>stable</ns:term_status>
+        <rdfs:comment>The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.</rdfs:comment>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Checksum"/>
+        <rdfs:range rdf:resource="&xsd;hexBinary"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#contextualExample -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#contextualExample">
+        <rdfs:comment xml:lang="en">Example for use of the external repository identifier</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#copyrightText -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#copyrightText">
+        <rdfs:comment>The text of copyright declarations recited in the Package or File.</rdfs:comment>
+        <ns:term_status>stable</ns:term_status>
+        <rdfs:range rdf:resource="&rdfs;Literal"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#created -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#created">
+        <ns:term_status>stable</ns:term_status>
+        <rdfs:comment>The date and time at which the SpdxDocument was created. This value must in UTC and have &apos;Z&apos; as its timezone indicator.</rdfs:comment>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#CreationInfo"/>
+        <rdfs:subPropertyOf rdf:resource="http://spdx.org/rdf/terms#date"/>
+        <rdfs:range rdf:resource="&xsd;dateTime"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#creator -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#creator">
+        <rdfs:comment xml:lang="en">The name and, optionally, contact information of a person, organization or tool that created, or was used to create, the SpdxDocument.
+Values of this property must conform to the agent and tool syntax.</rdfs:comment>
+        <ns:term_status>stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#CreationInfo"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#date -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#date">
+        <rdfs:comment xml:lang="en">A date-time stamp.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Annotation"/>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#CreationInfo"/>
+        <rdfs:range rdf:resource="&xsd;dateTime"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#description -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#description">
+        <rdfs:comment xml:lang="en">Provides a detailed description of the package.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Package"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#documentation -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#documentation">
+        <rdfs:comment xml:lang="en">Website containing the documentation related to the repository identifier</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range rdf:resource="&xsd;anyURI"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#downloadLocation -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#downloadLocation">
+        <rdfs:comment xml:lang="en">The URI at which this package is available for download. Private (i.e., not publicly reachable) URIs are acceptable as values of this property.
+The values http://spdx.org/rdf/terms#none and http://spdx.org/rdf/terms#noassertion may be used to specify that the package is not downloadable or that no attempt was made to determine its download location, respectively.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range rdf:resource="&xsd;anyURI"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#example -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#example">
+        <rdfs:comment xml:lang="en">Text for examples in describing an SPDX element.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#LicenseException"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#externalDocumentId -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#externalDocumentId">
+        <rdfs:comment xml:lang="en">externalDocumentId is a string containing letters, numbers, “.”, “-” or “+” which uniquely identifies an external document within this document.
+</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#ExternalDocumentRef"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#externalReferenceSite -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#externalReferenceSite">
+        <rdfs:comment xml:lang="en">Website for the maintainers of the external reference site</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range rdf:resource="&xsd;anyURI"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#extractedText -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#extractedText">
+        <rdfs:comment xml:lang="en">Verbatim license or licensing notice text that was discovered.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#ExtractedLicenseInfo"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#fileContributor -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#fileContributor">
+        <rdfs:comment xml:lang="en">This field provides a place for the SPDX file creator to record file contributors. Contributors could include names of copyright holders and/or authors who may not be copyright holders yet contributed to the file content.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#File"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#fileName -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#fileName">
+        <rdfs:comment xml:lang="en">The name of the file relative to the root of the package.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#File"/>
+        <rdfs:subPropertyOf rdf:resource="http://spdx.org/rdf/terms#name"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#filesAnalyzed -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#filesAnalyzed">
+        <rdfs:comment xml:lang="en">Indicates whether the file content of this package has been available for or subjected to analysis when creating the SPDX document. If “false” indicates packages that represent metadata or URI references to a project, product, artifact, distribution or a component. If set to “false”, the package must not contain any files.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range rdf:resource="&xsd;boolean"/>
+    </owl:DatatypeProperty>
+    <owl:Axiom>
+        <rdfs:comment>Default value is true</rdfs:comment>
+        <owl:annotatedSource rdf:resource="http://spdx.org/rdf/terms#filesAnalyzed"/>
+        <owl:annotatedProperty rdf:resource="&rdfs;range"/>
+        <owl:annotatedTarget rdf:resource="&xsd;boolean"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#isOsiApproved -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#isOsiApproved">
+        <rdfs:comment xml:lang="en">Indicates if the OSI has approved the license.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#License"/>
+        <rdfs:range rdf:resource="&xsd;boolean"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#licenseComments -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#licenseComments">
+        <rdfs:comment xml:lang="en">he licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#SpdxItem"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#licenseExceptionId -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#licenseExceptionId">
+        <rdfs:comment xml:lang="en">short form license exception identifier in Appendix I.2 of the SPDX specification.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#LicenseException"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#licenseExceptionText -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#licenseExceptionText">
+        <rdfs:comment xml:lang="en">Full text of the license exception.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#LicenseException"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#licenseId -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#licenseId">
+        <rdfs:comment xml:lang="en">A human readable short form license identifier for a license.  The license ID is iether on the standard license oist or the form &quot;LicenseRef-&quot;[idString] where [idString] is a unique string containing letters, numbers, &quot;.&quot;, &quot;-&quot; or &quot;+&quot;.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#SimpleLicenseingInfo"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#licenseListVersion -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#licenseListVersion">
+        <rdf:type rdf:resource="&owl;FunctionalProperty"/>
+        <rdfs:comment xml:lang="en">An optional field for creators of the SPDX file to provide the version of the SPDX License List used when the SPDX file was created.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#CreationInfo"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#licenseText -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#licenseText">
+        <rdfs:comment xml:lang="en">Full text of the license.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#License"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#locatorFormat -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#locatorFormat">
+        <rdfs:comment xml:lang="en">Regular expression for the format of the external repository identifier</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#name -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#name">
+        <rdfs:comment xml:lang="en">The full human readable name of the item. This should include version information when applicable.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#SpdxElement"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#noticeText -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#noticeText">
+        <rdfs:comment xml:lang="en">This field provides a place for the SPDX file creator to record potential legal notices found in the file. This may or may not include copyright statements.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#File"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#originator -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#originator">
+        <rdfs:comment xml:lang="en">The name and, optionally, contact information of the person or organization that originally created the package.
+Values of this property must conform to the agent and tool syntax.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#packageFileName -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#packageFileName">
+        <rdfs:comment xml:lang="en">The base name of the package file name. For example, zlib-1.2.5.tar.gz.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Package"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#packageName -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#packageName">
+        <rdfs:comment xml:lang="en">Identify the full name of the package as given by Package Originator.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Package"/>
+        <rdfs:subPropertyOf rdf:resource="http://spdx.org/rdf/terms#name"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#packageVerificationCodeValue -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#packageVerificationCodeValue">
+        <rdfs:comment xml:lang="en">The actual package verification code as a hex encoded value.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#PackageVerificationCode"/>
+        <rdfs:range rdf:resource="&xsd;hexBinary"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#referenceLocator -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#referenceLocator">
+        <rdfs:comment xml:lang="en">The unique string with no spaces necessary to access the package-specific information, metadata, or content within the target location. The format of the locator is subject to constraints defined by the &lt;type&gt;. </rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#reviewDate -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#reviewDate">
+        <owl:deprecatedProperty xml:lang="en">Deprecated in favor of Annotation with an annotationType_review.</owl:deprecatedProperty>
+        <rdfs:comment xml:lang="en">The date and time at which the SpdxDocument was reviewed. This value must be in UTC and have &apos;Z&apos; as its timezone indicator.</rdfs:comment>
+        <ns:term_status xml:lang="en">deprecated</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Review"/>
+        <rdfs:range rdf:resource="&xsd;dateTime"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#reviewer -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#reviewer">
+        <rdfs:comment xml:lang="en">The name and, optionally, contact information of the person who performed the review.
+
+Values of this property must conform to the agent and tool syntax.</rdfs:comment>
+        <owl:deprecatedProperty xml:lang="en">The reviewer property is deprecated in favor of Annotation with an annotationType review.</owl:deprecatedProperty>
+        <ns:term_status xml:lang="en">depcrecated</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Review"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#snippetName -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#snippetName">
+        <rdfs:comment xml:lang="en">Identify a specific snippet in a human convenient manner.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:subPropertyOf rdf:resource="http://spdx.org/rdf/terms#name"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#sourceInfo -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#sourceInfo">
+        <rdfs:comment xml:lang="en">Allows the producer(s) of the SPDX document to describe how the package was acquired and/or changed from the original source.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Package"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#specVersion -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#specVersion">
+        <rdf:type rdf:resource="&owl;FunctionalProperty"/>
+        <rdfs:comment xml:lang="en">Identifies the version of this specification that was used to produce this SPDX document. The value for this version of the spec is SPDX-1.2. The values SPDX-1.0 and SPDX-1.1 may also be supported by SPDX tools for backwards compatibility purposes.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#SpdxDocument"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#standardLicenseHeader -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#standardLicenseHeader">
+        <rdfs:comment xml:lang="en">License author&apos;s preferred text to indicated that a file is covered by the license.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#License"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#standardLicenseTemplate -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#standardLicenseTemplate">
+        <rdfs:comment xml:lang="en">License template which describes sections of the license which can be varied. See License Template section of the specification for format information.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#License"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#summary -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#summary">
+        <rdfs:comment xml:lang="en">Provides a short description of the package.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Package"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#supplier -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#supplier">
+        <rdfs:comment xml:lang="en">The name and, optionally, contact information of the person or organization who was the immediate supplier of this package to the recipient. The supplier may be different than originator when the software has been repackaged.
+Values of this property must conform to the agent and tool syntax.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#verificationCodeExcludedFile -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#verificationCodeExcludedFile">
+        <rdfs:comment xml:lang="en">A file that was excluded when calculating the package verification code. This is usually a file containing SPDX data regarding the package. If a package contains more than one SPDX file all SPDX files must be excluded from the package verification code. If this is not done it would be impossible to correctly calculate the verification codes in both files.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#PackageVerificationCode"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#versionInfo -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#versionInfo">
+        <rdfs:comment xml:lang="en">Provides an indication of the version of the package that is described by this SpdxDocument.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Package"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://usefulinc.com/ns/doap#homepage -->
+
+    <owl:DatatypeProperty rdf:about="http://usefulinc.com/ns/doap#homepage">
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range rdf:resource="&xsd;anyURI"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://www.w3.org/2000/01/rdf-schema#comment -->
+
+    <owl:DatatypeProperty rdf:about="&rdfs;comment"/>
+    
+
+
+    <!-- http://www.w3.org/2000/01/rdf-schema#seeAlso -->
+
+    <owl:DatatypeProperty rdf:about="&rdfs;seeAlso">
+        <rdfs:comment xml:lang="en">rdfs:seeAlso is an instance of rdf:Property that is used to indicate a resource that might provide additional information about the subject resource.</rdfs:comment>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://www.w3.org/2009/pointers#lineNumber -->
+
+    <owl:DatatypeProperty rdf:about="http://www.w3.org/2009/pointers#lineNumber">
+        <rdfs:comment xml:lang="en">Line number within the reference starting at one.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range rdf:resource="&xsd;positiveInteger"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/2009/pointers#LineCharPointer"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://www.w3.org/2009/pointers#offset -->
+
+    <owl:DatatypeProperty rdf:about="http://www.w3.org/2009/pointers#offset">
+        <rdfs:comment>Offset from the start of the reference.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:range rdf:resource="&xsd;positiveInteger"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/2009/pointers#OffsetPointer"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://spdx.org/rdf/terms#Annotation -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#Annotation">
+        <rdfs:subClassOf rdf:resource="&owl;Thing"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#date"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;dateTimeStamp"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#annotationType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#annotationType_other"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#annotationType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#annotationType_review"/>
+                    </owl:Restriction>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="&rdfs;comment"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#annotator"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">An Annotation is a comment on an SpdxItem by an agent.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#AnyLicenseInfo -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#AnyLicenseInfo">
+        <ns:term_status>stable</ns:term_status>
+        <rdfs:isDefinedBy>http://spdx.org/rdf/terms#AnyLicenseInfo</rdfs:isDefinedBy>
+        <rdfs:comment>The AnyLicenseInfo class includes all resources that represent licensing information.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#Checksum -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#Checksum">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#checksumValue"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;hexBinary"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#algorithm"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_md5"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#algorithm"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#algorithm"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha256"/>
+                    </owl:Restriction>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented.
+</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#ConjunctiveLicenseSet -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#ConjunctiveLicenseSet">
+        <rdfs:subClassOf rdf:resource="http://spdx.org/rdf/terms#AnyLicenseInfo"/>
+        <rdfs:subClassOf rdf:resource="&rdfs;Container"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#member"/>
+                <owl:onClass rdf:resource="http://spdx.org/rdf/terms#AnyLicenseInfo"/>
+                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">A ConjunctiveLicenseSet represents a set of licensing information all of which apply.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#CreationInfo -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#CreationInfo">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#licenseListVersion"/>
+                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#created"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;dateTimeStamp"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="&rdfs;comment"/>
+                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#creator"/>
+                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">A CreationInfo provides information about the individuals, organizations and tools involved in the creation of an SpdxDocument.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#DisjunctiveLicenseSet -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#DisjunctiveLicenseSet">
+        <rdfs:subClassOf rdf:resource="http://spdx.org/rdf/terms#AnyLicenseInfo"/>
+        <rdfs:subClassOf rdf:resource="&rdfs;Container"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#member"/>
+                <owl:onClass rdf:resource="http://spdx.org/rdf/terms#AnyLicenseInfo"/>
+                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">A DisjunctiveLicenseSet represents a set of licensing information where only one license applies at a time. This class implies that the recipient gets to choose one of these licenses they would prefer to use.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#ExternalDocumentRef -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#ExternalDocumentRef">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#checksum"/>
+                <owl:onClass rdf:resource="http://spdx.org/rdf/terms#Checksum"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#externalDocumentId"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;anyURI"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#spdxDocument"/>
+                <owl:onClass rdf:resource="http://spdx.org/rdf/terms#SpdxDocument"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">Information about an external SPDX document reference including the checksum.  This allows for verification of the external references.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#ExternalRef -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#ExternalRef">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="&rdfs;comment"/>
+                <owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#referenceLocator"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#referenceType"/>
+                <owl:onClass rdf:resource="http://spdx.org/rdf/terms#ReferenceType"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#referenceCategory"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#referenceCategory_other"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#referenceCategory"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#referenceCategory_packageManager"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#referenceCategory"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#referenceCategory_security"/>
+                    </owl:Restriction>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">An External Reference allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#ExtractedLicenseInfo -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#ExtractedLicenseInfo">
+        <rdfs:subClassOf rdf:resource="http://spdx.org/rdf/terms#SimpleLicenseingInfo"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#extractedText"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">An ExtractedLicensingInfo represents a license or licensing notice that was found in the package. Any license text that is recognized as a license may be represented as a License rather than an ExtractedLicensingInfo.</rdfs:comment>
+        <ns:term_status>stable</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#File -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#File">
+        <rdfs:subClassOf rdf:resource="http://spdx.org/rdf/terms#SpdxItem"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#noticeText"/>
+                <owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#fileContributor"/>
+                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#artifactOf"/>
+                <owl:onClass rdf:resource="http://usefulinc.com/ns/doap#Project"/>
+                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#fileName"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#fileType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#fileType_application"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#fileType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#fileType_archive"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#fileType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#fileType_audio"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#fileType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#fileType_binary"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#fileType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#fileType_documentation"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#fileType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#fileType_image"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#fileType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#fileType_other"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#fileType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#fileType_source"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#fileType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#fileType_spdx"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#fileType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#fileType_text"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#fileType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#fileType_video"/>
+                    </owl:Restriction>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#checksum"/>
+                <owl:onClass rdf:resource="http://spdx.org/rdf/terms#Checksum"/>
+                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="http://spdx.org/rdf/terms#Snippet"/>
+        <rdfs:comment xml:lang="en">A File represents a named sequence of information that is contained in a software package.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#License -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#License">
+        <rdfs:subClassOf rdf:resource="http://spdx.org/rdf/terms#SimpleLicenseingInfo"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#isOsiApproved"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;boolean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#standardLicenseHeader"/>
+                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#licenseText"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#standardLicenseTemplate"/>
+                <owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">A License represents a copyright license. The SPDX license list website is annotated with these properties (using RDFa) to allow license data published there to be easily processed.
+The license list is populated in accordance with the License List fields guidelines. These guidelines are not normative and may change over time. SPDX tooling should not rely on values in the license list conforming to the current guidelines.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#LicenseException -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#LicenseException">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#licenseExceptionText"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="&rdfs;comment"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#example"/>
+                <owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#name"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="&rdfs;seeAlso"/>
+                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;anyURI"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#licenseExceptionId"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">An exception to a license.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#ListedLicense -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#ListedLicense">
+        <rdfs:subClassOf rdf:resource="http://spdx.org/rdf/terms#License"/>
+        <rdfs:comment xml:lang="en">A license which is included in the SPDX License List (http://spdx.org/licenses).</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#OrLaterOperator -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#OrLaterOperator">
+        <rdfs:subClassOf rdf:resource="http://spdx.org/rdf/terms#AnyLicenseInfo"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#member"/>
+                <owl:onClass rdf:resource="http://spdx.org/rdf/terms#SimpleLicenseingInfo"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">A license with an or later operator indicating this license version or any later version of the license (e.g. GPL-2.0+)</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#Package -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#Package">
+        <rdfs:subClassOf rdf:resource="http://spdx.org/rdf/terms#SpdxItem"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#externalRef"/>
+                <owl:onClass rdf:resource="http://spdx.org/rdf/terms#ExternalRef"/>
+                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#packageFileName"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#filesAnalyzed"/>
+                <owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;boolean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#description"/>
+                <owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://usefulinc.com/ns/doap#homepage"/>
+                <owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;anyURI"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#originator"/>
+                <owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#downloadLocation"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#sourceInfo"/>
+                <owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#supplier"/>
+                <owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#packageVerificationCode"/>
+                <owl:onClass rdf:resource="http://spdx.org/rdf/terms#PackageVerificationCode"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#licenseDeclared"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#noassertion"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#licenseDeclared"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#none"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#licenseDeclared"/>
+                        <owl:onClass rdf:resource="http://spdx.org/rdf/terms#AnyLicenseInfo"/>
+                        <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                    </owl:Restriction>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#versionInfo"/>
+                <owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#summary"/>
+                <owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#checksum"/>
+                <owl:onClass rdf:resource="http://spdx.org/rdf/terms#Checksum"/>
+                <owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">A Package represents a collection of software files that are delivered as a single functional component.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#PackageVerificationCode -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#PackageVerificationCode">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#packageVerificationCodeValue"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#verificationCodeExcludedFile"/>
+                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">A manifest based verification code (the algorithm is defined in section 4.7 of the full specification) of the SPDX Item. This allows consumers of this data and/or database to determine if an SPDX item they have in hand is identical to the SPDX item from which the data was produced. This algorithm works even if the SPDX document is included in the SPDX item.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#ReferenceType -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#ReferenceType">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#externalReferenceSite"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;anyURI"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#contextualExample"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;anyURI"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#documentation"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">Types used to external reference identifiers.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#Relationship -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#Relationship">
+        <rdfs:subClassOf rdf:resource="&owl;Thing"/>
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_amendment"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_ancestorOf"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_buildToolOf"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_containedBy"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_contains"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_copyOf"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_descendantOf"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_describedBy"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_describes"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_distributionArtifact"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_documentation"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_dynamicLink"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_expandedFromArchive"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_fileAdded"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_fileDeleted"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_fileModified"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_generatedFrom"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_generates"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_hasPrerequisite"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_metafileOf"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_optionalComponentOf"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_other"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_packageOf"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_patchApplied"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_patchFor"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_prerequisiteFor"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_staticLink"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#relationshipType_testcaseOf"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationshipType"/>
+                        <owl:hasValue rdf:resource="http://www.semanticweb.org/spdx/ontologies/2014/6/SPDX-2.1#relationshipType_dataFileOf"/>
+                    </owl:Restriction>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="&rdfs;comment"/>
+                <owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relatedSpdxElement"/>
+                <owl:onClass rdf:resource="http://spdx.org/rdf/terms#SpdxElement"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">A Relationship represents a relationship between two SpdxElements.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#Review -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#Review">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="&rdfs;comment"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#reviewDate"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;dateTime"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#reviewer"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">A Review represents an audit and signoff by an individual, organization or tool on the information in an SpdxDocument.</rdfs:comment>
+        <owl:deprecatedClass xml:lang="en">This class has been deprecated in favor of an Annotation with an Annotation type of review.</owl:deprecatedClass>
+        <ns:term_status xml:lang="en">deprecated</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#SimpleLicenseingInfo -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#SimpleLicenseingInfo">
+        <rdfs:subClassOf rdf:resource="http://spdx.org/rdf/terms#AnyLicenseInfo"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#licenseId"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="&rdfs;comment"/>
+                <owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="&rdfs;seeAlso"/>
+                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;anyURI"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#name"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">The SimpleLicenseInfo class includes all resources that represent simple, atomic, licensing information.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#Snippet -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#Snippet">
+        <rdfs:subClassOf rdf:resource="http://spdx.org/rdf/terms#SpdxItem"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#snippetFromFile"/>
+                <owl:onClass rdf:resource="http://spdx.org/rdf/terms#File"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#range"/>
+                <owl:onClass rdf:resource="http://www.w3.org/2009/pointers#CompoundPointer"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">The set of bytes in a file.  The name of the snippet is the name of the file appended with the byte range in parenthesis (ie: &quot;./file/name(2145:5532)&quot;)</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#SpdxDocument -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#SpdxDocument">
+        <rdfs:subClassOf rdf:resource="http://spdx.org/rdf/terms#SpdxElement"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#describesPackage"/>
+                <owl:onClass rdf:resource="http://spdx.org/rdf/terms#Package"/>
+                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#describesFile"/>
+                <owl:onClass rdf:resource="http://spdx.org/rdf/terms#File"/>
+                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#hasExtractedLicensingInfo"/>
+                <owl:onClass rdf:resource="http://spdx.org/rdf/terms#ExtractedLicenseInfo"/>
+                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#creationInfo"/>
+                <owl:onClass rdf:resource="http://spdx.org/rdf/terms#CreationInfo"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#specVersion"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#externalDocumentRef"/>
+                <owl:onClass rdf:resource="http://spdx.org/rdf/terms#ExternalDocumentRef"/>
+                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#dataLicense"/>
+                <owl:hasValue rdf:resource="http://spdx.org/licenses/CC0-1.0"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">An SpdxDocument is a summary of the contents, provenance, ownership and licensing analysis of a specific software package. This is, effectively, the top level of SPDX information.</rdfs:comment>
+        <ns:term_status>stable</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#SpdxElement -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#SpdxElement">
+        <rdfs:subClassOf rdf:resource="&owl;Thing"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#annotation"/>
+                <owl:onClass rdf:resource="http://spdx.org/rdf/terms#Annotation"/>
+                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#name"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="&rdfs;comment"/>
+                <owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#relationship"/>
+                <owl:onClass rdf:resource="http://spdx.org/rdf/terms#Relationship"/>
+                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <ns:term_status>stable</ns:term_status>
+        <rdfs:comment>An SpdxElement is any thing described in SPDX, either a document or an SpdxItem. SpdxElements can be related to other SpdxElements.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#SpdxItem -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#SpdxItem">
+        <rdfs:subClassOf rdf:resource="http://spdx.org/rdf/terms#SpdxElement"/>
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#licenseConcluded"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#noassertion"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#licenseConcluded"/>
+                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#none"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#licenseConcluded"/>
+                        <owl:onClass rdf:resource="http://spdx.org/rdf/terms#AnyLicenseInfo"/>
+                        <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                    </owl:Restriction>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#copyrightText"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#licenseInfoFromFiles"/>
+                <owl:onClass rdf:resource="http://spdx.org/rdf/terms#SimpleLicenseingInfo"/>
+                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#licenseComments"/>
+                <owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">An SpdxItem is a potentially copyrightable work.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#WithExceptionOperator -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#WithExceptionOperator">
+        <rdfs:subClassOf rdf:resource="http://spdx.org/rdf/terms#AnyLicenseInfo"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#member"/>
+                <owl:onClass rdf:resource="http://spdx.org/rdf/terms#SimpleLicenseingInfo"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#licenseException"/>
+                <owl:onClass rdf:resource="http://spdx.org/rdf/terms#LicenseException"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">Sometimes a set of license terms apply except under special circumstances. In this case, use the binary “WITH” operator to construct a new &lt;SPDX-License-Expression&gt; to represent the special exception situation. A valid license expression is where the left operand is a valid &lt;SPDX-License-Expression&gt; value and the right operand is an SPDX License List Exception Identifier (SPDX LL Exception Identifier) that represents the special exception terms.  SPDX License LL Identifiers can be found on the SPDX License List. The syntax for the “WITH” operator is:
+ 
+ &lt;SPDX-License-Expression-2&gt; = (&lt;SPDX-License-Expression-1&gt;  WITH  &lt;SPDX-LL-Exception-Identifier&gt;)
+ 
+For example, when the Bison exception is to be applied to GPL-2.0+, the expression would be: 
+(GPL-2.0+ WITH Bison-exception-2.2), where:
+ 
+&lt;SPDX-License-Expression-1&gt; = GPL-2.0+
+&lt;SPDX-LL-Exception-Identifier&gt; = Bison-exception-2.2
+&lt;SPDX-License-Expression-1&gt; = (GPL-2.0+ WITH Bison-exception-2.2)
+ 
+If the applicable exception is not found on the SPDX License List, then use LicenseRef-[idString] to express the license and exception.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://usefulinc.com/ns/doap#Project -->
+
+    <owl:Class rdf:about="http://usefulinc.com/ns/doap#Project"/>
+    
+
+
+    <!-- http://www.w3.org/2000/01/rdf-schema#Container -->
+
+    <owl:Class rdf:about="&rdfs;Container"/>
+    
+
+
+    <!-- http://www.w3.org/2009/pointers#ByteOffsetPointer -->
+
+    <owl:Class rdf:about="http://www.w3.org/2009/pointers#ByteOffsetPointer">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2009/pointers#OffsetPointer"/>
+        <ns:term_status>stable</ns:term_status>
+        <rdfs:comment xml:lang="en">Single pointer using a byte offset from the start of the reference.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/2009/pointers#CompoundPointer -->
+
+    <owl:Class rdf:about="http://www.w3.org/2009/pointers#CompoundPointer">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2009/pointers#Pointer"/>
+        <ns:term_status>stable</ns:term_status>
+        <rdfs:comment xml:lang="en">An abstract method made of a pair of pointers to a defined section to be subclassed for extensibility.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/2009/pointers#LineCharPointer -->
+
+    <owl:Class rdf:about="http://www.w3.org/2009/pointers#LineCharPointer">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2009/pointers#OffsetPointer"/>
+        <rdfs:comment xml:lang="en">Single pointer using line and char numbers.</rdfs:comment>
+        <ns:term_status>stable</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/2009/pointers#OffsetPointer -->
+
+    <owl:Class rdf:about="http://www.w3.org/2009/pointers#OffsetPointer">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2009/pointers#SinglePointer"/>
+        <ns:term_status>stable</ns:term_status>
+        <rdfs:comment xml:lang="en">Generic single pointer based on an offset.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/2009/pointers#Pointer -->
+
+    <owl:Class rdf:about="http://www.w3.org/2009/pointers#Pointer">
+        <ns:term_status>stable</ns:term_status>
+        <rdfs:comment xml:lang="en">Abstract Pointer to be subclassed for extensibility.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/2009/pointers#SinglePointer -->
+
+    <owl:Class rdf:about="http://www.w3.org/2009/pointers#SinglePointer">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2009/pointers#Pointer"/>
+        <ns:term_status>stable</ns:term_status>
+        <rdfs:comment xml:lang="en">Abstract pointer to a single point to be subclassed for extensibility.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/2009/pointers#StartEndPointer -->
+
+    <owl:Class rdf:about="http://www.w3.org/2009/pointers#StartEndPointer">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2009/pointers#CompoundPointer"/>
+        <ns:term_status>stable</ns:term_status>
+        <rdfs:comment xml:lang="en">Compound pointer to a range with a start and an end point.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Individuals
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://spdx.org/licenses/CC0-1.0 -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/licenses/CC0-1.0"/>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#annotationType_other -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#annotationType_other">
+        <rdfs:comment xml:lang="en">Type of annotation which does not fit in any of the pre-defined annotation types.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#annotationType_review -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#annotationType_review">
+        <rdfs:comment xml:lang="en">A Review represents an audit and signoff by an individual, organization or tool on the information for an SpdxElement.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#checksumAlgorithm_md5 -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#checksumAlgorithm_md5">
+        <rdfs:comment xml:lang="en">Indicates the algorithm used was MD5</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#checksumAlgorithm_sha1 -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#checksumAlgorithm_sha1">
+        <rdf:type>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#algorithm"/>
+                <owl:onClass rdf:resource="http://spdx.org/rdf/terms#Checksum"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+            </owl:Restriction>
+        </rdf:type>
+        <ns:term_status>stable</ns:term_status>
+        <rdfs:comment>Indicates the algorithm used was SHA-1</rdfs:comment>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#checksumAlgorithm_sha256 -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#checksumAlgorithm_sha256">
+        <rdfs:comment xml:lang="en">Indicates the algorithm used was SHA256</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#fileType_application -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#fileType_application">
+        <rdfs:comment xml:lang="en"> The file is associated with a specific application type (MIME type of application/* )</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#fileType_archive -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#fileType_archive">
+        <rdfs:comment xml:lang="en">Indicates the file is an archive file.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#fileType_audio -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#fileType_audio">
+        <rdfs:comment xml:lang="en">The file is associated with an audio file (MIME type of audio/* , ie. .mp3 ); 
+IMAGE if the file is assoicated with an picture image file (MIME type of image/*,  ie. .jpg, .gif  )</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#fileType_binary -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#fileType_binary">
+        <rdfs:comment xml:lang="en">Indicates the file is not a text file. spdx:filetype_archive is preferred for archive files even though they are binary.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#fileType_documentation -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#fileType_documentation">
+        <rdfs:comment xml:lang="en">The file serves as documentation.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#fileType_image -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#fileType_image">
+        <rdfs:comment xml:lang="en">The file is assoicated with an picture image file (MIME type of image/*,  ie. .jpg, .gif  ).</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#fileType_other -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#fileType_other">
+        <rdfs:comment xml:lang="en">Indicates the file is not a source, archive or binary file.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#fileType_source -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#fileType_source">
+        <rdfs:comment xml:lang="en">Indicates the file is a source code file.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#fileType_spdx -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#fileType_spdx">
+        <rdfs:comment xml:lang="en">The file is an SPDX document.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#fileType_text -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#fileType_text">
+        <rdfs:comment xml:lang="en">The file is human readable text file (MIME type of text/*).</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#fileType_video -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#fileType_video">
+        <rdfs:comment xml:lang="en">The file is associated with a video file type (MIME type of video/*).</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#noassertion -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#noassertion">
+        <rdfs:comment>Indicates that the preparer of the SPDX document is not making any assertion regarding the value of this field.</rdfs:comment>
+        <ns:term_status>stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#none -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#none">
+        <ns:term_status>stable</ns:term_status>
+        <rdfs:comment>When this value is used as the object of a property it indicates that the preparer of the SpdxDocument believes that there is no value for the property. This value should only be used if there is sufficient evidence to support this assertion.</rdfs:comment>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#referenceCategory_other -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#referenceCategory_other">
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#referenceCategory_packageManager -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#referenceCategory_packageManager">
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#referenceCategory_security -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#referenceCategory_security">
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_amendment -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_amendment">
+        <rdfs:comment xml:lang="en">To be used when SPDXRef-A amends the SPDX information in SPDXRef-B.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_ancestorOf -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_ancestorOf">
+        <rdfs:comment xml:lang="en">A Relationship of relationshipType_ancestorOf expresses that an SPDXElement is an ancestor of (same lineage but pre-dates) the relatedSPDXElement.  For example, an upstream File is an ancestor of a modified downstream File</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_buildToolOf -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_buildToolOf">
+        <rdfs:comment xml:lang="en">To be used when SPDXRef-A is used to to build SPDXRef-B.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_containedBy -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_containedBy">
+        <rdfs:comment xml:lang="en">A Relationship of relationshipType_containedBy expresses that an SPDXElement is contained by the relatedSPDXElement.  For example, a File contained by a Package. </rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_contains -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_contains">
+        <rdfs:comment xml:lang="en">A Relationship of relationshipType_contains expresses that an SPDXElement contains the relatedSPDXElement.  For example, a Package contains a File. (relationshipType_contains introduced in SPDX 2.0 deprecates property &apos;hasFile&apos; from SPDX 1.2)</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_copyOf -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_copyOf">
+        <rdfs:comment xml:lang="en">A Relationship of relationshipType_copyOf expresses that the SPDXElement is an exact copy of the relatedSDPXElement.  For example, a downstream distribution of a binary library which was copied from the upstream package.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_dataFile -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_dataFile">
+        <rdfs:comment xml:lang="en">Is to be used when SPDXRef-A is a data file used in SPDXRef-B.  Replaced by relationshipType_dataFileOf</rdfs:comment>
+        <ns:term_status xml:lang="en">deprecated</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_descendantOf -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_descendantOf">
+        <rdfs:comment xml:lang="en">A Relationship of relationshipType_descendantOf expresses that an SPDXElement is a descendant of (same lineage but post-dates) the relatedSPDXElement.  For example, an downstream File that was modified is a descendant of an upstream File</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_describedBy -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_describedBy">
+        <rdfs:comment xml:lang="en">Is to be used an SPDXRef-A is described by SPDXRef-Document.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_describes -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_describes">
+        <ns:term_status>stable</ns:term_status>
+        <rdfs:comment xml:lang="en">Is to be used when SPDXRef-DOCUMENT describes SPDXRef-A.</rdfs:comment>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_distributionArtifact -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_distributionArtifact">
+        <rdfs:comment xml:lang="en">A Relationship of relationshipType_distributionArtifact expresses that distributing the SPDXElement requires that the relatedSPDXElement also be distributed.  For example, distributing a binary File may require that a source tarball (another File) be made available with the distribuiton. </rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_documentation -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_documentation">
+        <rdfs:comment xml:lang="en">To be used when SPDXRef-A provides documentation of SPDXRef-B.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_dynamicLink -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_dynamicLink">
+        <rdfs:comment xml:lang="en">Is to be used when SPDXRef-A dynamically links to SPDXRef-B.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_expandedFromArchive -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_expandedFromArchive">
+        <rdfs:comment xml:lang="en">A Relationship of relationshipType_expandedFromArchive expresses that the SPDXElement is a file which was epanded from a relatedSPDXElement file.  For example, if there is an archive file xyz.tar.gz containing a file foo.c the archive file was expanded in a directory arch/xyz, the file arch/xyz/foo.c would have a relationshipType_expandedFromArchive with the file xyz.tar.gz.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_fileAdded -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_fileAdded">
+        <rdfs:comment xml:lang="en">A Relationship of relationshipType_fileAdded expresses that the SPDXElement is a file which has been added to the relatedSPDXElement package.  For example, a package (the relatedSPDXElement) has been patched to remove a file (the SPDXElement).  This relationship is typically used to express the result of a patched package when the actual patchfile is not present.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_fileDeleted -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_fileDeleted">
+        <rdfs:comment xml:lang="en">A Relationship of relationshipType_fileDeleted expresses that the SPDXElement is a package where the relatedSPDXElement file has been removed.  For example, a package has been patched to remove a file a file (the relatedSPDXElement resulting in the patched package (the SPDXElement).  This relationship is typically used to express the result of a patched package when the actual patchfile is not present.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_fileModified -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_fileModified">
+        <rdfs:comment xml:lang="en">A Relationship of relationshipType_fileModified expresses that the SPDXElement is a file which is a modified version of the relatedSPDXElement file.  For example, a file (the SPDXElement) has been patched to modify the contents of the original file (the SPDXElement).  This relationship is typically used to express the result of a patched package when the actual patchfile is not present.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_generatedFrom -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_generatedFrom">
+        <rdfs:comment xml:lang="en">A Relationship of relationshipType_generatedFrom expresses that an SPDXElement was generated from the relatedSPDXElement.  For example, a binary File might have been generated from a source File.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_generates -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_generates">
+        <rdfs:comment xml:lang="en">A Relationship of relationshipType_generates expresses that an SPDXElement generates the relatedSPDXElement.  For example, a source File generates a binary File.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_hasPrerequisite -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_hasPrerequisite">
+        <rdfs:comment xml:lang="en">Is to be used when SPDXRef-A has as a prerequisite SPDXRef-B.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_metafileOf -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_metafileOf">
+        <rdfs:comment xml:lang="en">To be used when SPDXRef-A is a metafile of SPDXRef-B.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_optionalComponentOf -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_optionalComponentOf">
+        <rdfs:comment xml:lang="en">To be used when SPDXRef-A is an optional component of SPDXRef-B.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_other -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_other">
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:comment xml:lang="en">to be used for a relationship which has not been defined in the formal SPDX specification. A description of the relationship should be included in the Relationship comments field.</rdfs:comment>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_packageOf -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_packageOf">
+        <rdfs:comment xml:lang="en">To be used when SPDXRef-A is used as a package as part of SPDXRef-B.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_patchApplied -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_patchApplied">
+        <rdfs:comment xml:lang="en">A Relationship of relationshipType_patchApplied expresses that the SPDXElement is a &apos;patchfile&apos; that was applied and produced the relatedSPDXElement. For example, a .diff File relates to a specific file where the diff was applied.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_patchFor -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_patchFor">
+        <rdfs:comment xml:lang="en">A Relationship of relationshipType_patchFor expresses that the SPDXElement is a &apos;patchfile&apos; that is designed to patch (apply modifications to) the relatedSPDXElement.  For example, relationship from a .diff File to a Package it is designed to patch. </rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_prerequisiteFor -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_prerequisiteFor">
+        <rdfs:comment xml:lang="en">Is to be used when SPDXRef-A is a prerequisite for SPDXRef-B</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_staticLink -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_staticLink">
+        <rdfs:comment xml:lang="en">Is to be used when SPDXRef-A statically links to SPDXRef-B.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_testcaseOf -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_testcaseOf">
+        <rdfs:comment xml:lang="en">Is to be used when SPDXRef-A is a test case used in testing SPDXRef-B.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#relationshipType_variantOf -->
+
+    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_variantOf">
+        <rdfs:comment xml:lang="en">A Relationship of relationshipType_variantOf expresses that an SPDXElement is a variant of the relatedSPDXElement, but it is not clear which came first.  For example, if the content of two Files differs by some edit, but there is no way to tell which came first (no reliable date information), then one File is a variant of the other File.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.semanticweb.org/spdx/ontologies/2014/6/SPDX-2.1#relationshipType_dataFileOf -->
+
+    <owl:NamedIndividual rdf:about="http://www.semanticweb.org/spdx/ontologies/2014/6/SPDX-2.1#relationshipType_dataFileOf">
+        <rdfs:comment xml:lang="en">Is to be used when SPDXRef-A is a data file used in SPDXRef-B.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // General axioms
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <rdf:Description>
+        <rdf:type rdf:resource="&owl;AllDifferent"/>
+        <owl:distinctMembers rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://spdx.org/rdf/terms#annotationType_other"/>
+            <rdf:Description rdf:about="http://spdx.org/rdf/terms#annotationType_review"/>
+        </owl:distinctMembers>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="&owl;AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://spdx.org/rdf/terms#Annotation"/>
+            <rdf:Description rdf:about="http://spdx.org/rdf/terms#Relationship"/>
+            <rdf:Description rdf:about="http://spdx.org/rdf/terms#SpdxElement"/>
+        </owl:members>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="&owl;AllDifferent"/>
+        <owl:distinctMembers rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://spdx.org/rdf/terms#noassertion"/>
+            <rdf:Description rdf:about="http://spdx.org/rdf/terms#none"/>
+        </owl:distinctMembers>
+    </rdf:Description>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 3.4.2) http://owlapi.sourceforge.net -->
+


### PR DESCRIPTION
Signed-off-by: Gary O'Neall <gary@sourceauditor.com>

Adding the RDF ontology to the repository so that we can track any changes and keep this document in sync with the spec.

Please let me know if you think this files doesn't belong in the spec repo - I can create another repository, but it would only contain one file and I think there are some advantages to keeping the OWL document in the same repo (e.g. versions will be more easily kept in sync).