### PR TITLE
CONTRIBUTING: Give more guidance about list vs. issue/PR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,13 @@
 # Contributing
 
-When contributing to this repository, please first discuss the change you wish to make on [the SPDX technical mailing list][spdx-tech].
+The SPDX specification is maintained by the SPDX [legal][spdx-legal] and [tech][spdx-tech] teams.
+Design and planning is primarily done via the team [mailing][spdx-legal-list] [lists][spdx-tech-list] and meetings.
+You may want to discuss significant changes on the mailing list first to get design feedback before investing time in a pull request.
+Minor changes such as markup and typo fixes may be submitted directly to this repository (either as [issues][] or [pull-requests][]) without previous discussion.
 
-[spdx-tech]: https://lists.spdx.org/mailman/listinfo/spdx-tech
+[issues]: https://github.com/spdx/spdx-spec/issues/
+[pull-requests]: https://github.com/spdx/spdx-spec/pulls/
+[spdx-legal]: https://wiki.spdx.org/view/Legal_Team
+[spdx-legal-list]: https://lists.spdx.org/mailman/listinfo/spdx-legal
+[spdx-tech]: https://wiki.spdx.org/view/Technical_Team
+[spdx-tech-list]: https://lists.spdx.org/mailman/listinfo/spdx-tech


### PR DESCRIPTION
So folks can feel comfortable submitting typo-fix PRs without needing to [follow up on the list][1].

[1]: https://lists.spdx.org/pipermail/spdx-tech/2018-January/003531.html