### PR TITLE
chapters/8: Allow rdf:about for referencing external SPDX IDs

### DIFF
--- a/chapters/8-annotations.md
+++ b/chapters/8-annotations.md
@@ -114,15 +114,19 @@ Example:
 
 **8.4.6** RDF:
 
-For RDF, the annotations are a property of the SPDX element it is annotationg.
+For RDF, the annotations may be a property of the SPDX element it is annotating.
 
-    <SpdxElement rdf:about=”#SPDXRef-45”>
-        <annotation>
-            <Annotation>
-                ...
-            </Annotation>
-        </annotation>
-    </SpdxElement rdf:about=”#SPDXRef-45”>
+    <SpdxElement rdf:about="#SPDXRef-45">
+        <Annotation>
+            ...
+        </Annotation>
+    </SpdxElement rdf:about="#SPDXRef-45">
+
+Alternatively, they may contain an `rdf:about` attribute with an SPDXID.
+
+    <Annotation rfd:about="#SPDXRef-45">
+        ...
+    </Annotation>
 
 ## 8.5 Annotation Comment <a name="8.5"></a>
 


### PR DESCRIPTION
`rdf:about` seems to be documented [here][1].  There are also a lot of examples using it [here][2], but I couldn't find clear a specification for `rdf:about` there.  What I'm looking for is a way to reference an external subject, the annotation tag is the predicate, and the contents of the annotation element are the object.  Ping @goneall for some RDF/XML assistance.

Also:

* Fix an “annotationg” → “annotating” typo.
* Remove a doubled `<annotation>` element.
* Fix curly quotes in the example I touch.

Fixes #67, by covering the XML case (the tag/value case is already covered since 2.0).

[1]: https://www.w3.org/TR/rdfa-primer/#alternative-for-setting-the-context-about
[2]: https://www.w3.org/TR/rdf-syntax-grammar/
  