### PR TITLE
chapters/4: Fix "package" -> "file" typo for copyright intent

### DIFF
--- a/chapters/4-file-information.md
+++ b/chapters/4-file-information.md
@@ -327,7 +327,7 @@ NOASSERTION, if
 
 (ii) the SPDX document creator has intentionally provided no information (no meaning should be implied from the absence of an assertion).
 
-**4.8.2** Intent: Record any copyright notice for the package.
+**4.8.2** Intent: Record any copyright notice for the file.
 
 **4.8.3** Cardinality: Mandatory, one.
 


### PR DESCRIPTION
Reported by @kesteward [here][1] and in #56.

Fixes #56.

[1]: https://bugs.linuxfoundation.org/show_bug.cgi?id=1384