### PR TITLE
.travis.yml: Remove explicit 'pip install'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ env:
   - GIT_EMAIL: opensource@steenbe.nl
   - GH_REF: git@github.com:spdx/spdx-spec.git
 language: python
-before_script:
-- pip install -r requirements.txt
 script:
 - openssl aes-256-cbc -K $encrypted_0222e5876250_key -iv $encrypted_0222e5876250_iv -in $TRAVIS_BUILD_DIR/.travis/deploy-key.enc -out $TRAVIS_BUILD_DIR/.travis/deploy-key -d
 - chmod 600 $TRAVIS_BUILD_DIR/.travis/deploy-key


### PR DESCRIPTION
Travis does this already as part of [its default install for Python builds][1].  This is resulting in redundant install calls (e.g. [here][2] and [here][3]).

[1]: https://docs.travis-ci.com/user/languages/python/#pip
[2]: https://travis-ci.org/spdx/spdx-spec/builds/376491183#L434
[3]: https://travis-ci.org/spdx/spdx-spec/builds/376491183#L476