### PR TITLE
Slight improvement of language of sect 3

### DIFF
--- a/chapters/3-package-information.md
+++ b/chapters/3-package-information.md
@@ -1,6 +1,6 @@
 # 3 Package Information
 
-One instance of the Package Information is required per package being described. A package can contain sub-packages, but the information in this section is a reference to the entire contents of the package listed. Starting with SPDX 2.0, it is not necessary to have a package wrapping a set of files.
+If you organise your SPDX information by grouping into packages, then one instance of the Package Information is required per package being described. A package can contain sub-packages, but the information in this section is a reference to the entire contents of the package listed. Starting with SPDX 2.0, it is not necessary to have a package wrapping a set of files.
 
 Cardinality: Optional, one or many.
 


### PR DESCRIPTION
I'm proposing a slight wording change of section 3 to make it clearer the Package information only applies if the SPDX file is grouped by package.