### PR TITLE
chapters/3: Simplify the verification-code algorithm

### DIFF
--- a/chapters/3-package-information.md
+++ b/chapters/3-package-information.md
@@ -4,10 +4,10 @@ One instance of the Package Information is required per package being described.
 
 Cardinality: Optional, one or many.
 
-In tag:value format, the order in which package and files occur is syntactically significant.
+In `tag:value` format, the order in which package and files occur is syntactically significant.
 
-A new Package Information section is denoted by the Package Name field.
-All Package Information fields must be grouped together before the start of a Files section, if file(s) are present.
+A new Package Information section is denoted by the [Package Name](#3.1) field.
+All Package Information fields must be grouped together before the start of a [Files section](4-file-information.md), if file(s) are present.
 All files contained in a package must immediately follow the applicable Package Information.
 A new Package Information section (via Package Name) denotes the start of another package.
 Sub-packages should not be nested inside a Package Information section, but should be separate and should use a Relationship to clarify.
@@ -17,13 +17,13 @@ Fields:
 
 ## 3.1 Package Name <a name="3.1"></a>
 
-**3.1.1** Purpose: Identify the full name of the package as given by Package Originator.
+**3.1.1** Purpose: Identify the full name of the package as given by the [Package Originator](#3.6).
 
-**3.1.2** Intent: Here, the name of each package is an important conventional technical identifier to be maintained for each package.
+**3.1.2** Intent: The name of each package is an important conventional technical identifier to be maintained for each package.
 
 **3.1.3** Cardinality: Mandatory, one.
 
-**3.1.4** DataFormat: single line of text.
+**3.1.4** Data Format: Single line of text.
 
 **3.1.5** Tag: `PackageName:`
 
@@ -47,9 +47,9 @@ Example:
 
 **3.2.3** Cardinality: Mandatory, one.
 
-**3.2.4** DataFormat: “SPDXRef-[idstring]
+**3.2.4** Data Format: `SPDXRef-[idstring]`
 
-where [idstring] is a unique string containing letters, numbers, “.”,“-”.
+where `[idstring]` is a unique string containing letters, numbers, `.`, and/or `-`.
 
 **3.2.5** Tag: `SPDXID:`
 
@@ -63,17 +63,18 @@ Example:
 
 See [section 2.5](2-document-creation-information.md#2.5) for the definition of the SPDX Document Namespace and [section 2.3](2-document-creation-information.md#2.3) for the definition of the SPDX Identifier
 
-Example using xml:base:
+Example using `xml:base`:
 
     <rdf:RDF xml:base="http://acme.com/spdxdocs/acmeproj/v1.2/1BE2A4FF-5F1A-48D3-8483-28A9B0349A1B">
         ...
-        <Package rdf:ID=”SPDXRef-1”>
+        <Package rdf:ID="SPDXRef-1">
         ...
         </Package>
+    </rdf:RDF>
 
 Example using document URI:
 
-    <Package rdf:about="http://acme.com/spdxdocs/acmeproj/v1.2/1BE2A4FF-5F1A-48D3-8483-28A9B0349...">
+    <Package rdf:about="http://acme.com/spdxdocs/acmeproj/v1.2/1BE2A4FF-5F1A-48D3-8483-28A9B0349A1B">
         ...
     </Package>
 
@@ -85,9 +86,9 @@ Example using document URI:
 
 **3.3.3** Cardinality: Optional, one.
 
-**3.3.4** DataFormat: single line of text.
+**3.3.4** Data Format: Single line of text.
 
-**3.3.5**  Tag: `PackageVersion:`
+**3.3.5** Tag: `PackageVersion:`
 
 Example:
 
@@ -107,11 +108,11 @@ Example:
 
 **3.4.1** Purpose: Provide the actual file name of the package, or path of the directory being treated as a package. This may include the packaging and compression methods used as part of the file name, if appropriate.
 
-**3.4.2** Intent: Here, the actual file name of the compressed file containing the package may be a significant technical element that needs to be included with each package identification information. If a grouping, like a set of files in a subdirectory, is being treated as a package, the subdirectory name may be appropriate to provide. Subdirectory name is preceeded with a “./”, see [http://www.ietf.org/rfc/rfc3986.txt](http://www.ietf.org/rfc/rfc3986.txt) for syntax.
+**3.4.2** Intent: The actual file name of the compressed file containing the package may be a significant technical element that needs to be included with each package identification information. If a grouping, like a set of files in a subdirectory, is being treated as a package, the subdirectory name may be appropriate to provide. Subdirectory name is preceeded with a `./`. See [RFC 3986][rfc3986] for syntax.
 
 **3.4.3** Cardinality: Optional, one.
 
-**3.4.4** Data Format: single line of text.
+**3.4.4** Data Format: Single line of text.
 
 **3.4.5** Tag: `PackageFileName:`
 
@@ -123,7 +124,7 @@ Example (subdirectory being treated as a package):
 
     PackageFileName: ./myrootdir/mysubdir1
 
-**3.4.6**  RDF: property `spdx:packageFileName` in class `spdx:Package`
+**3.4.6** RDF: property `spdx:packageFileName` in class `spdx:Package`
 
 Example:
 
@@ -143,21 +144,24 @@ Example (subdirectory being treated as a package):
 
 ## 3.5 Package Supplier <a name="3.5"></a>
 
-**3.5.1** Purpose: Identify the actual distribution source for the package/directory identified in the SPDX file. This may or may not be different from the originating distribution source for the package. The name of the Package Supplier must be an organization or recognized author and not a web site. For example, Sourceforge is a host website, not a supplier, the supplier for http://sourceforge.net/projects/bridge/ is "The Linux Foundation."
+**3.5.1** Purpose: Identify the actual distribution source for the package/directory identified in the SPDX file. This may or may not be different from the originating distribution source for the package. The name of the Package Supplier must be an organization or recognized author and not a web site. For example, [SourceForge][] is a host website, not a supplier, the supplier for https://sourceforge.net/projects/bridge/ is “[The Linux Foundation][LinuxFoundation].”
 
-Use NOASSERTION if:
+Use `NOASSERTION` if:
+
 (i) the SPDX file creator has attempted to but cannot reach a reasonable objective determination;
+
 (ii) the SPDX file creator has made no attempt to determine this field; or
+
 (iii) the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
 
-**3.5.2** Intent: This field assists with understanding the point of distribution for the code in the package. This field is vital for ensuring that downstream package recipients can address any ambiguity or concerns that might arise with the information in the SPDX file or the contents of the package it documents.
+**3.5.2** Intent: Assist with understanding the point of distribution for the code in the package. This field is vital for ensuring that downstream package recipients can address any ambiguity or concerns that might arise with the information in the SPDX file or the contents of the package it documents.
 
 **3.5.3** Cardinality: Optional, one.
 
-**3.5.4** Data Format: single line of text with the following keywords | “NOASSERTION”
+**3.5.4** Data Format: Single line of text with the following keywords | `NOASSERTION`
 
-    "Person:" person name and optional "("email")"
-    "Organization:" organization name and optional "("email")"
+* `Person:` person name and optional `(<email>)`
+* `Organization:` organization name and optional `(<email>)`
 
 **3.5.5** Tag: `PackageSupplier:`
 
@@ -171,27 +175,30 @@ Example:
 
     <Package rdf:about="...">
         ...
-        <supplier>Person: Jane Doe (jane.doe@example.com) </supplier>
+        <supplier>Person: Jane Doe (jane.doe@example.com)</supplier>
         ...
     </Package>
 
 ## 3.6 Package Originator <a name="3.6"></a>
 
-**3.6.1** Purpose: If the package identified in the SPDX file originated from a different person or organization than identified as Package Supplier (see section 3.5 above), this field identifies from where or whom the package originally came. In some cases a package may be created and originally distributed by a different third party than the Package Supplier of the package. For example, the SPDX file identifies the package glibc and Red Hat as the Package Supplier, but Free Software Foundation is the Package Originator.
+**3.6.1** Purpose: If the package identified in the SPDX file originated from a different person or organization than identified as Package Supplier (see [section 3.5](#3.5) above), this field identifies from where or whom the package originally came. In some cases a package may be created and originally distributed by a different third party than the Package Supplier of the package. For example, the SPDX file identifies the package [glibc][] and [Red Hat][RedHat] as the Package Supplier, but the [Free Software Foundation][FSF] is the Package Originator.
 
-Use NOASSERTION if:
+Use `NOASSERTION` if:
+
 (i) the SPDX file creator has attempted to but cannot reach a reasonable objective determination;
+
 (ii) the SPDX file creator has made no attempt to determine this field; or
+
 (iii) the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
 
-**3.6.2** Intent: This field assists with understanding the point of origin of the code in the package. This field is vital for understanding who originally distributed a package and should help in addressing any ambiguity or concerns that might arise with the information in the SPDX file or the contents of the Package it documents.
+**3.6.2** Intent: Assist with understanding the point of origin of the code in the package. This field is vital for understanding who originally distributed a package and should help in addressing any ambiguity or concerns that might arise with the information in the SPDX file or the contents of the Package it documents.
 
 **3.6.3** Cardinality: Optional, one.
 
-**3.6.4** Data Format: single line of text with the following keywords | “NOASSERTION”
+**3.6.4** Data Format: Single line of text with the following keywords | `NOASSERTION`
 
-    "Person:" person name and optional "("email")"
-    "Organization:" organization name and optional "("email")"
+* `Person:` person name and optional `(<email>)`
+* `Organization:` organization name and optional `(<email>)`
 
 **3.6.5** Tag: `PackageOriginator:`
 
@@ -199,11 +206,11 @@ Example:
 
     PackageOriginator: Organization: ExampleCodeInspect (contact@example.com)
 
-**3.6.6**  RDF: property `spdx:originator` in class `spdx:Package`
+**3.6.6** RDF: property `spdx:originator` in class `spdx:Package`
 
 Example:
 
-    <Package rdf:about="...”>
+    <Package rdf:about="...">
         <originator>Organization: ExampleCodeInspect (contact@example.com)</originator>
     </Package>
 
@@ -211,28 +218,32 @@ Example:
 
 **3.7.1** Purpose: This section identifies the download Universal Resource Locator (URL), or a specific location within a version control system (VCS) for the package at the time that the SPDX file was created.
 
-Use NONE if there is no download location whatsoever.
+Use:
 
-Use NOASSERTION if:
-(i) the SPDX file creator has attempted to but cannot reach a reasonable objective determination;
-(ii) the SPDX file creator has made no attempt to determine this field; or
-(iii) the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+* `NONE` if there is no download location whatsoever.
+* `NOASSERTION` if:
 
-**3.7.2** Intent: Here, where and how to download the exact package being referenced is critical verification and tracking data.
+    (i) the SPDX file creator has attempted to but cannot reach a reasonable objective determination;
+
+    (ii) the SPDX file creator has made no attempt to determine this field; or
+
+    (iii) the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+
+**3.7.2** Intent: Where and how to download the exact package being referenced is critical verification and tracking data.
 
 **3.7.3** Cardinality: Mandatory, one.
 
-**3.7.4** Data Format: uniform resource locator | VCS location | “NONE” | “NOASSERTION”
+**3.7.4** Data Format: uniform resource locator | VCS location | `NONE` | `NOASSERTION`
 
 For version-controlled files, the VCS location syntax is similar to a URL and has the:
 
     <vcs_tool>+<transport>://<host_name>[/<path_to_repository>][@<revision_tag_or_branch>][#<sub_path>]
 
-This VCS location compact notation (inspired and mostly adopted from https://pip.pypa.io/en/latest/reference/pip_install.html#vcs-support as of 20150220)  supports referencing locations in version control systems such as Git, Mercurial, Subversion and Bazaar, and specifies the type of VCS tool using url prefixes: “git+”, “hg+”, “bzr+”, “svn+” and specific transport schemes such as SSH or HTTPS.
+This VCS location compact notation (inspired and mostly adopted from [pip][pip-vcs] as of 2015-02-20) supports referencing locations in version control systems such as [Git][], [Mercurial][], [Subversion][] and [Bazaar][], and specifies the type of VCS tool using url prefixes: `git+`, `hg+`, `bzr+`, `svn+` and specific transport schemes such as SSH or HTTPS.
 
-Specifying sub-paths, branch names, a commit hash, a revision or a tag name is recommended, and supported using the "@"delimiter for commits and the "#" delimiter for sub-paths.
+Specifying sub-paths, branch names, a commit hash, a revision or a tag name is recommended, and supported using the `@` delimiter for commits and the `#` delimiter for sub-paths.
 
-Using user names and password in the host_name is not supported and should be considered as an error. User access control to URLs or VCS repositories must be handled outside of an SPDX document.
+Using user names and password in the `<host_name>` is not supported and should be considered as an error. User access control to URLs or VCS repositories must be handled outside of an SPDX document.
 
 In VCS location compact notations, the trailing slashes in `<host_name>`, `<path_to_repository>` are not significant. Leading and trailing slashes in `<sub_path>` are not significant.
 
@@ -248,9 +259,9 @@ Example for a plain URL:
 
     PackageDownloadLocation: http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz
 
-Example for Git:
+Example for [Git][]:
 
-SPDX supports git, git+git, git+https git+http and git+ssh transports. git and git+git are equivalent.
+SPDX supported schemes are: `git`, `git+git`, `git+https`, `git+http`, and `git+ssh`. `git` and `git+git` are equivalent.
 
 Here are the supported forms:
 
@@ -266,13 +277,13 @@ Here are the supported forms:
 
     PackageDownloadLocation: git+git@git.myproject.org:MyProject
 
-To specify a sub-path to a file or directory inside a repository use the "#" delimiter:
+To specify a sub-path to a file or directory inside a repository use the `#` delimiter:
 
     PackageDownloadLocation: git://git.myproject.org/MyProject#src/somefile.c
 
     PackageDownloadLocation: git+https://git.myproject.org/MyProject#src/Class.java
 
-To specify branch names, a commit hash or a tag name, use the "@" delimiter:
+To specify branch names, a commit hash or a tag name, use the `@` delimiter:
 
     PackageDownloadLocation: git://git.myproject.org/MyProject.git@master
 
@@ -286,9 +297,9 @@ Sub-paths and branch names or commit hash can be combined too:
 
     PackageDownloadLocation: git+https://git.myproject.org/MyProject@da39a3ee5e6b4b0d3255bfef95601890afd80709#lib/variable.rb
 
-Example for Mercurial:
+Example for [Mercurial][]:
 
-SPDX supported schemes are: hg+http, hg+https, hg+static-http and hg+ssh.
+SPDX supported schemes are: `hg+http`, `hg+https`, `hg+static-http`, and `hg+ssh`.
 
 The supported forms are:
 
@@ -298,13 +309,13 @@ The supported forms are:
 
     PackageDownloadLocation: hg+ssh://hg.myproject.org/MyProject
 
-To specify a sub-path to a file or directory inside a repository use the "#" delimiter:
+To specify a sub-path to a file or directory inside a repository use the `#` delimiter:
 
     PackageDownloadLocation: hg+https://hg.myproject.org/MyProject#src/somefile.c
 
     PackageDownloadLocation: hg+https://hg.myproject.org/MyProject#src/Class.java
 
-To pass branch names, a commit hash, a tag name or a local branch name use the "@" delimiter:
+To pass branch names, a commit hash, a tag name or a local branch name use the `@` delimiter:
 
     PackageDownloadLocation: hg+https://hg.myproject.org/MyProject@da39a3ee5e6b
 
@@ -320,9 +331,9 @@ Sub-paths and branch names or commit hash can be combined too:
 
     PackageDownloadLocation: hg+https://hg.myproject.org/MyProject@da39a3ee5e6b#lib/variable.rb
 
-Example for Subversion:
+Example for [Subversion][]:
 
-SPDX supports the URL schemes svn, svn+svn, svn+http, svn+https, svn+ssh. svn and svn+svn are equivalent.
+SPDX supported schemes are: `svn`, `svn+svn`, `svn+http`, `svn+https`, `svn+ssh`. `svn` and `svn+svn` are equivalent.
 
 The supported forms are:
 
@@ -334,7 +345,7 @@ The supported forms are:
 
     PackageDownloadLocation: svn+https://svn.myproject.org/svn/MyProject/trunk
 
-To specify a sub-path to a file or directory inside a repository use the "#" delimiter:
+To specify a sub-path to a file or directory inside a repository use the `#` delimiter:
 
     PackageDownloadLocation: svn+https://svn.myproject.org/MyProject#src/somefile.c
 
@@ -346,7 +357,7 @@ This support is less important for SVN since the URL path can also contain sub-p
 
     PackageDownloadLocation: svn+https://svn.myproject.org/MyProject/trunk/src/somefile.c
 
-You can specify a revision using the "@" delimiter:
+You can specify a revision using the `@` delimiter:
 
     PackageDownloadLocation: svn+https://svn.myproject.org/svn/MyProject/trunk@2019
 
@@ -356,9 +367,9 @@ Sub-paths and revisions can be combined too:
 
     PackageDownloadLocation: svn+https://svn.myproject.org/MyProject/trunk@1234#lib/variable/variable.rb
 
-Example for Bazaar:
+Example for [Bazaar][]:
 
-SPDX supports Bazaar using the bzr+http, bzr+https, bzr+ssh, bzr+sftp, bzr+ftp and bzr+lp schemes.
+SPDX supported schemes are: `bzr+http`, `bzr+https`, `bzr+ssh`, `bzr+sftp`, `bzr+ftp`, and `bzr+lp`.
 
 The supported forms are:
 
@@ -374,13 +385,13 @@ The supported forms are:
 
     PackageDownloadLocation: bzr+lp:MyProject
 
-To specify a sub-path to a file or directory inside a repository use the "#" delimiter:
+To specify a sub-path to a file or directory inside a repository use the `#` delimiter:
 
     PackageDownloadLocation: bzr+https://bzr.myproject.org/MyProject/trunk#src/somefile.c
 
     PackageDownloadLocation: bzr+https://bzr.myproject.org/MyProject/trunk#src/Class.java
 
-You can specify a revision or tag using the "@" delimiter:
+You can specify a revision or tag using the `@` delimiter:
 
     PackageDownloadLocation: bzr+https://bzr.myproject.org/MyProject/trunk@2019
 
@@ -414,17 +425,17 @@ Example:
 
 ## 3.8 Files Analyzed <a name="3.8"></a>
 
-**3.8.1** Purpose: Indicates whether the file content of this package has been available for or subjected to analysis when creating the SPDX document. If “false” indicates packages that represent metadata or URI references to a project, product, artifact, distribution or a component. If set to “false”, the package must not contain any files.
+**3.8.1** Purpose: Indicates whether the file content of this package has been available for or subjected to analysis when creating the SPDX document. If `false`, indicates packages that represent metadata or URI references to a project, product, artifact, distribution or a component. If `false`, the package must not contain any files.
 
 **3.8.2** Intent: A package can refer to a project, product, artifact, distribution or a component that is external to the SPDX document.
 
 Some examples:
 
-A bundle of external products: Package A can be metadata about Packages and their dependencies. It may also be a loosely organized manifest of references to Packages involved in a product or project. Build or execution may transitively discover more Packages and dependencies. All of these referenced Packages can have their own SPDX Documents. In this case, Package A may be defined with its File Analyzed attribute set to “false”. Package A includes External Document References to SPDX documents containing Packages referenced in all the available relationships. The Relationships section then relates the SPDX documents and contained SPDX elements with appropriate semantics per the dependencies in the scope of Package A.
+A bundle of external products: Package A can be metadata about Packages and their dependencies. It may also be a loosely organized manifest of references to Packages involved in a product or project. Build or execution may transitively discover more Packages and dependencies. All of these referenced Packages can have their own SPDX Documents. In this case, Package A may be defined with its File Analyzed attribute set to `false`. Package A includes External Document References to SPDX documents containing Packages referenced in all the available relationships. The Relationships section then relates the SPDX documents and contained SPDX elements with appropriate semantics per the dependencies in the scope of Package A.
 Package relation to external product: Package A can have a STATIC_LINK relationship to Package B, but the binary representation of Package B is furnished by the build process and thus not contained in the file list of Package A. In this case, Package B needs to be defined with its Files Analyzed attribute set to false and all the other attributes subject to the subsequently defined constraints. Then, the relationship between Package A and Package B can be documented as described in [Section 7](7-relationships-between-SPDX-elements.md).
-File derived from external product: Package A contains multiple files derived from an outside project. Rather than use the artifactOf* attributes (Sections 4.9-4.11) to describe the relation of these files to their project, the outside project can be represented by another package, Package B, whose FilesAnalyzed attribute is set to “false”. Each of the binary files can then have a relationship to package B (Section 6). This allows the outside project to be represented by a single SPDX identifier (the identifier of Package B). It also allows the relationship(s) between the outside project and each of the files be represented in much more detail.
+File derived from external product: Package A contains multiple files derived from an outside project. Rather than use the `artifactOf*` attributes (Sections 4.9-4.11) to describe the relation of these files to their project, the outside project can be represented by another package, Package B, whose [`FilesAnalyzed`](#3.8) attribute is set to `false`. Each of the binary files can then have a relationship to package B (Section 6). This allows the outside project to be represented by a single SPDX identifier (the identifier of Package B). It also allows the relationship(s) between the outside project and each of the files be represented in much more detail.
 
-**3.8.3** Cardinality: Optional, one. (If omitted, the default value of “true” is assumed).
+**3.8.3** Cardinality: Optional, one.  If omitted, the default value of `true` is assumed.
 
 **3.8.4** Data Format: Boolean
 
@@ -434,11 +445,11 @@ Example:
 
     FilesAnalyzed: false
 
-**3.8.6** RDF: property `spdx:filesAnalyzed` in class `spdx:Package`.
+**3.8.6** RDF: property `spdx:filesAnalyzed` in class `spdx:Package`
 
 Example:
 
-    <Package rdf:about=”...”>
+    <Package rdf:about="...">
         ...
         <filesAnalyzed>false</filesAnalyzed>
         ...
@@ -448,38 +459,40 @@ Example:
 
 **3.9.1** Purpose: This field provides an independently reproducible mechanism identifying specific contents of a package based on the actual files (except the SPDX file itself, if it is included in the package) that make up each package and that correlates to the data in this SPDX file. This identifier enables a recipient to determine if any file in the original package (that the analysis was done on) has been changed and permits inclusion of an SPDX file as part of a package.
 
-**3.9.2** Intent: Providing a unique identifier based on the files inside each package, eliminates confusion over which version or modification of a specific package the SPDX file refers to. It also permits one to embed the SPDX file within the package without altering the identifier.
+**3.9.2** Intent: Provide a unique identifier based on the files inside each package, eliminating confusion over which version or modification of a specific package the SPDX file refers to. This field also permits embedding the SPDX file within the package without altering the identifier.
 
-**3.9.3** Cardinality: Mandatory, one if filesAnalyzed is true or omitted, Zero (must be omitted) if filesAnalyzed is false.
+**3.9.3** Cardinality: Mandatory, one if [`FilesAnalyzed`](#3.8) is `true` or omitted, zero (must be omitted) if `FilesAnalyzed` is `false`.
 
 **3.9.4** Algorithm:
 
     verificationcode = 0
-    filelist = templist = “”
+    filelist = templist = ""
     for all files in the package {
-        if file is an “excludes” file, skip it /* exclude SPDX analysis file(s) */
-
-            append templist with “SHA1(file)/n”
+        if file is an 'excludes' file, skip it /* exclude SPDX analysis file(s) */
+            append templist with "SHA1(read(file))/n"
         }
     sort templist in ascending order by SHA1 value
     filelist = templist with "/n"s removed. /* ordered sequence of SHA1 values with no separators */
     verificationcode = SHA1(filelist)
 
-Where SHA1(file) applies a SHA1 algorithm on the contents of file and returns the result in lowercase hexadecimal digits.
+Where:
 
-Required sort order: '0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f' (ASCII order)
+* `SHA1(bytes)` applies [the SHA-1 algorithm][SHA-1] to `bytes` and returns the result in ASCII-encoded lowercase hexadecimal digits.
+* `read(file)` returns the content of the file as an array of bytes.
 
-**3.9.5** Data Format: single line of text with 160 bit binary represented as 40 lowercase hexadecimal digits
+Hashes must be sorted in ascending ASCII order: `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`, `a`, `b`, `c`, `d`, `e`, `f`
 
-**3.9.6** Tag: `PackageVerificationCode:` (and optionally `(excludes: FileName)`)
+**3.9.5** Data Format: Single line of text with 160-bit binary represented as 40 lowercase hexadecimal digits (and optionally `(excludes: <FileName>)`)
 
-where FileName is as specified in 6.1.
+`FileName` is specified in [section 4.1](4-file-information.md#4.1).
+
+**3.9.6** Tag: `PackageVerificationCode:`
 
 Example:
 
     PackageVerificationCode: d6a770ba38583ed4bb4525bd96e50461655d2758 (excludes: ./package.spdx)
 
-**3.9.7** RDF: `spdx:packageVerificationCodeValue`, `spdx:packageVerificationCodeExcludedFile` in class `spdx:PackageVerificationCode`
+**3.9.7** RDF: `spdx:packageVerificationCodeValue`, `spdx:packageVerificationCodeExcludedFile` in class `spdx:PackageVerificationCode` in class `spdx:Package`
 
 Example:
 
@@ -498,15 +511,15 @@ Example:
 
 ## 3.10 Package Checksum <a name="3.10"></a>
 
-**3.10.1** Purpose: This field provides an independently reproducible mechanism that permits unique identification of a specific package that correlates to the data in this SPDX file. This identifier enables a recipient to determine if any file in the original package has been changed. If the SPDX file is to be included in a package, this value should not be calculated. The SHA-1 algorithm will be used to provide the checksum by default.
+**3.10.1** Purpose: Provide an independently reproducible mechanism that permits unique identification of a specific package that correlates to the data in this SPDX file. This identifier enables a recipient to determine if any file in the original package has been changed. If the SPDX file is to be included in a package, this value should not be calculated. The [SHA-1][] algorithm will be used to provide the checksum by default. 
 
-**3.10.2** Intent: Here, by providing a unique identifier of the package, confusion over which version or modification of a specific package the SPDX file references should be eliminated.
+**3.10.2** Intent: Eliminate confusion over which version or modification of a specific package the SPDX file references by providing a unique identifier of the package.
 
 **3.10.3** Cardinality: Optional, one or many.
 
-**3.10.4** Algorithms that can be used: SHA1, SHA256, MD5
+**3.10.4** Algorithms that can be used: [`SHA1`][SHA-1], [`SHA256`][SHA-256], [`MD5`][MD5]
 
-**3.10.5** Data Format: There are three components, an algorithm identifier(“SHA1”), a colon separator ”:”, and a bit value represented as lowercase hexadecimal digits (appropriate as output to the algorithm).
+**3.10.5** Data Format: There are three components, an algorithm identifier (e.g. `SHA1`), a colon separator `:`, and a bit value represented as lowercase hexadecimal digits (appropriate as output to the algorithm).
 
 **3.10.6** Tag: `PackageChecksum:`
 
@@ -518,7 +531,7 @@ Example:
 
     PackageChecksum: MD5: 624c1abb3664f4b35547e7c73864ad24
 
-**3.10.7** RDF: properties `spdx:algorithm`, `spdx:checksumValue` in class `spdx:checksum`
+**3.10.7** RDF: properties `spdx:algorithm`, `spdx:checksumValue` in class `spdx:checksum` in class `spdx:Package`
 
 Example:
 
@@ -547,22 +560,26 @@ Example:
 
 ## 3.11 Package Home Page <a name="3.11"></a>
 
-**3.11.1** Purpose: This field provides a place for the SPDX file creator to record a web site that serves as the package's home page. This link can also be used to reference further information about the package referenced by the SPDX file creator.
+**3.11.1** Purpose: Provide a place for the SPDX file creator to record a web site that serves as the package's home page. This link can also be used to reference further information about the package referenced by the SPDX file creator.
 
-Use NONE if there is no package home page whatsoever.
+Use:
 
-Use NOASSERTION if:
-(i) the SPDX file creator has attempted to but cannot reach a reasonable objective determination;
-(ii) the SPDX file creator has made no attempt to determine this field; or
-(iii) the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+* `NONE` if there is no package home page whatsoever.
+* `NOASSERTION` if:
 
-**3.11.2** Intent: Here, by providing a link to the package's home page, the SPDX file creator can provide additional information useful for analysis. This saves the recipient of the SPDX file who is looking for more info from having to search for and verify a match between the package and the associated project homepage.
+    (i) the SPDX file creator has attempted to but cannot reach a reasonable objective determination;
+
+    (ii) the SPDX file creator has made no attempt to determine this field; or
+
+    (iii) the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+
+**3.11.2** Intent: Save the recipient of the SPDX file who is looking for more info from having to search for and verify a match between the package and the associated project homepage.
 
 **3.11.3** Cardinality: Optional, one.
 
-**3.11.4** Data Format: uniform resource locator | “NONE” | “NOASSERTION”
+**3.11.4** Data Format: uniform resource locator | `NONE` | `NOASSERTION`
 
-**3.11.5** Tag: “PackageHomePage:”
+**3.11.5** Tag: `PackageHomePage:`
 
 Example:
 
@@ -577,15 +594,15 @@ Example:
 
 ## 3.12 Source Information <a name="3.12"></a>
 
-**3.12.1** Purpose: This field provides a place for the SPDX file creator to record any relevant background information or additional comments about the origin of the package. For example, this field might include comments indicating whether the package was pulled from a source code management system or has been repackaged.
+**3.12.1** Purpose: Provide a place for the SPDX file creator to record any relevant background information or additional comments about the origin of the package. For example, this field might include comments indicating whether the package was pulled from a source code management system or has been repackaged.
 
-**3.12.2** Intent: Here, by providing a comment field, the SPDX file creator can provide additional information to describe any anomalies or discoveries in the determination of the origin of the package.
+**3.12.2** Intent: The SPDX file creator can provide additional information to describe any anomalies or discoveries in the determination of the origin of the package.
 
 **3.12.3** Cardinality: Optional, one.
 
 **3.12.4** Data Format: free form text that can span multiple lines.
 
-In Tag:value format this is delimited by `<text> .. </text>`.
+In `tag:value` format this is delimited by `<text>...</text>`.
 
 **3.12.5** Tag: `PackageSourceInfo:`
 
@@ -605,30 +622,31 @@ Example:
 
 ## 3.13 Concluded License <a name="3.13"></a>
 
-**3.13.1** Purpose: This field contains the license the SPDX file creator has concluded as governing the package or alternative values, if the governing license cannot be determined.
+**3.13.1** Purpose: Contain the license the SPDX file creator has concluded as governing the package or alternative values, if the governing license cannot be determined.
 
 The options to populate this field are limited to:
 
-A valid SPDX License Expression as defined in Appendix IV;
+* A valid SPDX License Expression as defined in [Appendix IV](appendix-IV-SPDX-license-expressions.md);
+* `NONE`, if the SPDX file creator concludes there is no license available for this package; or
+* `NOASSERTION` if:
 
-NONE, if the SPDX file creator concludes there is no license available for this package; or
-NOASSERTION if:
+    (i) the SPDX file creator has attempted to but cannot reach a reasonable objective determination;
 
-(i) the SPDX file creator has attempted to but cannot reach a reasonable objective determination;
-(ii) the SPDX file creator has made no attempt to determine this field; or
-(iii) the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+    (ii) the SPDX file creator has made no attempt to determine this field; or
 
-If the Concluded License is not the same as the Declared License, a written explanation should be provided in the Comments on License field [(section 3.16)](#3.16). With respect to NOASSERTION, a written explanation in the Comments on License field [(section 3.16)](#3.16) is preferred.
+    (iii) the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+
+If the Concluded License is not the same as the [Declared License](#3.15), a written explanation should be provided in the Comments on License field [(section 3.16)](#3.16). With respect to `NOASSERTION`, a written explanation in the Comments on License field [(section 3.16)](#3.16) is preferred.
 
 **3.13.2** Intent: Here, the intent is for the SPDX file creator to analyze the license information in package, and other objective information, e.g., COPYING file, together with the results from any scanning tools, to arrive at a reasonably objective conclusion as to what license governs the package.
 
 **3.13.3** Cardinality: Mandatory, one.
 
-**3.13.4** Data Format: <SPDX LIcense Expression> | “NONE” | “NOASSERTION”
+**3.13.4** Data Format: `<SPDX License Expression>` | `NONE` | `NOASSERTION`
 
 where:
 
-<SPDX LIcense Expression> is a valid SPDX License Expression as defined in Appendix IV.
+`<SPDX License Expression>` is a valid SPDX License Expression as defined in [Appendix IV](appendix-IV-SPDX-license-expressions.md).
 
 **3.13.5** Tag: `PackageLicenseConcluded:`
 
@@ -669,33 +687,27 @@ Example:
 
 The options to populate this field are limited to:
 
-The SPDX License List short form identifier, if a detected license is on the SPDX License List;
-A user defined license reference denoted by LicenseRef-\[idstring\] \(for a license not on the SPDX License List\);
-NONE, if no license information is detected in any of the files; or
-NOASSERTION, if:
+* The SPDX License List short form identifier, if a detected license is on the SPDX License List;
+* A user defined license reference denoted by `LicenseRef-<idstring>` (for a license not on the SPDX License List);
+* `NONE`, if no license information is detected in any of the files; or
+* `NOASSERTION`, if:
 
-(i) the SPDX file creator has made no attempt to determine this field; or
-(ii) the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+    (i) the SPDX file creator has made no attempt to determine this field; or
+
+    (ii) the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
 
 **3.14.2** Intent: Here, the intention is to capture all license information detected in the actual files.
 
-**3.14.3** Cardinality: Mandatory, one or many if filesAnalyzed is true or omitted.
+**3.14.3** Cardinality: Mandatory, one or many if [`FilesAnalyzed`](#3.8) is `true` or omitted, zero (must be omitted) if `FilesAnalyzed` is `false`.
 
-Zero (must be omitted) if filesAnalyzed is false.
-
-**3.14.4** Data Format: \<short form identifier in Appendix I> |
-
-  [“DocumentRef-”[idstring]”:”]"LicenseRef"-[idstring] |
-
-  | “NONE” | “NOASSERTION”
+**3.14.4** Data Format: [`<shortIdentifier>`](appendix-I-SPDX-license-list.md#I.1) |
+  `[DocumentRef-<idstring>:]LicenseRef-<idstring>` |
+  `NONE` | `NOASSERTION`
 
 where:
 
-  “DocumentRef-”[idstring] is an optional reference to an external SPDX
-
-document as described in [section 2.6](2-document-creation-information.md#2.6)
-
-  [idstring] is a unique string containing letters, numbers, “.”, or “-”
+* `DocumentRef-<idstring>` is an optional reference to an external SPDX document as described in [section 2.6](2-document-creation-information.md#2.6).
+* `<idstring>` is a unique string containing letters, numbers, `.`, or `-`.
 
 **3.14.5** Tag: `PackageLicenseInfoFromFiles:`
 
@@ -713,7 +725,7 @@ Example:
 
     <Package rdf:about="...">
         ...
-        <licenseInfoFromFiles rdf:resource=" http://spdx.org/licenses/GPL-2.0" />
+        <licenseInfoFromFiles rdf:resource="https://spdx.org/licenses/GPL-2.0" />
         <licenseInfoFromFiles rdf:resource="#LicenseRef-1" />
         <licenseInfoFromFiles rdf:resource="#LicenseRef-2" />
         ...
@@ -721,25 +733,27 @@ Example:
 
 ## 3.15 Declared License <a name="3.15"></a>
 
-**3.15.1** Purpose: This field lists the licenses that have been declared by the authors of the package. Any license information that does not originate from the package authors, e.g. license information from a third party repository, should not be included in this field.
+**3.15.1** Purpose: List the licenses that have been declared by the authors of the package. Any license information that does not originate from the package authors, e.g. license information from a third party repository, should not be included in this field.
 
 The options to populate this field are limited to:
 
-A valid SPDX License Expression as defined in Appendix IV;
-NONE, if the package contains no license information whatsoever; or
-NOASSERTION if:
-(i) the SPDX file creator has made no attempt to determine this field; or
-(ii) the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+* A valid SPDX License Expression as defined in [Appendix IV](appendix-IV-SPDX-license-expressions.md);
+* `NONE`, if the package contains no license information whatsoever; or
+* `NOASSERTION` if:
+
+    (i) the SPDX file creator has made no attempt to determine this field; or
+
+    (ii) the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
 
 **3.15.2** Intent: This is simply the license identified in text in one or more files (for example COPYING file) in the source code package. This field is not intended to capture license information obtained from an external source, such as the package website. Such information can be included in Concluded License [(section 3.13)](#3.13). This field may have multiple Declared Licenses, if multiple licenses are declared at the package level.
 
 **3.15.3** Cardinality: Mandatory, one.
 
-**3.15.4** Data Format: \<SPDX License Expression> | “NONE” | “NOASSERTION”
+**3.15.4** Data Format: `<SPDX License Expression>` | `NONE` | `NOASSERTION`
 
 where:
 
-\<SPDX License Expression> is a valid SPDX License Expression as defined in Appendix IV.
+* `<SPDX License Expression>` is a valid SPDX License Expression as defined in [Appendix IV](appendix-IV-SPDX-license-expressions.md).
 
 **3.15.5** Tag: `PackageLicenseDeclared:`
 
@@ -755,7 +769,7 @@ Example:
 
 Example:
 
-    <Package rdf:about=”...”>
+    <Package rdf:about="...">
         ...
         <licenseDeclared rdf:resource="http://spdx.org/licenses/LGPL-2.0" />
         ...
@@ -777,17 +791,17 @@ Example:
 
 ## 3.16 Comments on License <a name="3.16"></a>
 
-**3.16.1** Purpose: This field provides a place for the SPDX file creator to record any relevant background information or analysis that went in to arriving at the Concluded License for a package. If the Concluded License does not match the Declared License or License Information from Files, this should be explained by the SPDX file creator. Its is also preferable to include an explanation here when the Concluded License is NOASSERTION.
+**3.16.1** Purpose: This field provides a place for the SPDX file creator to record any relevant background information or analysis that went in to arriving at the Concluded License for a package. If the Concluded License does not match the Declared License or License Information from Files, this should be explained by the SPDX file creator. Its is also preferable to include an explanation here when the Concluded License is `NOASSERTION`.
 
-**3.16.2** Intent: Here, the intent is to provide the recipient of the SPDX file with a detailed explanation of how the Concluded License was determined if it does not match the License Information from the files or the source code package, is marked NOASSERTION, or other helpful information relevant to determining the license of the package.
+**3.16.2** Intent: Here, the intent is to provide the recipient of the SPDX file with a detailed explanation of how the Concluded License was determined if it does not match the License Information from the files or the source code package, is marked `NOASSERTION`, or other helpful information relevant to determining the license of the package.
 
 **3.16.3** Cardinality: Optional, one.
 
 **3.16.4** Data Format: free form text that can span multiple lines.
 
-In Tag:value format this is delimited by `<text> .. </text>`,
+In `tag:value` format this is delimited by `<text>...</text>`.
 
-in RDF, it is delimited by `<licenseComment>`.
+In RDF, it is delimited by `<licenseComment>`.
 
 **3.16.5** Tag: `PackageLicenseComments:`
 
@@ -814,23 +828,23 @@ Example:
 
 **3.17.1** Purpose: Identify the copyright holders of the package, as well as any dates present. This will be a free form text field extracted from package information files. The options to populate this field are limited to:
 
-Any text related to a copyright notice, even if not complete;
-NONE if the package contains no copyright information whatsoever; or
-NOASSERTION, if
+* Any text related to a copyright notice, even if not complete;
+* `NONE` if the package contains no copyright information whatsoever; or
+* `NOASSERTION`, if
 
-(i) the SPDX document creator has made no attempt to determine this field; or
+    (i) the SPDX document creator has made no attempt to determine this field; or
 
-(ii) the SPDX document creator has intentionally provided no information (no meaning should be implied by doing so).
+    (ii) the SPDX document creator has intentionally provided no information (no meaning should be implied by doing so).
 
 **3.17.2** Intent: Record any copyright notices for the package.
 
 **3.17.3** Cardinality: Mandatory, one.
 
-**3.17.4** Data Format: free form text that can span multiple lines | “NONE” | “NOASSERTION”
+**3.17.4** Data Format: free form text that can span multiple lines | `NONE` | `NOASSERTION`
 
 **3.17.5** Tag: `PackageCopyrightText:`
 
-In Tag:value format multiple lines are delimited by `<text> .. </text>`.
+In `tag:value` format multiple lines are delimited by `<text>...</text>`.
 
 Example:
 
@@ -856,9 +870,9 @@ Example:
 
 **3.18.4** Data Format: free form text that can span multiple lines.
 
-**3.18.5**  Tag: `PackageSummary:`
+**3.18.5** Tag: `PackageSummary:`
 
-In Tag:value format multiple lines are delimited by `<text> .. </text>`.
+In `tag:value` format multiple lines are delimited by `<text>...</text>`.
 
 Example:
 
@@ -886,7 +900,7 @@ Example:
 
 **3.19.5** Tag: `PackageDescription:`
 
-In Tag:value format multiple lines are delimited by `<text> .. </text>`.
+In `tag:value` format multiple lines are delimited by `<text>...</text>`.
 
 Example:
 
@@ -920,7 +934,7 @@ Example:
 
 **3.20.5** Tag: `PackageComment:`
 
-In Tag:value format multiple lines are delimited by `<text> .. </text>`.
+In `tag:value` format multiple lines are delimited by `<text>...</text>`.
 
 Example:
 
@@ -950,9 +964,8 @@ Example:
 
 where:
 
-`<category>` is “SECURITY” | “PACKAGE-MANAGER” | “OTHER”
-
-`<type>` is an [idstring] that is defined in Appendix.
+* `<category>` is `SECURITY` | `PACKAGE-MANAGER` | `OTHER`
+* `<type>` is an `[idstring]` that is defined in [Appendix IV](appendix-IV-SPDX-license-expressions.md).
 
 `<locator>` is the unique string with no spaces necessary to access the package-specific information, metadata, or content within the target location. The format of the locator is subject to constraints defined by the `<type>`.
 
@@ -964,51 +977,51 @@ Example:
 
     ExternalRef: OTHER LocationRef-acmeforge acmecorp/acmenator/4.1.3-alpha
 
-**3.21.6** RDF: property `target` in class `spdx:ExternalRef`
+**3.21.6** RDF: property `target` in class `spdx:ExternalRef` in class `spdx:Package`
 
-Example (for a ‘listed’ location):
+Example (for a listed location):
 
     <spdx:Package  rdf:about="...">
         ...
         <spdx:externalRef>
             <spdx:ExternalRef>
-                <spdx:referenceCategory rdf:resouce=”http://spdx.org/rdf/terms#referenceCategory_packageManager” />
-                <spdx:referenceType rdf:resource=”http://spdx.org/rdf/refeferences/maven-central” />
+                <spdx:referenceCategory rdf:resouce="http://spdx.org/rdf/terms#referenceCategory_packageManager" />
+                <spdx:referenceType rdf:resource="http://spdx.org/rdf/refeferences/maven-central" />
                 <spdx:referenceLocator>org.apache.commons:commons-lang:3.2.1</spdx:referenceLocator>
             </spdx:ExternalRef>
         </spdx:externalRef>
         ...
     </spdx:package>
 
-Example  (for a not ‘listed’ location):
+Example (for an unlisted location):
 
     <spdx:Package rdf:about="...">
         ...
         <spdx:externalRef>
             <spdx:ExternalRef>
                 <spdx:referenceCategory rdf:resource="http://spdx.org/rdf/terms#referenceCategory_other" />
-                <spdx:referenceType rdf:resource=”http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82...LocationRef-acmeforge” />
+                <spdx:referenceType rdf:resource="http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82...LocationRef-acmeforge" />
                 <spdx:referenceLocator>acmecorp/acmenator/4.1.3-alpha</spdx:referenceLocator>
             </spdx:ExternalRef>
         </spdx:externalRef>
         ...
     </spdx:package>
 
-The referenceType value for a non-listed location consists of the SPDX document namespace (per [section 2.5](2-document-creation-information.md#2.5)) followed by a “#” and the category as defined in 3.21.4.
+The referenceType value for a non-listed location consists of the SPDX document namespace (per [section 2.5](2-document-creation-information.md#2.5)) followed by a `#` and the category as defined in [3.21.4](#3.21).
 
 ## 3.22 External Reference Comment <a name="3.22"></a>
 
 **3.22.1** Purpose: To provide human-readable information about the purpose and target of the reference.
 
-**3.22.2** Intent: To inform a human consumer why the reference exists, what kind of information, content or metadata can be extracted. The target’s relationship to artifactOf values of files in the package may need to be explained here. If the reference is BINARY, its relationship to PackageDownloadLocation may need to be explained. If the reference is SOURCE, its relationship to PackageDownloadLocation and SourceInformation may need to be explained.
+**3.22.2** Intent: To inform a human consumer why the reference exists, what kind of information, content or metadata can be extracted. The target's relationship to artifactOf values of files in the package may need to be explained here. If the reference is BINARY, its relationship to PackageDownloadLocation may need to be explained. If the reference is SOURCE, its relationship to PackageDownloadLocation and SourceInformation may need to be explained.
 
-**3.22.3** Cardinality: Conditional (Optional, one) for each External Reference.
+**3.22.3** Cardinality: Conditional (Optional, one) for each [External Reference][#3.21).
 
 **3.22.4** Data format: Free form text that can span multiple lines.
 
-In Tag:value format this is delimited by `<text> .. </text>`, and is expected to follow an External References so that the association can be made.
+In `tag:value` format this is delimited by `<text>...</text>` and is expected to follow an [External Reference](#3.21) so that the association can be made.
 
-in RDF, it is delimited by `<ExternalRefComment>`.
+In RDF, it is delimited by `<ExternalRefComment>`.
 
 **3.22.5** Tag: `ExternalRefComment:`
 
@@ -1018,14 +1031,14 @@ Example:
     security vulnerabilities (CVEs) which affect Vendor Product Version
     acmecorp:acmenator:6.6.6.</text>
 
-**3.22.6** RDF: Property `rdfs:comment` in class `spdx:ExternalRef`
+**3.22.6** RDF: Property `rdfs:comment` in class `spdx:ExternalRef` in class `spdx:Package`
 
     <spdx:Package rdf:about="...">
         ...
         <spdx:externalRef>
             <spdx:ExternalRef>
-                <spdx:referenceCategory rdf:resouce=”http://spdx.org/rdf/terms#referenceCategory_packageManager” />
-                <spdx:referenceType rdf:resource=”http://spdx.org/rdf/refeferences/maven-central” />
+                <spdx:referenceCategory rdf:resouce="http://spdx.org/rdf/terms#referenceCategory_packageManager" />
+                <spdx:referenceType rdf:resource="http://spdx.org/rdf/refeferences/maven-central" />
                 <spdx:referenceLocator>org.apache.commons:commons-lang:3.2.1</spdx:referenceLocator>
                 <rdfs:comment>
                     NIST National Vulnerability Database (NVD) describes
@@ -1036,3 +1049,19 @@ Example:
         </spdx:externalRef>
         ...
     </spdx:package>
+
+
+[Bazaar]: http://bazaar.canonical.com/
+[FSF]: http://www.fsf.org/
+[Git]: https://git-scm.com/
+[glibc]: https://www.gnu.org/software/libc/
+[LinuxFoundation]: https://www.linuxfoundation.org/
+[MD5]: https://tools.ietf.org/html/rfc1321
+[Mercurial]: https://www.mercurial-scm.org/
+[pip-vcs]: https://pip.pypa.io/en/latest/reference/pip_install.html#vcs-support
+[Red Hat]: https://www.redhat.com/
+[rfc3986]: https://tools.ietf.org/html/rfc3986
+[SHA-1]: https://tools.ietf.org/html/rfc3174
+[SHA-256]: https://tools.ietf.org/html/rfc6234
+[SourceForge]: https://sourceforge.net/
+[Subversion]: https://subversion.apache.org/

--- a/chapters/3-package-information.md
+++ b/chapters/3-package-information.md
@@ -465,15 +465,17 @@ Example:
 
 **3.9.4** Algorithm:
 
-    verificationcode = 0
-    filelist = templist = ""
+    hashes = []  /* initialize to an empty array */
     for all files in the package {
-        if file is an 'excludes' file, skip it /* exclude SPDX analysis file(s) */
-            append templist with "SHA1(read(file))/n"
+        if file is in "excludes" {
+            continue  /* exclude SPDX analysis file(s), etc. */
         }
-    sort templist in ascending order by SHA1 value
-    filelist = templist with "/n"s removed. /* ordered sequence of SHA1 values with no separators */
-    verificationcode = SHA1(filelist)
+        content = read(file)
+        append SHA1(content) to hashes
+    }
+    sortedHashes = sort values in hashes in ascending order
+    sortedHash = concatenated values from sortedHashes
+    verificationCode = SHA1(sortedHash)
 
 Where:
 


### PR DESCRIPTION
Spun of from #17.  Review that PR first.

Instead of using a newline-delimited file to hold and sort hashes, just store the hashes in an array.  This avoids the need to inject newlines, sort, and then remove the newlines.  Most languages will have a native array structure, so there's no need to use the newline approach as a custom array structure.

Also, use the more intuitive (to me, anyway):

```
  if file is in "excludes" {
    continue  /* exclude SPDX analysis file(s), etc. */
  }
  operate on the file that's not excluded
```

instead of the old:

```
  if file is an 'excludes' file, skip it
    operate on the file that's not excluded
  }
```