### PR TITLE
chapters/3: Optional PackageDownloadLocation

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -16,4 +16,5 @@
 * [Appendix IV: SPDX License Expressions](./chapters/appendix-IV-SPDX-license-expressions.md)
 * [Appendix V: Using SPDX short identifiers in Source Files](./chapters/appendix-V-using-SPDX-short-identifiers-in-source-files.md)
 * [Appendix VI: External Repository Identifiers](./chapters/appendix-VI-external-repository-identifiers.md)
-* [Appendix VII: Creative Commons Attribution License 3.0 Unported](./chapters/appendix-VII-creative-commons-attribution-license-3.0-unported.md)
+* [Appendix VII: Version-Control URIs](./chapters/appendix-VII-version-control-uris.md)
+* [Appendix VIII: Creative Commons Attribution License 3.0 Unported](./chapters/appendix-VIII-creative-commons-attribution-license-3.0-unported.md)

--- a/chapters/3-package-information.md
+++ b/chapters/3-package-information.md
@@ -211,36 +211,27 @@ Example:
 
 **3.7.1** Purpose: This section identifies the download Universal Resource Locator (URL), or a specific location within a version control system (VCS) for the package at the time that the SPDX file was created.
 
-Use NONE if there is no download location whatsoever.
+**3.7.2** Intent: The download location is useful metadata.
 
-Use NOASSERTION if:
+**3.7.3** Cardinality: Optional, one or many.
+
+**3.7.4** Data Format: uniform resource locator | VCS location | `NONE` | `NOASSERTION`
+
+Use `NONE` if there is no download location whatsoever.
+
+Leave this property unset if:
+
 (i) the SPDX file creator has attempted to but cannot reach a reasonable objective determination;
 (ii) the SPDX file creator has made no attempt to determine this field; or
 (iii) the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
 
-**3.7.2** Intent: Here, where and how to download the exact package being referenced is critical verification and tracking data.
+The deprecated `NOASSERTION` value has the same semantics as leaving the property unset.
 
-**3.7.3** Cardinality: Mandatory, one.
-
-**3.7.4** Data Format: uniform resource locator | VCS location | “NONE” | “NOASSERTION”
-
-For version-controlled files, the VCS location syntax is similar to a URL and has the:
-
-    <vcs_tool>+<transport>://<host_name>[/<path_to_repository>][@<revision_tag_or_branch>][#<sub_path>]
-
-This VCS location compact notation (inspired and mostly adopted from https://pip.pypa.io/en/latest/reference/pip_install.html#vcs-support as of 20150220)  supports referencing locations in version control systems such as Git, Mercurial, Subversion and Bazaar, and specifies the type of VCS tool using url prefixes: “git+”, “hg+”, “bzr+”, “svn+” and specific transport schemes such as SSH or HTTPS.
-
-Specifying sub-paths, branch names, a commit hash, a revision or a tag name is recommended, and supported using the "@"delimiter for commits and the "#" delimiter for sub-paths.
-
-Using user names and password in the host_name is not supported and should be considered as an error. User access control to URLs or VCS repositories must be handled outside of an SPDX document.
-
-In VCS location compact notations, the trailing slashes in `<host_name>`, `<path_to_repository>` are not significant. Leading and trailing slashes in `<sub_path>` are not significant.
+For version-control systems without [a registered URI scheme][iana-schemes], the version-control URI syntax defined in [appendix VII](appendix-VII-version-control-uris.md) may be used.
 
 **3.7.5** Tag: `PackageDownloadLocation:`
 
-Examples if ambiguous:
-
-    PackageDownloadLocation: NOASSERTION
+Example for no no download location:
 
     PackageDownloadLocation: NONE
 
@@ -248,164 +239,12 @@ Example for a plain URL:
 
     PackageDownloadLocation: http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz
 
-Example for Git:
-
-SPDX supports git, git+git, git+https git+http and git+ssh transports. git and git+git are equivalent.
-
-Here are the supported forms:
-
-    PackageDownloadLocation: git://git.myproject.org/MyProject
-    
-    PackageDownloadLocation: git+https://git.myproject.org/MyProject.git
-    
-    PackageDownloadLocation: git+http://git.myproject.org/MyProject
-    
-    PackageDownloadLocation: git+ssh://git.myproject.org/MyProject.git
-    
-    PackageDownloadLocation: git+git://git.myproject.org/MyProject
-    
-    PackageDownloadLocation: git+git@git.myproject.org:MyProject
-
-To specify a sub-path to a file or directory inside a repository use the "#" delimiter:
-
-    PackageDownloadLocation: git://git.myproject.org/MyProject#src/somefile.c
-    
-    PackageDownloadLocation: git+https://git.myproject.org/MyProject#src/Class.java
-
-To specify branch names, a commit hash or a tag name, use the "@" delimiter:
-
-    PackageDownloadLocation: git://git.myproject.org/MyProject.git@master
-    
-    PackageDownloadLocation: git+https://git.myproject.org/MyProject.git@v1.0
-    
-    PackageDownloadLocation: git://git.myproject.org/MyProject.git@da39a3ee5e6b4b0d3255bfef95601890afd80709
-
-Sub-paths and branch names or commit hash can be combined too:
-
-    PackageDownloadLocation: git+https://git.myproject.org/MyProject.git@master#/src/MyClass.cpp
-    
-    PackageDownloadLocation: git+https://git.myproject.org/MyProject@da39a3ee5e6b4b0d3255bfef95601890afd80709#lib/variable.rb
-
-Example for Mercurial:
-
-SPDX supported schemes are: hg+http, hg+https, hg+static-http and hg+ssh.
-
-The supported forms are:
-
-    PackageDownloadLocation: hg+http://hg.myproject.org/MyProject
-    
-    PackageDownloadLocation: hg+https://hg.myproject.org/MyProject
-    
-    PackageDownloadLocation: hg+ssh://hg.myproject.org/MyProject
-
-To specify a sub-path to a file or directory inside a repository use the "#" delimiter:
-
-    PackageDownloadLocation: hg+https://hg.myproject.org/MyProject#src/somefile.c
-    
-    PackageDownloadLocation: hg+https://hg.myproject.org/MyProject#src/Class.java
-
-To pass branch names, a commit hash, a tag name or a local branch name use the "@" delimiter:
-
-    PackageDownloadLocation: hg+https://hg.myproject.org/MyProject@da39a3ee5e6b
-    
-    PackageDownloadLocation: hg+https://hg.myproject.org/MyProject@2019
-    
-    PackageDownloadLocation: hg+https://hg.myproject.org/MyProject@v1.0
-    
-    PackageDownloadLocation: hg+https://hg.myproject.org/MyProject@special_feature
-
-Sub-paths and branch names or commit hash can be combined too:
-
-    PackageDownloadLocation: hg+https://hg.myproject.org/MyProject@master#/src/MyClass.cpp
-    
-    PackageDownloadLocation: hg+https://hg.myproject.org/MyProject@da39a3ee5e6b#lib/variable.rb
-
-Example for Subversion:
-
-SPDX supports the URL schemes svn, svn+svn, svn+http, svn+https, svn+ssh. svn and svn+svn are equivalent.
-
-The supported forms are:
-
-    PackageDownloadLocation: svn://svn.myproject.org/svn/MyProject
-    
-    PackageDownloadLocation: svn+svn://svn.myproject.org/svn/MyProject
-    
-    PackageDownloadLocation: svn+http://svn.myproject.org/svn/MyProject/trunk
-    
-    PackageDownloadLocation: svn+https://svn.myproject.org/svn/MyProject/trunk
-
-To specify a sub-path to a file or directory inside a repository use the "#" delimiter:
-
-    PackageDownloadLocation: svn+https://svn.myproject.org/MyProject#src/somefile.c
-    
-    PackageDownloadLocation: svn+https://svn.myproject.org/MyProject#src/Class.java
-
-This support is less important for SVN since the URL path can also contain sub-paths; this two forms are equivalent:
-
-    PackageDownloadLocation: svn+https://svn.myproject.org/MyProject/trunk#src/somefile.c
-    
-    PackageDownloadLocation: svn+https://svn.myproject.org/MyProject/trunk/src/somefile.c
-
-You can specify a revision using the "@" delimiter:
-
-    PackageDownloadLocation: svn+https://svn.myproject.org/svn/MyProject/trunk@2019
-
-Sub-paths and revisions can be combined too:
-
-    PackageDownloadLocation: svn+https://svn.myproject.org/MyProject@123#/src/MyClass.cpp
-    
-    PackageDownloadLocation: svn+https://svn.myproject.org/MyProject/trunk@1234#lib/variable/variable.rb
-
-Example for Bazaar:
-
-SPDX supports Bazaar using the bzr+http, bzr+https, bzr+ssh, bzr+sftp, bzr+ftp and bzr+lp schemes.
-
-The supported forms are:
-
-    PackageDownloadLocation: bzr+https://bzr.myproject.org/MyProject/trunk
-    
-    PackageDownloadLocation: bzr+http://bzr.myproject.org/MyProject/trunk
-    
-    PackageDownloadLocation: bzr+sftp://myproject.org/MyProject/trunk
-    
-    PackageDownloadLocation: bzr+ssh://myproject.org/MyProject/trunk
-    
-    PackageDownloadLocation: bzr+ftp://myproject.org/MyProject/trunk
-    
-    PackageDownloadLocation: bzr+lp:MyProject
-
-To specify a sub-path to a file or directory inside a repository use the "#" delimiter:
-
-    PackageDownloadLocation: bzr+https://bzr.myproject.org/MyProject/trunk#src/somefile.c
-    
-    PackageDownloadLocation: bzr+https://bzr.myproject.org/MyProject/trunk#src/Class.java
-
-You can specify a revision or tag using the "@" delimiter:
-
-    PackageDownloadLocation: bzr+https://bzr.myproject.org/MyProject/trunk@2019
-    
-    PackageDownloadLocation: bzr+http://bzr.myproject.org/MyProject/trunk@v1.0
-
-Sub-paths and revisions can be combined too:
-
-    PackageDownloadLocation: bzr+https://bzr.myproject.org/MyProject/trunk@2019#src/somefile.c
-
 **3.7.6** RDF: property `spdx:downloadLocation` in class `spdx:Package`
 
 Example:
 
     <Package rdf:about="...">
         <downloadLocation>http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz</downloadLocation>
-    </Package>
-
-    <Package rdf:about="...">
-        <downloadLocation>
-            git+https://git.myproject.org/MyProject.git@v10.0#src/lib.c
-        </downloadLocation>
-    </Package>
-
-    <Package rdf:about="...">
-        <downloadLocation rdf:resource="http://spdx.org/rdf/terms#noassertion"/>
     </Package>
 
     <Package rdf:about="...">
@@ -1036,3 +875,5 @@ Example:
         </spdx:externalRef>
         ...
     </spdx:package>
+
+[iana-schemes]: https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml

--- a/chapters/appendix-VII-version-control-uris.md
+++ b/chapters/appendix-VII-version-control-uris.md
@@ -1,0 +1,158 @@
+# Appendix VII: Version-Control URIs
+
+Version-control systems (VCSs) are encouraged to [register a URI scheme][iana-schemes] for their system.
+This appendix defines a URI scheme (based on [pip's][pip-vcs]) that can be used in the absence of such registration.
+The exact syntax of license expressions is described below in [ABNF][rfc5234].
+`ALPHA` is from the [ABNF core rules][rfc5234-aB].
+[`scheme`][rfc3986-s3.1], [`authority`][rfc3986-s3.2], [`path-abempty`][rfc3986-s3.3], and [`fragment`][rfc3986-s3.5] are from [RFC 3986][rfc3986].
+
+```
+vcs-uri = vcs-tool ["+" transport] "://" authority path-abempty ["#" fragment]
+vcs-tool = 1*ALPHA
+transport = scheme
+```
+
+If the final [segment][rfc3986-s3.3] of `path-abempty` includes a `@`, the portion after the final `@` represents the tag, branch, or commit hash.
+Trailing slashes in `path-abempty` are not significant.
+
+If `fragment` is non-empty, it represents a sub-path within the referenced filesystem.
+Leading and trailing slashes in `fragment` are not significant.
+
+Authors are encouraged to use `@` and `fragment` to make their reference as specific as possible.
+
+`vcs-tool` may be extended as needed, but this specification defines the following values:
+
+* `bzr` for [Bazaar][].
+* `git` for [Git][].
+* `hg` for [Mercurial][].
+* `svn` for [Subversion][].
+
+`transport` is the [IANA-registered scheme][iana-schemes] used for VCS retrieval.
+
+VCS URI consumers are not required to support [user names and passwords][rfc3986-s3.2.1] in `authority` and may reject URIs which include them.
+
+## VII.1 Git <a name="VII.1"></a>
+
+VCS URI consumers should support the following URI [schemes][rfc3986-s3.1] (`vcs-tool ["+" transport]`):
+
+* `git` for the pack transfer service, generally on [port 9418][iana-ports].
+* `git+git`, a deprecated synonym for `git`.
+* `git+http` for Git over [HTTP][rfc7230-s2.7.1], generally on [port 80][rfc7230-s2.7.1].
+* `git+https` for Git over [HTTPS][rfc7230-s2.7.2], generally on [port 443][rfc7230-s2.7.2].
+* `git+ssh` for Git over [SSH][rfc4251], generally on [port 22][rfc4253-s4.1].
+
+Examples:
+
+* `git://example.net/MyProject`: the `MyProject` repository from `example.net` over `git`.
+* `git+git://example.net/MyProject`: this form is semantically equivalent to the previous entry.
+* `git+https://example.net/MyProject.git`: the `MyProject.git` repository from `example.net` over `git`.
+    The server may decide to treat `MyProject.git` as a synonym for `MyProject` or not, depending on its configuration.
+    For example, see [`git-daemon`][git-daemon.1]'s `--strict-paths`.
+* `git+http://example.net/MyProject`: the `MyProject` repository from `example.net` over `git+http`.
+* `git+ssh://example.net/MyProject.git`: the `MyProject.git` repository from `example.net` over `git+ssh`.
+* `git://example.net/MyProject#src/somefile.c`: the `src/somefile.c` file from the `MyProject` repository from `example.net` over `git`.
+* `git+https://example.net/MyProject#src/Class.java`: the `src/Class.java` file from the `MyProject` repository from `example.net` over `git+https`.
+* `git://example.net/MyProject.git@master`: the `master` branch (or tag) of the `MyProject.git` repository from `example.net` over `git`.
+* `git+https://example.net/MyProject.git@v1.0`: the `v1.0` tag (or branch) of the `MyProject.git` repository from `example.net` over `git+https`.
+* `git://example.net/MyProject.git@da39a3ee5e6b4b0d3255bfef95601890afd80709`: the `da39a3ee5e6b4b0d3255bfef95601890afd80709` commit (or branch, or tag) of the `MyProject.git` repository from `example.net` over `git`.
+* `git+https://example.net/MyProject.git@master#/src/MyClass.cpp`: the `src/MyClass.cpp` file from the `master` branch (or tag) of the `MyProject.git` repository from `example.net` over `git+https`.
+* `git+https://example.net/MyProject@da39a3ee5e6b4b0d3255bfef95601890afd80709#lib/variable.rb`: the `lib/variable.rb` file from the `da39a3ee5e6b4b0d3255bfef95601890afd80709` commit (or branch, or tag) of the `MyProject` repository from `example.net` over `git+https`.
+
+## VII.2 Mercurial <a name="VII.2"></a>
+
+VCS URI consumers should support the following URI [schemes][rfc3986-s3.1] (`vcs-tool ["+" transport]`):
+
+* `hg+http` for Mercurial over [HTTP][rfc7230-s2.7.1], generally on [port 80][rfc7230-s2.7.1].
+* `hg+https` for Mercurial over [HTTPS][rfc7230-s2.7.2], generally on [port 443][rfc7230-s2.7.2].
+* `hg+satic-http`, deprecated. [Mecurial 1.1 and later can detect this automatically][mercurial-static-http], so unless you need to support ancient ([~2008][mercurial-1.1]) clients you should use `hg+http` or `hg+https`.
+* `hg+ssh` for Mercurial over [SSH][rfc4251], generally on [port 22][rfc4253-s4.1].
+
+Examples:
+
+* `hg+http://example.net/MyProject`: the `MyProject` repository from `example.net` over `hg+http`.
+* `hg+https://example.net/MyProject`: the `MyProject` repository from `example.net` over `hg+https`.
+* `hg+ssh://example.net/MyProject`: the `MyProject` repository from `example.net` over `hg+ssh`.
+* `hg+https://example.net/MyProject#src/somefile.c`: the `src/somefile.c` file from the `MyProject` repository from `example.net` over `hg+https`.
+* `hg+https://example.net/MyProject#src/Class.java`: the `src/Class.java` file from the `MyProject` repository from `example.net` over `hg+https`.
+* `hg+https://example.net/MyProject@da39a3ee5e6b`: the `da39a3ee5e6b` commit (or branch, or tag) of the `MyProject` repository from `example.net` over `hg+https`.
+* `hg+https://example.net/MyProject@v1.0`: the `v1.0` tag (or branch) of the `MyProject` repository from `example.net` over `hg+https`.
+* `hg+https://example.net/MyProject@special_feature`: the `special_feature` branch (or tag) of the `MyProject` repository from `example.net` over `hg+https`.
+* `hg+https://example.net/MyProject@master#/src/MyClass.cpp`: the `src/MyClass.cpp` file from the `master` branch (or tag) of the `MyProject` repository from `example.net` over `hg+https`.
+* `hg+https://example.net/MyProject@da39a3ee5e6b#lib/variable.rb`: the `lib/variable.rb` file from the `da39a3ee5e6b` commit (or branch, or tag) of the `MyProject` repository from `example.net` over `hg+https`.
+
+## VII.3 Subversion <a name="VII.3"></a>
+
+VCS URI consumers should support the following URI [schemes][rfc3986-s3.1] (`vcs-tool ["+" transport]`):
+
+* `svn` for the Subversion service, generally on [port 3690][iana-ports].
+* `svn+svn`, a deprecated synonym for `svn`.
+* `svn+http` for Subversion over [HTTP][rfc7230-s2.7.1], generally on [port 80][rfc7230-s2.7.1].
+* `svn+https` for Subversion over [HTTPS][rfc7230-s2.7.2], generally on [port 443][rfc7230-s2.7.2].
+* `svn+ssh` for Subversion over [SSH][rfc4251], generally on [port 22][rfc4253-s4.1].
+
+Examples:
+
+* `svn://example.net/MyProject`: the `MyProject` repository from `example.net` over `svn`.
+* `svn+svn://example.net/MyProject`: this form is semantically equivalent to the previous entry.
+* `svn+http://example.net/MyProject/trunk`: the `trunk` branch of the `MyProject` repository from `example.net` over `svn+http`.
+* `svn+https://example.net/MyProject/trunk`: the `trunk` branch of the `MyProject` repository from `example.net` over `svn+https`.
+* `svn+https://example.net/MyProject#src/somefile.c`: the `src/somefile.c` file from the `MyProject` repository from `example.net` over `svn+https`.
+* `svn+https://example.net/MyProject#src/Class.java`: the `src/Class.java` file from the `MyProject` repository from `example.net` over `svn+https`.
+* `svn+https://example.net/MyProject/trunk#src/somefile.c`: the `src/somefile.c` file from the `trunk` branch of the `MyProject` repository from `example.net` over `svn+https`.
+* `svn+https://example.net/MyProject/trunk/src/somefile.c`: this form is semantically equivalent to the previous entry.
+* `svn+https://example.net/MyProject/trunk@2019`: the `2019` revision of the `trunk` branch of the `MyProject` repository from `example.net` over `svn+https`.
+* `svn+https://example.net/MyProject@123#/src/MyClass.cpp`: the `src/MyClass.cpp` file from the `123` revision of the `MyProject` repository from `example.net` over `svn+https`.
+* `svn+https://example.net/MyProject/trunk@1234#lib/variable.rb`: the `lib/variable.rb` file from the `1233` revision of the `trunk` branch of the `MyProject` repository from `example.net` over `svn+https`.
+
+## VII.4 Bazaar <a name="VII.4"></a>
+
+VCS URI consumers should support the following URI [schemes][rfc3986-s3.1] (`vcs-tool ["+" transport]`):
+
+* `bzr+http` for Bazaar over [HTTP][rfc7230-s2.7.1], generally on [port 80][rfc7230-s2.7.1].
+* `bzr+https` for Bazaar over [HTTPS][rfc7230-s2.7.2], generally on [port 443][rfc7230-s2.7.2].
+* `bzr+ssh` for Bazaar over [SSH][rfc4251], generally on [port 22][rfc4253-s4.1].
+* `bzr+sftp` for Bazaar over [SFTP][sftp-draft-13], generally on [port 22][rfc4253-s4.1].
+* `bzr+ftp` for Bazaar over [FTP][rfc-959], generally on ports [20][rfc-959-p18] and [21][rfc-959-s8].
+* `bzr+lp` for Bazaar from [Launchpad][bzr-lp].
+
+Examples:
+
+* `bzr+http://example.net/MyProject/trunk`: the `trunk` branch of the `MyProject` repository from `example.net` over `bzr+http`.
+* `bzr+https://example.net/MyProject/trunk`: the `trunk` branch of the `MyProject` repository from `example.net` over `bzr+https`.
+* `bzr+sftp://example.net/MyProject/trunk`: the `trunk` branch of the `MyProject` repository from `example.net` over `bzr+sftp`.
+* `bzr+ssh://example.net/MyProject/trunk`: the `trunk` branch of the `MyProject` repository from `example.net` over `bzr+ssh`.
+* `bzr+ftp://example.net/MyProject/trunk`: the `trunk` branch of the `MyProject` repository from `example.net` over `bzr+ftp`.
+* `bzr+lp:MyProject`: the `MyProject` repository from Launchpad.
+* `bzr+https://example.net/MyProject/trunk#src/somefile.c`: the `src/somefile.c` file from the `trunk` branch of the `MyProject` repository from `example.net` over `svn+https`.
+* `bzr+https://example.net/MyProject/trunk#src/Class.java`: the `src/Class.java` file from the `trunk` branch of the `MyProject` repository from `example.net` over `svn+https`.
+* `bzr+https://example.net/MyProject/trunk@2019`: the `2019` revision of the `trunk` branch of the `MyProject` repository from `example.net` over `bzr+https`.
+* `bzr+http://example.net/MyProject/trunk@v1.0`: the `v1.0` tag of the `trunk` branch of the `MyProject` repository from `example.net` over `bzr+http`.
+* `bzr+https://example.net/MyProject/trunk@2019#src/somefile.c`: the `src/somefile.c` file from the `2019` revision of the `trunk` branch of the `MyProject` repository from `example.net` over `svn+https`.
+
+[Bazaar]: https://bazaar.canonical.com/
+[Git]: https://git-scm.com/
+[git-daemon.1]: https://git-scm.com/docs/git-daemon
+[iana-ports]: https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xml
+[iana-schemes]: https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml
+[bzr-lp]: http://doc.bazaar.canonical.com/bzr.2.7/en/tutorials/using_bazaar_with_launchpad.html#getting-the-code-for-a-project
+[Mercurial]: https://www.mercurial-scm.org/
+[mercurial-1.1]: https://www.mercurial-scm.org/repo/hg-stable/rev/1.1
+[mercurial-static-http]: https://www.mercurial-scm.org/wiki/StaticHTTP
+[pip-vcs]: https://pip.pypa.io/en/stable/reference/pip_install/#vcs-support
+[rfc959]: https://tools.ietf.org/html/rfc959
+[rfc959-p18]: https://tools.ietf.org/html/rfc959#page-18
+[rfc959-s8]: https://tools.ietf.org/html/rfc959#section-8
+[rfc3986]: https://tools.ietf.org/html/rfc3986
+[rfc3986-s3.1]: https://tools.ietf.org/html/rfc3986#section-3.1
+[rfc3986-s3.2]: https://tools.ietf.org/html/rfc3986#section-3.2
+[rfc3986-s3.2.1]: https://tools.ietf.org/html/rfc3986#section-3.2.1
+[rfc3986-s3.3]: https://tools.ietf.org/html/rfc3986#section-3.3
+[rfc3986-s3.5]: https://tools.ietf.org/html/rfc3986#section-3.5
+[rfc4251]: https://tools.ietf.org/html/rfc4251
+[rfc4253-s4.1]: https://tools.ietf.org/html/rfc4253#section-4.1
+[rfc5234]: http://tools.ietf.org/html/rfc5234
+[rfc5234-aB]: https://tools.ietf.org/html/rfc5234#appendix-B
+[rfc7230-s2.7.1]: http://tools.ietf.org/html/rfc7230#section-2.7.1
+[rfc7230-s2.7.2]: http://tools.ietf.org/html/rfc7230#section-2.7.2
+[sftp-draft-13]: https://tools.ietf.org/html/draft-ietf-secsh-filexfer-13
+[Subversion]: https://subversion.apache.org/

--- a/chapters/appendix-VIII-creative-commons-attribution-license-3.0-unported.md
+++ b/chapters/appendix-VIII-creative-commons-attribution-license-3.0-unported.md
@@ -1,4 +1,4 @@
-# Appendix VII: Creative Commons Attribution License 3.0 Unported
+# Appendix VIII: Creative Commons Attribution License 3.0 Unported
  
 **License**
 


### PR DESCRIPTION
This is WIP, because I still need to fill in some of the Bazaar section.

There's no reason to require `PackageDownloadLocation` if we also allow `NOASSERTION`.  This commit deprecates `NOASSERTION`, and encourages authors to leave the property unset in those cases.

It also allows multiple entries, which can be useful if one download location is temporarily down or if clients are expected to prefer different authorities or protocols.

It also punts the version-control URI specification to a separate appendix.  Ideally VCSes would be registering their own schemes (and there is [a provisional registration for Git][1]).  We can't drop our VCS URI spec completely without backwards-compat concerns, but by shifting this information to an appendix we:

* Provide a more direct place for external consumers to link if they just want to lean on our VCS URI spec (e.g. [package-url][2]).

* Reduce noise for folks who are using IANA-registered schemes.

* Make it easier to deprecate and eventually drop our VCS URI spec as the VCSes register their own schemes with the IANA (hopefully Git) or fall out of common usage (possibly Subversion and Bazaar).

Related “let the IANA handle scheme registration” thoughts in #54 and #53.

While formalizing the VCS URI spec, I've dropped the:

    git+git@git.myproject.org:MyProject

example.  Git [supports the SCP-style syntax][3]:

    [user@]host.xz:path/to/repo.git/

but there's no easy way to formulate that as a URI.  The example I'm removing has its first colon way out towards the end, which, with the [URI ABNF][4] would make all of `git+git@git.myproject.org` the scheme (or a relative URI, since some of those are non-scheme chars).

Removing the SCP style does not reduce generality, because that same resource can be represented as:

    git+ssh://git.myproject.org/MyProject

or:

    git+ssh://git@git.myproject.org/MyProject

depending on how you read the SCP-style example.

I've also changed the examples from myproject.org to example.net, because that's what the IANA has [reserved for examples][5].

[1]: https://www.iana.org/assignments/uri-schemes/prov/git
[2]: https://github.com/package-url/purl-spec/blame/b6fbbf5cea6dae09c0d8ccd12b575efb0e2de8c2/README.rst#L734
[3]: https://git-scm.com/docs/git-fetch#_git_urls_a_id_urls_a
[4]: https://tools.ietf.org/html/rfc3986#section-3
[5]: https://tools.ietf.org/html/rfc2606#section-3