### PR TITLE
chapters/1: Fix "filesAnnalyzed" -> "FilesAnalyzed" typo

### DIFF
--- a/chapters/1-rationale.md
+++ b/chapters/1-rationale.md
@@ -80,7 +80,7 @@ Companies and organizations (collectively “Organizations”) are widely using 
 
 **1.8.1** Snippets have been added to allow a portion of a file to be identified as having different properties from the file it resides in. The use of snippets is completely optional and it is not manditory for snippets to be identified. See [section 5 Snippet Information](./5-snippet-information.md) for further details on the fields available to describe snippets.
 
-**1.8.2** External Packages can now be refered to in SPDX documents. When there is no SPDX file information available to document the content of these external packages, then the filesAnnalyzed attribute on a package should be set to false. See [section 3.8](3-package-information.md#3.8) Files Analyzed for more information.
+**1.8.2** External Packages can now be refered to in SPDX documents. When there is no SPDX file information available to document the content of these external packages, then the `filesAnalyzed` attribute on a package should be set to false. See [section 3.8](3-package-information.md#3.8) Files Analyzed for more information.
 
 **1.8.3** Packages are now able to associate with an “External Reference” which allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package. See: section [3.21 External Reference](3-package-information.md#3.21), [3.22 External Reference Comment](3-package-information.md#3.22) and [Appendix VI: External Repository Identifiers](./appendix-VI-external-repository-identifiers.md) for more information.
 


### PR DESCRIPTION
Also backtick this literal code.

Somewhat unfortunately, the tag/value key (`FilesAnalyzed`) and RDF/XML tag (`filesAnalyzed`) differ in case.  And our internal references seem to use both forms.  In this commit, I've stuck with the previous casing, which matches the RDF/XML tag.