### PR TITLE
Add examples in non-official formats

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,5 @@
+## Caution
+
+The examples in this directory (except for the [Tag-Value file](SPDXTagExample-v2.0.spdx)) are NOT official SPDX formats.
+
+The only official formats currently recognized in the SPDX spec are RDF/XML and Tag-Value. The examples in this directory are intended to be working documents, for use by the SPDX team in evaluating additional formats. The schemas seen in these examples are unstable and should NOT be relied upon as final.

--- a/examples/SPDXJSONExample-v2.0.json
+++ b/examples/SPDXJSONExample-v2.0.json
@@ -1,0 +1,383 @@
+{
+  "Document" : {
+    "specVersion" : "SPDX-2.0",
+    "creationInfo" : {
+      "creators" : [ "Person: Jane Doe ()", "Tool: LicenseFind-1.0", "Organization: ExampleCodeInspect ()" ],
+      "comment" : "This package has been shipped in source and binary form.\nThe binaries were created with gcc 4.5.1 and expect to link to\ncompatible system run time libraries.",
+      "licenseListVersion" : "1.19",
+      "created" : "2010-01-29T18:30:22Z"
+    },
+    "spdxVersion" : "SPDX-2.0",
+    "dataLicense" : "CC0-1.0",
+    "id" : "SPDXRef-DOCUMENT",
+    "name" : "SPDX-Tools-v2.0",
+    "comment" : "This document was created using SPDX 2.0 using licenses from the web site.",
+    "externalDocumentRefs" : [ {
+      "checksum" : {
+        "algorithm" : "checksumAlgorithm_sha1",
+        "value" : "d6a770ba38583ed4bb4525bd96e50461655d2759"
+      },
+      "spdxDocumentNamespace" : "http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301",
+      "externalDocumentId" : "DocumentRef-spdx-tool-1.2"
+    } ],
+    "documentDescribes" : [ {
+      "File" : {
+        "name" : "./package/foo.c",
+        "id" : "SPDXRef-File",
+        "fileTypes" : [ "fileType_source" ],
+        "checksums" : [ {
+          "algorithm" : "checksumAlgorithm_sha1",
+          "value" : "d6a770ba38583ed4bb4525bd96e50461655d2758"
+        }, {
+          "algorithm" : "checksumAlgorithm_md5",
+          "value" : "624c1abb3664f4b35547e7c73864ad24"
+        } ],
+        "licenseConcluded" : "(LGPL-2.0 OR LicenseRef-2)",
+        "licenseInfoFromFiles" : [ "LicenseRef-2", "GPL-2.0" ],
+        "licenseComments" : "The concluded license was taken from the package level that the file was included in.",
+        "copyrightText" : "Copyright 2008-2010 John Smith",
+        "artifactOf" : [ {
+          "name" : "Jena",
+          "homePage" : "http://www.openjena.org/",
+          "projectUri" : "http://subversion.apache.org/doap.rdf"
+        } ],
+        "comment" : "The concluded license was taken from the package level that the file was included in.\nThis information was found in the COPYING.txt file in the xyz directory.",
+        "noticeText" : "Copyright (c) 2001 Aaron Lehmann aaroni@vitelus.com\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the �Software�), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: \nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED �AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.",
+        "fileContributors" : [ "The Regents of the University of California", "Modified by Paul Mundt lethal@linux-sh.org", "IBM Corporation" ],
+        "fileDependencies" : [ ],
+        "annotations" : [ {
+          "annotator" : "Person: File Commenter",
+          "annotationDate" : "2011-01-29T18:30:22Z",
+          "annotationType" : "OTHER",
+          "comment" : "File level annotation"
+        } ],
+        "relationships" : [ ],
+        "sha1" : "d6a770ba38583ed4bb4525bd96e50461655d2758",
+        "copyright" : "Copyright 2008-2010 John Smith"
+      }
+    }, {
+      "Package" : {
+        "name" : "glibc",
+        "id" : "SPDXRef-Package",
+        "versionInfo" : "2.11.1",
+        "packageFileName" : "glibc-2.11.1.tar.gz",
+        "supplier" : "Person: Jane Doe (jane.doe@example.com)",
+        "originator" : "Organization: ExampleCodeInspect (contact@example.com)",
+        "downloadLocation" : "http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz",
+        "filesAnalyzed" : true,
+        "packageVerificationCode" : {
+          "value" : "d6a770ba38583ed4bb4525bd96e50461655d2758",
+          "excludedFileNames" : [ "excludes: ./package.spdx" ]
+        },
+        "checksums" : [ {
+          "algorithm" : "checksumAlgorithm_md5",
+          "value" : "624c1abb3664f4b35547e7c73864ad24"
+        }, {
+          "algorithm" : "checksumAlgorithm_sha256",
+          "value" : "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
+        }, {
+          "algorithm" : "checksumAlgorithm_sha1",
+          "value" : "85ed0817af83a24ad8da68c2b5094de69833983c"
+        } ],
+        "homepage" : "http://ftp.gnu.org/gnu/glibc",
+        "sourceInfo" : "uses glibc-2_11-branch from git://sourceware.org/git/glibc.git.",
+        "licenseConcluded" : "(LicenseRef-3 OR LGPL-2.0)",
+        "licenseInfoFromFiles" : [ "GPL-2.0", "LicenseRef-1", "LicenseRef-2" ],
+        "licenseDeclared" : "(LicenseRef-3 AND LGPL-2.0)",
+        "licenseComments" : "The license for this project changed with the release of version x.y.  The version of the project included here post-dates the license change.",
+        "copyrightText" : "Copyright 2008-2010 John Smith",
+        "summary" : "GNU C library.",
+        "description" : "The GNU C Library defines functions that are specified by the ISO C standard, as well as additional features specific to POSIX and other derivatives of the Unix operating system, and extensions specific to GNU systems.",
+        "comment" : null,
+        "externalRefs" : [ {
+          "referenceCategory" : "referenceCategory_other",
+          "referenceType" : {
+            "referenceTypeUri" : "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge"
+          },
+          "referenceLocator" : "acmecorp/acmenator/4.1.3-alpha",
+          "comment" : "This is the external ref for Acme"
+        }, {
+          "referenceCategory" : "referenceCategory_security",
+          "referenceType" : {
+            "referenceTypeUri" : "http://spdx.org/rdf/references/cpe23Type"
+          },
+          "referenceLocator" : "cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*",
+          "comment" : null
+        } ],
+        "annotations" : [ {
+          "annotator" : "Person: Package Commenter",
+          "annotationDate" : "2011-01-29T18:30:22Z",
+          "annotationType" : "OTHER",
+          "comment" : "Package level annotation"
+        } ],
+        "relationships" : [ {
+          "relationshipType" : "DYNAMIC_LINK",
+          "comment" : null,
+          "relatedSpdxElementId" : "SPDXRef-Saxon"
+        }, {
+          "relationshipType" : "CONTAINS",
+          "comment" : null,
+          "relatedSpdxElementId" : "SPDXRef-JenaLib"
+        } ],
+        "files" : [ {
+          "File" : {
+            "name" : "./src/org/spdx/parser/DOAPProject.java",
+            "id" : "SPDXRef-DoapSource",
+            "fileTypes" : [ "fileType_source" ],
+            "checksums" : [ {
+              "algorithm" : "checksumAlgorithm_sha1",
+              "value" : "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+            } ],
+            "licenseConcluded" : "Apache-2.0",
+            "licenseInfoFromFiles" : [ "Apache-2.0" ],
+            "licenseComments" : null,
+            "copyrightText" : "Copyright 2010, 2011 Source Auditor Inc.",
+            "artifactOf" : [ ],
+            "comment" : null,
+            "noticeText" : null,
+            "fileContributors" : [ "Open Logic Inc.", "Black Duck Software In.c", "Source Auditor Inc.", "SPDX Technical Team Members", "Protecode Inc." ],
+            "fileDependencies" : [ {
+              "File" : {
+                "name" : "./lib-source/jena-2.6.3-sources.jar",
+                "id" : "SPDXRef-JenaLib",
+                "fileTypes" : [ "fileType_archive" ],
+                "checksums" : [ {
+                  "algorithm" : "checksumAlgorithm_sha1",
+                  "value" : "3ab4e1c67a2d28fced849ee1bb76e7391b93f125"
+                } ],
+                "licenseConcluded" : "LicenseRef-1",
+                "licenseInfoFromFiles" : [ "LicenseRef-1" ],
+                "licenseComments" : "This license is used by Jena",
+                "copyrightText" : "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP",
+                "artifactOf" : [ {
+                  "name" : "Jena",
+                  "homePage" : "http://www.openjena.org/",
+                  "projectUri" : null
+                } ],
+                "comment" : "This file belongs to Jena",
+                "noticeText" : null,
+                "fileContributors" : [ "Hewlett Packard Inc.", "Apache Software Foundation" ],
+                "fileDependencies" : [ {
+                  "File" : {
+                    "name" : "./lib-source/commons-lang3-3.1-sources.jar",
+                    "id" : "SPDXRef-CommonsLangSrc",
+                    "fileTypes" : [ "fileType_archive" ],
+                    "checksums" : [ {
+                      "algorithm" : "checksumAlgorithm_sha1",
+                      "value" : "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
+                    } ],
+                    "licenseConcluded" : "Apache-2.0",
+                    "licenseInfoFromFiles" : [ "Apache-2.0" ],
+                    "licenseComments" : null,
+                    "copyrightText" : "Copyright 2001-2011 The Apache Software Foundation",
+                    "artifactOf" : [ {
+                      "name" : "Apache Commons Lang",
+                      "homePage" : "http://commons.apache.org/proper/commons-lang/",
+                      "projectUri" : null
+                    } ],
+                    "comment" : "This file is used by Jena",
+                    "noticeText" : "Apache Commons Lang\nCopyright 2001-2011 The Apache Software Foundation\n\nThis product includes software developed by\nThe Apache Software Foundation (http://www.apache.org/).\n\nThis product includes software from the Spring Framework,\nunder the Apache License 2.0 (see: StringUtils.containsWhitespace())",
+                    "fileContributors" : [ "Apache Software Foundation" ],
+                    "fileDependencies" : [ ],
+                    "annotations" : [ ],
+                    "relationships" : [ ],
+                    "sha1" : "c2b4e1c67a2d28fced849ee1bb76e7391b93f125",
+                    "copyright" : "Copyright 2001-2011 The Apache Software Foundation"
+                  }
+                } ],
+                "annotations" : [ ],
+                "relationships" : [ {
+                  "relationshipType" : "DYNAMIC_LINK",
+                  "comment" : null,
+                  "relatedSpdxElementId" : "SPDXRef-Package"
+                } ],
+                "sha1" : "3ab4e1c67a2d28fced849ee1bb76e7391b93f125",
+                "copyright" : "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP"
+              }
+            }, {
+              "File" : {
+                "name" : "./lib-source/commons-lang3-3.1-sources.jar",
+                "id" : "SPDXRef-CommonsLangSrc",
+                "fileTypes" : [ "fileType_archive" ],
+                "checksums" : [ {
+                  "algorithm" : "checksumAlgorithm_sha1",
+                  "value" : "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
+                } ],
+                "licenseConcluded" : "Apache-2.0",
+                "licenseInfoFromFiles" : [ "Apache-2.0" ],
+                "licenseComments" : null,
+                "copyrightText" : "Copyright 2001-2011 The Apache Software Foundation",
+                "artifactOf" : [ {
+                  "name" : "Apache Commons Lang",
+                  "homePage" : "http://commons.apache.org/proper/commons-lang/",
+                  "projectUri" : null
+                } ],
+                "comment" : "This file is used by Jena",
+                "noticeText" : "Apache Commons Lang\nCopyright 2001-2011 The Apache Software Foundation\n\nThis product includes software developed by\nThe Apache Software Foundation (http://www.apache.org/).\n\nThis product includes software from the Spring Framework,\nunder the Apache License 2.0 (see: StringUtils.containsWhitespace())",
+                "fileContributors" : [ "Apache Software Foundation" ],
+                "fileDependencies" : [ ],
+                "annotations" : [ ],
+                "relationships" : [ ],
+                "sha1" : "c2b4e1c67a2d28fced849ee1bb76e7391b93f125",
+                "copyright" : "Copyright 2001-2011 The Apache Software Foundation"
+              }
+            } ],
+            "annotations" : [ ],
+            "relationships" : [ ],
+            "sha1" : "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12",
+            "copyright" : "Copyright 2010, 2011 Source Auditor Inc."
+          }
+        }, {
+          "File" : {
+            "name" : "./lib-source/jena-2.6.3-sources.jar",
+            "id" : "SPDXRef-JenaLib",
+            "fileTypes" : [ "fileType_archive" ],
+            "checksums" : [ {
+              "algorithm" : "checksumAlgorithm_sha1",
+              "value" : "3ab4e1c67a2d28fced849ee1bb76e7391b93f125"
+            } ],
+            "licenseConcluded" : "LicenseRef-1",
+            "licenseInfoFromFiles" : [ "LicenseRef-1" ],
+            "licenseComments" : "This license is used by Jena",
+            "copyrightText" : "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP",
+            "artifactOf" : [ {
+              "name" : "Jena",
+              "homePage" : "http://www.openjena.org/",
+              "projectUri" : null
+            } ],
+            "comment" : "This file belongs to Jena",
+            "noticeText" : null,
+            "fileContributors" : [ "Hewlett Packard Inc.", "Apache Software Foundation" ],
+            "fileDependencies" : [ {
+              "File" : {
+                "name" : "./lib-source/commons-lang3-3.1-sources.jar",
+                "id" : "SPDXRef-CommonsLangSrc",
+                "fileTypes" : [ "fileType_archive" ],
+                "checksums" : [ {
+                  "algorithm" : "checksumAlgorithm_sha1",
+                  "value" : "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
+                } ],
+                "licenseConcluded" : "Apache-2.0",
+                "licenseInfoFromFiles" : [ "Apache-2.0" ],
+                "licenseComments" : null,
+                "copyrightText" : "Copyright 2001-2011 The Apache Software Foundation",
+                "artifactOf" : [ {
+                  "name" : "Apache Commons Lang",
+                  "homePage" : "http://commons.apache.org/proper/commons-lang/",
+                  "projectUri" : null
+                } ],
+                "comment" : "This file is used by Jena",
+                "noticeText" : "Apache Commons Lang\nCopyright 2001-2011 The Apache Software Foundation\n\nThis product includes software developed by\nThe Apache Software Foundation (http://www.apache.org/).\n\nThis product includes software from the Spring Framework,\nunder the Apache License 2.0 (see: StringUtils.containsWhitespace())",
+                "fileContributors" : [ "Apache Software Foundation" ],
+                "fileDependencies" : [ ],
+                "annotations" : [ ],
+                "relationships" : [ ],
+                "sha1" : "c2b4e1c67a2d28fced849ee1bb76e7391b93f125",
+                "copyright" : "Copyright 2001-2011 The Apache Software Foundation"
+              }
+            } ],
+            "annotations" : [ ],
+            "relationships" : [ {
+              "relationshipType" : "DYNAMIC_LINK",
+              "comment" : null,
+              "relatedSpdxElementId" : "SPDXRef-Package"
+            } ],
+            "sha1" : "3ab4e1c67a2d28fced849ee1bb76e7391b93f125",
+            "copyright" : "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP"
+          }
+        }, {
+          "File" : {
+            "name" : "./lib-source/commons-lang3-3.1-sources.jar",
+            "id" : "SPDXRef-CommonsLangSrc",
+            "fileTypes" : [ "fileType_archive" ],
+            "checksums" : [ {
+              "algorithm" : "checksumAlgorithm_sha1",
+              "value" : "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
+            } ],
+            "licenseConcluded" : "Apache-2.0",
+            "licenseInfoFromFiles" : [ "Apache-2.0" ],
+            "licenseComments" : null,
+            "copyrightText" : "Copyright 2001-2011 The Apache Software Foundation",
+            "artifactOf" : [ {
+              "name" : "Apache Commons Lang",
+              "homePage" : "http://commons.apache.org/proper/commons-lang/",
+              "projectUri" : null
+            } ],
+            "comment" : "This file is used by Jena",
+            "noticeText" : "Apache Commons Lang\nCopyright 2001-2011 The Apache Software Foundation\n\nThis product includes software developed by\nThe Apache Software Foundation (http://www.apache.org/).\n\nThis product includes software from the Spring Framework,\nunder the Apache License 2.0 (see: StringUtils.containsWhitespace())",
+            "fileContributors" : [ "Apache Software Foundation" ],
+            "fileDependencies" : [ ],
+            "annotations" : [ ],
+            "relationships" : [ ],
+            "sha1" : "c2b4e1c67a2d28fced849ee1bb76e7391b93f125",
+            "copyright" : "Copyright 2001-2011 The Apache Software Foundation"
+          }
+        } ],
+        "sha1" : "85ed0817af83a24ad8da68c2b5094de69833983c"
+      }
+    } ],
+    "extractedLicenseInfos" : [ {
+      "licenseId" : "LicenseRef-4",
+      "comment" : null,
+      "name" : null,
+      "seeAlso" : [ ],
+      "extractedText" : "/*\n * (c) Copyright 2009 University of Bristol\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n*/"
+    }, {
+      "licenseId" : "LicenseRef-3",
+      "comment" : "This is tye CyperNeko License",
+      "name" : "CyberNeko License",
+      "seeAlso" : [ "http://people.apache.org/~andyc/neko/LICENSE", "http://justasample.url.com" ],
+      "extractedText" : "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions\nare met:\n\n1. Redistributions of source code must retain the above copyright\n   notice, this list of conditions and the following disclaimer. \n\n2. Redistributions in binary form must reproduce the above copyright\n   notice, this list of conditions and the following disclaimer in\n   the documentation and/or other materials provided with the\n   distribution.\n\n3. The end-user documentation included with the redistribution,\n   if any, must include the following acknowledgment:  \n     \"This product includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment may appear in the software itself,\n   if and wherever such third-party acknowledgments normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be used to endorse\n   or promote products derived from this software without prior \n   written permission. For written permission, please contact \n   andyc@cyberneko.net.\n\n5. Products derived from this software may not be called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\nBE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+    }, {
+      "licenseId" : "LicenseRef-Beerware-4.2",
+      "comment" : null,
+      "name" : null,
+      "seeAlso" : [ ],
+      "extractedText" : "\"THE BEER-WARE LICENSE\" (Revision 42):\nphk@FreeBSD.ORG wrote this file. As long as you retain this notice you\ncan do whatever you want with this stuff. If we meet some day, and you think this stuff is worth it, you can buy me a beer in return Poul-Henning Kamp  </\nLicenseName: Beer-Ware License (Version 42)\nLicenseCrossReference:  http://people.freebsd.org/~phk/\nLicenseComment: \nThe beerware license has a couple of other standard variants."
+    }, {
+      "licenseId" : "LicenseRef-2",
+      "comment" : null,
+      "name" : null,
+      "seeAlso" : [ ],
+      "extractedText" : "This package includes the GRDDL parser developed by Hewlett Packard under the following license:\n� Copyright 2007 Hewlett-Packard Development Company, LP\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: \n\nRedistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. \nRedistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. \nThe name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+    }, {
+      "licenseId" : "LicenseRef-1",
+      "comment" : null,
+      "name" : null,
+      "seeAlso" : [ ],
+      "extractedText" : "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n*/"
+    } ],
+    "annotations" : [ {
+      "annotator" : "Person: Jane Doe ()",
+      "annotationDate" : "2010-01-29T18:30:22Z",
+      "annotationType" : "OTHER",
+      "comment" : "Document level annotation"
+    } ],
+    "relationships" : [ {
+      "relationshipType" : "CONTAINS",
+      "comment" : null,
+      "relatedSpdxElementId" : "SPDXRef-Package"
+    }, {
+      "relationshipType" : "DESCRIBES",
+      "comment" : null,
+      "relatedSpdxElementId" : "SPDXRef-File"
+    }, {
+      "relationshipType" : "COPY_OF",
+      "comment" : null,
+      "relatedSpdxElementId" : "DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement"
+    }, {
+      "relationshipType" : "DESCRIBES",
+      "comment" : null,
+      "relatedSpdxElementId" : "SPDXRef-Package"
+    } ],
+    "reviewers" : [ {
+      "reviewer" : "Person: Suzanne Reviewer",
+      "reviewDate" : "2011-03-13T00:00:00Z",
+      "comment" : "Another example reviewer."
+    }, {
+      "reviewer" : "Person: Joe Reviewer",
+      "reviewDate" : "2010-02-10T00:00:00Z",
+      "comment" : "This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses"
+    } ]
+  }
+}

--- a/examples/SPDXTagExample-v2.0.spdx
+++ b/examples/SPDXTagExample-v2.0.spdx
@@ -1,0 +1,315 @@
+SPDXVersion: SPDX-2.0
+DataLicense: CC0-1.0
+DocumentNamespace: http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301
+DocumentName: SPDX-Tools-v2.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentComment: <text>This document was created using SPDX 2.0 using licenses from the web site.</text>
+
+## External Document References
+ExternalDocumentRef: DocumentRef-spdx-tool-1.2 http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301 SHA1: d6a770ba38583ed4bb4525bd96e50461655d2759
+## Creation Information
+Creator: Tool: LicenseFind-1.0
+Creator: Organization: ExampleCodeInspect ()
+Creator: Person: Jane Doe ()
+Created: 2010-01-29T18:30:22Z
+CreatorComment: <text>This package has been shipped in source and binary form.
+The binaries were created with gcc 4.5.1 and expect to link to
+compatible system run time libraries.</text>
+LicenseListVersion: 1.19
+## Annotations
+Annotator: Person: Jane Doe ()
+AnnotationDate: 2010-01-29T18:30:22Z
+AnnotationComment: <text>Document level annotation</text>
+AnnotationType: OTHER
+SPDXREF: SPDXRef-DOCUMENT
+## Relationships
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-File
+Relationship: SPDXRef-DOCUMENT COPY_OF DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement
+Relationship: SPDXRef-DOCUMENT CONTAINS SPDXRef-Package
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package
+
+FileName: ./package/foo.c
+SPDXID: SPDXRef-File
+FileComment: <text>The concluded license was taken from the package level that the file was included in.
+This information was found in the COPYING.txt file in the xyz directory.</text>
+FileType: SOURCE
+FileChecksum: MD5: 624c1abb3664f4b35547e7c73864ad24
+FileChecksum: SHA1: d6a770ba38583ed4bb4525bd96e50461655d2758
+LicenseConcluded: (LGPL-2.0 OR LicenseRef-2)
+LicenseInfoInFile: LicenseRef-2
+LicenseInfoInFile: GPL-2.0
+LicenseComments: The concluded license was taken from the package level that the file was included in.
+FileCopyrightText: <text>Copyright 2008-2010 John Smith</text>
+ArtifactOfProjectName: Jena
+ArtifactOfProjectHomePage: http://www.openjena.org/
+ArtifactOfProjectURI: http://subversion.apache.org/doap.rdf
+FileNotice: <text>Copyright (c) 2001 Aaron Lehmann aaroni@vitelus.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the �Software�), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED �AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</text>
+FileContributor: The Regents of the University of California
+FileContributor: Modified by Paul Mundt lethal@linux-sh.org
+FileContributor: IBM Corporation
+## Annotations
+Annotator: Person: File Commenter
+AnnotationDate: 2011-01-29T18:30:22Z
+AnnotationComment: <text>File level annotation</text>
+AnnotationType: OTHER
+SPDXREF: SPDXRef-File
+## Package Information
+PackageName: glibc
+SPDXID: SPDXRef-Package
+PackageVersion: 2.11.1
+PackageFileName: glibc-2.11.1.tar.gz
+PackageSupplier: Person: Jane Doe (jane.doe@example.com)
+PackageOriginator: Organization: ExampleCodeInspect (contact@example.com)
+PackageDownloadLocation: http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz
+PackageVerificationCode: d6a770ba38583ed4bb4525bd96e50461655d2758 (excludes: ./package.spdx)
+PackageChecksum: SHA1: 85ed0817af83a24ad8da68c2b5094de69833983c
+PackageChecksum: SHA256: 11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd
+PackageChecksum: MD5: 624c1abb3664f4b35547e7c73864ad24
+PackageHomePage: http://ftp.gnu.org/gnu/glibc
+PackageSourceInfo: <text>uses glibc-2_11-branch from git://sourceware.org/git/glibc.git.</text>
+PackageLicenseConcluded: (LicenseRef-3 OR LGPL-2.0)
+## License information from files
+PackageLicenseInfoFromFiles: GPL-2.0
+PackageLicenseInfoFromFiles: LicenseRef-1
+PackageLicenseInfoFromFiles: LicenseRef-2
+PackageLicenseDeclared: (LicenseRef-3 AND LGPL-2.0)
+PackageLicenseComments: <text>The license for this project changed with the release of version x.y.  The version of the project included here post-dates the license change.</text>
+PackageCopyrightText: <text>Copyright 2008-2010 John Smith</text>
+PackageSummary: <text>GNU C library.</text>
+PackageDescription: <text>The GNU C Library defines functions that are specified by the ISO C standard, as well as additional features specific to POSIX and other derivatives of the Unix operating system, and extensions specific to GNU systems.</text>
+## External references
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*
+ExternalRef: OTHER LocationRef-acmeforge acmecorp/acmenator/4.1.3-alpha
+ExternalRefComment: This is the external ref for Acme
+## Annotations
+Annotator: Person: Package Commenter
+AnnotationDate: 2011-01-29T18:30:22Z
+AnnotationComment: <text>Package level annotation</text>
+AnnotationType: OTHER
+SPDXREF: SPDXRef-Package
+## Relationships
+Relationship: SPDXRef-Package CONTAINS SPDXRef-JenaLib
+Relationship: SPDXRef-Package DYNAMIC_LINK SPDXRef-Saxon
+
+## File Information
+FileName: ./lib-source/commons-lang3-3.1-sources.jar
+SPDXID: SPDXRef-CommonsLangSrc
+FileComment: <text>This file is used by Jena</text>
+FileType: ARCHIVE
+FileChecksum: SHA1: c2b4e1c67a2d28fced849ee1bb76e7391b93f125
+LicenseConcluded: Apache-2.0
+LicenseInfoInFile: Apache-2.0
+FileCopyrightText: <text>Copyright 2001-2011 The Apache Software Foundation</text>
+ArtifactOfProjectName: Apache Commons Lang
+ArtifactOfProjectHomePage: http://commons.apache.org/proper/commons-lang/
+FileNotice: <text>Apache Commons Lang
+Copyright 2001-2011 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+
+This product includes software from the Spring Framework,
+under the Apache License 2.0 (see: StringUtils.containsWhitespace())</text>
+FileContributor: Apache Software Foundation
+
+FileName: ./lib-source/jena-2.6.3-sources.jar
+SPDXID: SPDXRef-JenaLib
+FileComment: <text>This file belongs to Jena</text>
+FileType: ARCHIVE
+FileChecksum: SHA1: 3ab4e1c67a2d28fced849ee1bb76e7391b93f125
+LicenseConcluded: LicenseRef-1
+LicenseInfoInFile: LicenseRef-1
+LicenseComments: This license is used by Jena
+FileCopyrightText: <text>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</text>
+ArtifactOfProjectName: Jena
+ArtifactOfProjectHomePage: http://www.openjena.org/
+FileContributor: Hewlett Packard Inc.
+FileContributor: Apache Software Foundation
+FileDependency: ./lib-source/commons-lang3-3.1-sources.jar
+## Relationships
+Relationship: SPDXRef-JenaLib DYNAMIC_LINK SPDXRef-Package
+
+FileName: ./src/org/spdx/parser/DOAPProject.java
+SPDXID: SPDXRef-DoapSource
+FileType: SOURCE
+FileChecksum: SHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+LicenseConcluded: Apache-2.0
+LicenseInfoInFile: Apache-2.0
+FileCopyrightText: <text>Copyright 2010, 2011 Source Auditor Inc.</text>
+FileContributor: Open Logic Inc.
+FileContributor: Black Duck Software In.c
+FileContributor: Source Auditor Inc.
+FileContributor: SPDX Technical Team Members
+FileContributor: Protecode Inc.
+FileDependency: ./lib-source/jena-2.6.3-sources.jar
+FileDependency: ./lib-source/commons-lang3-3.1-sources.jar
+
+## Snippet
+SnippetSPDXID: SPDXRef-Snippet
+SnippetFromFileSPDXID: SPDXRef-DoapSource
+SnippetByteRange: 310:420
+SnippetLineRange: 5:23
+SnippetLicenseConcluded: GPL-2.0
+SnippetLicenseComments: <text>
+The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.
+</text>
+SnippetCopyrightText: <text> Copyright 2008-2010 John Smith </text>
+SnippetComment: <text>
+This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0.
+</text>
+SnippetName: from linux kernel
+LicenseInfoInSnippet: GPL-2.0
+
+## Package Without Files
+PackageName: Saxon
+SPDXID: SPDXRef-Saxon
+PackageVersion: 8.8
+PackageFileName: saxonB-8.8.zip
+PackageDownloadLocation: https://sourceforge.net/projects/saxon/files/Saxon-B/8.8.0.7/saxonb8-8-0-7j.zip/download
+PackageChecksum: SHA1: 85ed0817af83a24ad8da68c2b5094de69833983c
+PackageHomePage: http://saxon.sourceforge.net/
+PackageLicenseConcluded: MPL-1.0
+PackageLicenseDeclared: MPL-1.0
+PackageLicenseComments: <text>Other versions available for a commercial license</text>
+PackageDescription: <text>The Saxon package is a collection of tools for processing XML documents.</text>
+FilesAnalyzed: false
+
+## License Information
+LicenseID: LicenseRef-3
+ExtractedText: <text>The CyberNeko Software License, Version 1.0
+
+ 
+(C) Copyright 2002-2005, Andy Clark.  All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The end-user documentation included with the redistribution,
+   if any, must include the following acknowledgment:  
+     "This product includes software developed by Andy Clark."
+   Alternately, this acknowledgment may appear in the software itself,
+   if and wherever such third-party acknowledgments normally appear.
+
+4. The names "CyberNeko" and "NekoHTML" must not be used to endorse
+   or promote products derived from this software without prior 
+   written permission. For written permission, please contact 
+   andyc@cyberneko.net.
+
+5. Products derived from this software may not be called "CyberNeko",
+   nor may "CyberNeko" appear in their name, without prior written
+   permission of the author.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</text>
+LicenseName: CyberNeko License
+LicenseCrossReference: http://people.apache.org/~andyc/neko/LICENSE, http://justasample.url.com
+LicenseComment: <text>This is tye CyperNeko License</text>
+
+LicenseID: LicenseRef-4
+ExtractedText: <text>/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/</text>
+
+LicenseID: LicenseRef-Beerware-4.2
+ExtractedText: <text>"THE BEER-WARE LICENSE" (Revision 42):
+phk@FreeBSD.ORG wrote this file. As long as you retain this notice you
+can do whatever you want with this stuff. If we meet some day, and you think this stuff is worth it, you can buy me a beer in return Poul-Henning Kamp  </
+LicenseName: Beer-Ware License (Version 42)
+LicenseCrossReference:  http://people.freebsd.org/~phk/
+LicenseComment: 
+The beerware license has a couple of other standard variants.</text>
+
+LicenseID: LicenseRef-1
+ExtractedText: <text>/*
+ * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/</text>
+
+LicenseID: LicenseRef-2
+ExtractedText: <text>This package includes the GRDDL parser developed by Hewlett Packard under the following license:
+� Copyright 2007 Hewlett-Packard Development Company, LP
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. 
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</text>
+
+## Review Information
+Reviewer: Person: Suzanne Reviewer
+ReviewDate: 2011-03-13T00:00:00Z
+ReviewComment: <text>Another example reviewer.</text>
+
+Reviewer: Person: Joe Reviewer
+ReviewDate: 2010-02-10T00:00:00Z
+ReviewComment: <text>This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses</text>
+

--- a/examples/SPDXXMLExample-v2.0.xml
+++ b/examples/SPDXXMLExample-v2.0.xml
@@ -1,0 +1,143 @@
+<SpdxDocument><Document><specVersion>SPDX-2.0</specVersion><creationInfo><creators>Person: Jane Doe ()</creators><creators>Tool: LicenseFind-1.0</creators><creators>Organization: ExampleCodeInspect ()</creators><comment>This package has been shipped in source and binary form.
+The binaries were created with gcc 4.5.1 and expect to link to
+compatible system run time libraries.</comment><licenseListVersion>1.19</licenseListVersion><created>2010-01-29T18:30:22Z</created></creationInfo><spdxVersion>SPDX-2.0</spdxVersion><dataLicense>CC0-1.0</dataLicense><id>SPDXRef-DOCUMENT</id><name>SPDX-Tools-v2.0</name><comment>This document was created using SPDX 2.0 using licenses from the web site.</comment><externalDocumentRefs><checksum><algorithm>checksumAlgorithm_sha1</algorithm><value>d6a770ba38583ed4bb4525bd96e50461655d2759</value></checksum><spdxDocumentNamespace>http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301</spdxDocumentNamespace><externalDocumentId>DocumentRef-spdx-tool-1.2</externalDocumentId></externalDocumentRefs><documentDescribes><File><name>./package/foo.c</name><id>SPDXRef-File</id><fileTypes>fileType_source</fileTypes><checksums><algorithm>checksumAlgorithm_md5</algorithm><value>624c1abb3664f4b35547e7c73864ad24</value></checksums><checksums><algorithm>checksumAlgorithm_sha1</algorithm><value>d6a770ba38583ed4bb4525bd96e50461655d2758</value></checksums><licenseConcluded>(LGPL-2.0 OR LicenseRef-2)</licenseConcluded><licenseInfoFromFiles>LicenseRef-2</licenseInfoFromFiles><licenseInfoFromFiles>GPL-2.0</licenseInfoFromFiles><licenseComments>The concluded license was taken from the package level that the file was included in.</licenseComments><copyrightText>Copyright 2008-2010 John Smith</copyrightText><artifactOf><name>Jena</name><homePage>http://www.openjena.org/</homePage><projectUri>http://subversion.apache.org/doap.rdf</projectUri></artifactOf><comment>The concluded license was taken from the package level that the file was included in.
+This information was found in the COPYING.txt file in the xyz directory.</comment><noticeText>Copyright (c) 2001 Aaron Lehmann aaroni@vitelus.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the �Software�), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED �AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</noticeText><fileContributors>The Regents of the University of California</fileContributors><fileContributors>Modified by Paul Mundt lethal@linux-sh.org</fileContributors><fileContributors>IBM Corporation</fileContributors><annotations><annotator>Person: File Commenter</annotator><annotationDate>2011-01-29T18:30:22Z</annotationDate><annotationType>OTHER</annotationType><comment>File level annotation</comment></annotations><sha1>d6a770ba38583ed4bb4525bd96e50461655d2758</sha1><copyright>Copyright 2008-2010 John Smith</copyright></File></documentDescribes><documentDescribes><Package><name>glibc</name><id>SPDXRef-Package</id><versionInfo>2.11.1</versionInfo><packageFileName>glibc-2.11.1.tar.gz</packageFileName><supplier>Person: Jane Doe (jane.doe@example.com)</supplier><originator>Organization: ExampleCodeInspect (contact@example.com)</originator><downloadLocation>http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz</downloadLocation><filesAnalyzed>true</filesAnalyzed><packageVerificationCode><value>d6a770ba38583ed4bb4525bd96e50461655d2758</value><excludedFileNames>excludes: ./package.spdx</excludedFileNames></packageVerificationCode><checksums><algorithm>checksumAlgorithm_sha1</algorithm><value>85ed0817af83a24ad8da68c2b5094de69833983c</value></checksums><checksums><algorithm>checksumAlgorithm_sha256</algorithm><value>11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd</value></checksums><checksums><algorithm>checksumAlgorithm_md5</algorithm><value>624c1abb3664f4b35547e7c73864ad24</value></checksums><homepage>http://ftp.gnu.org/gnu/glibc</homepage><sourceInfo>uses glibc-2_11-branch from git://sourceware.org/git/glibc.git.</sourceInfo><licenseConcluded>(LicenseRef-3 OR LGPL-2.0)</licenseConcluded><licenseInfoFromFiles>GPL-2.0</licenseInfoFromFiles><licenseInfoFromFiles>LicenseRef-1</licenseInfoFromFiles><licenseInfoFromFiles>LicenseRef-2</licenseInfoFromFiles><licenseDeclared>(LicenseRef-3 AND LGPL-2.0)</licenseDeclared><licenseComments>The license for this project changed with the release of version x.y.  The version of the project included here post-dates the license change.</licenseComments><copyrightText>Copyright 2008-2010 John Smith</copyrightText><summary>GNU C library.</summary><description>The GNU C Library defines functions that are specified by the ISO C standard, as well as additional features specific to POSIX and other derivatives of the Unix operating system, and extensions specific to GNU systems.</description><comment/><externalRefs><referenceCategory>referenceCategory_other</referenceCategory><referenceType><referenceTypeUri>http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge</referenceTypeUri></referenceType><referenceLocator>acmecorp/acmenator/4.1.3-alpha</referenceLocator><comment>This is the external ref for Acme</comment></externalRefs><externalRefs><referenceCategory>referenceCategory_security</referenceCategory><referenceType><referenceTypeUri>http://spdx.org/rdf/references/cpe23Type</referenceTypeUri></referenceType><referenceLocator>cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*</referenceLocator><comment/></externalRefs><annotations><annotator>Person: Package Commenter</annotator><annotationDate>2011-01-29T18:30:22Z</annotationDate><annotationType>OTHER</annotationType><comment>Package level annotation</comment></annotations><relationships><relationshipType>DYNAMIC_LINK</relationshipType><comment/><relatedSpdxElementId>SPDXRef-Saxon</relatedSpdxElementId></relationships><relationships><relationshipType>CONTAINS</relationshipType><comment/><relatedSpdxElementId>SPDXRef-JenaLib</relatedSpdxElementId></relationships><files><File><name>./src/org/spdx/parser/DOAPProject.java</name><id>SPDXRef-DoapSource</id><fileTypes>fileType_source</fileTypes><checksums><algorithm>checksumAlgorithm_sha1</algorithm><value>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</value></checksums><licenseConcluded>Apache-2.0</licenseConcluded><licenseInfoFromFiles>Apache-2.0</licenseInfoFromFiles><licenseComments/><copyrightText>Copyright 2010, 2011 Source Auditor Inc.</copyrightText><comment/><noticeText/><fileContributors>Open Logic Inc.</fileContributors><fileContributors>Black Duck Software In.c</fileContributors><fileContributors>Source Auditor Inc.</fileContributors><fileContributors>SPDX Technical Team Members</fileContributors><fileContributors>Protecode Inc.</fileContributors><fileDependencies><File><name>./lib-source/jena-2.6.3-sources.jar</name><id>SPDXRef-JenaLib</id><fileTypes>fileType_archive</fileTypes><checksums><algorithm>checksumAlgorithm_sha1</algorithm><value>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</value></checksums><licenseConcluded>LicenseRef-1</licenseConcluded><licenseInfoFromFiles>LicenseRef-1</licenseInfoFromFiles><licenseComments>This license is used by Jena</licenseComments><copyrightText>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</copyrightText><artifactOf><name>Jena</name><homePage>http://www.openjena.org/</homePage><projectUri/></artifactOf><comment>This file belongs to Jena</comment><noticeText/><fileContributors>Hewlett Packard Inc.</fileContributors><fileContributors>Apache Software Foundation</fileContributors><fileDependencies><File><name>./lib-source/commons-lang3-3.1-sources.jar</name><id>SPDXRef-CommonsLangSrc</id><fileTypes>fileType_archive</fileTypes><checksums><algorithm>checksumAlgorithm_sha1</algorithm><value>c2b4e1c67a2d28fced849ee1bb76e7391b93f125</value></checksums><licenseConcluded>Apache-2.0</licenseConcluded><licenseInfoFromFiles>Apache-2.0</licenseInfoFromFiles><licenseComments/><copyrightText>Copyright 2001-2011 The Apache Software Foundation</copyrightText><artifactOf><name>Apache Commons Lang</name><homePage>http://commons.apache.org/proper/commons-lang/</homePage><projectUri/></artifactOf><comment>This file is used by Jena</comment><noticeText>Apache Commons Lang
+Copyright 2001-2011 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+
+This product includes software from the Spring Framework,
+under the Apache License 2.0 (see: StringUtils.containsWhitespace())</noticeText><fileContributors>Apache Software Foundation</fileContributors><sha1>c2b4e1c67a2d28fced849ee1bb76e7391b93f125</sha1><copyright>Copyright 2001-2011 The Apache Software Foundation</copyright></File></fileDependencies><relationships><relationshipType>DYNAMIC_LINK</relationshipType><comment/><relatedSpdxElementId>SPDXRef-Package</relatedSpdxElementId></relationships><sha1>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</sha1><copyright>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</copyright></File></fileDependencies><fileDependencies><File><name>./lib-source/commons-lang3-3.1-sources.jar</name><id>SPDXRef-CommonsLangSrc</id><fileTypes>fileType_archive</fileTypes><checksums><algorithm>checksumAlgorithm_sha1</algorithm><value>c2b4e1c67a2d28fced849ee1bb76e7391b93f125</value></checksums><licenseConcluded>Apache-2.0</licenseConcluded><licenseInfoFromFiles>Apache-2.0</licenseInfoFromFiles><licenseComments/><copyrightText>Copyright 2001-2011 The Apache Software Foundation</copyrightText><artifactOf><name>Apache Commons Lang</name><homePage>http://commons.apache.org/proper/commons-lang/</homePage><projectUri/></artifactOf><comment>This file is used by Jena</comment><noticeText>Apache Commons Lang
+Copyright 2001-2011 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+
+This product includes software from the Spring Framework,
+under the Apache License 2.0 (see: StringUtils.containsWhitespace())</noticeText><fileContributors>Apache Software Foundation</fileContributors><sha1>c2b4e1c67a2d28fced849ee1bb76e7391b93f125</sha1><copyright>Copyright 2001-2011 The Apache Software Foundation</copyright></File></fileDependencies><sha1>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</sha1><copyright>Copyright 2010, 2011 Source Auditor Inc.</copyright></File></files><files><File><name>./lib-source/jena-2.6.3-sources.jar</name><id>SPDXRef-JenaLib</id><fileTypes>fileType_archive</fileTypes><checksums><algorithm>checksumAlgorithm_sha1</algorithm><value>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</value></checksums><licenseConcluded>LicenseRef-1</licenseConcluded><licenseInfoFromFiles>LicenseRef-1</licenseInfoFromFiles><licenseComments>This license is used by Jena</licenseComments><copyrightText>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</copyrightText><artifactOf><name>Jena</name><homePage>http://www.openjena.org/</homePage><projectUri/></artifactOf><comment>This file belongs to Jena</comment><noticeText/><fileContributors>Hewlett Packard Inc.</fileContributors><fileContributors>Apache Software Foundation</fileContributors><fileDependencies><File><name>./lib-source/commons-lang3-3.1-sources.jar</name><id>SPDXRef-CommonsLangSrc</id><fileTypes>fileType_archive</fileTypes><checksums><algorithm>checksumAlgorithm_sha1</algorithm><value>c2b4e1c67a2d28fced849ee1bb76e7391b93f125</value></checksums><licenseConcluded>Apache-2.0</licenseConcluded><licenseInfoFromFiles>Apache-2.0</licenseInfoFromFiles><licenseComments/><copyrightText>Copyright 2001-2011 The Apache Software Foundation</copyrightText><artifactOf><name>Apache Commons Lang</name><homePage>http://commons.apache.org/proper/commons-lang/</homePage><projectUri/></artifactOf><comment>This file is used by Jena</comment><noticeText>Apache Commons Lang
+Copyright 2001-2011 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+
+This product includes software from the Spring Framework,
+under the Apache License 2.0 (see: StringUtils.containsWhitespace())</noticeText><fileContributors>Apache Software Foundation</fileContributors><sha1>c2b4e1c67a2d28fced849ee1bb76e7391b93f125</sha1><copyright>Copyright 2001-2011 The Apache Software Foundation</copyright></File></fileDependencies><relationships><relationshipType>DYNAMIC_LINK</relationshipType><comment/><relatedSpdxElementId>SPDXRef-Package</relatedSpdxElementId></relationships><sha1>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</sha1><copyright>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</copyright></File></files><files><File><name>./lib-source/commons-lang3-3.1-sources.jar</name><id>SPDXRef-CommonsLangSrc</id><fileTypes>fileType_archive</fileTypes><checksums><algorithm>checksumAlgorithm_sha1</algorithm><value>c2b4e1c67a2d28fced849ee1bb76e7391b93f125</value></checksums><licenseConcluded>Apache-2.0</licenseConcluded><licenseInfoFromFiles>Apache-2.0</licenseInfoFromFiles><licenseComments/><copyrightText>Copyright 2001-2011 The Apache Software Foundation</copyrightText><artifactOf><name>Apache Commons Lang</name><homePage>http://commons.apache.org/proper/commons-lang/</homePage><projectUri/></artifactOf><comment>This file is used by Jena</comment><noticeText>Apache Commons Lang
+Copyright 2001-2011 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+
+This product includes software from the Spring Framework,
+under the Apache License 2.0 (see: StringUtils.containsWhitespace())</noticeText><fileContributors>Apache Software Foundation</fileContributors><sha1>c2b4e1c67a2d28fced849ee1bb76e7391b93f125</sha1><copyright>Copyright 2001-2011 The Apache Software Foundation</copyright></File></files><sha1>85ed0817af83a24ad8da68c2b5094de69833983c</sha1></Package></documentDescribes><extractedLicenseInfos><licenseId>LicenseRef-4</licenseId><comment/><name/><extractedText>/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/</extractedText></extractedLicenseInfos><extractedLicenseInfos><licenseId>LicenseRef-3</licenseId><comment>This is tye CyperNeko License</comment><name>CyberNeko License</name><seeAlso>http://people.apache.org/~andyc/neko/LICENSE</seeAlso><seeAlso>http://justasample.url.com</seeAlso><extractedText>The CyberNeko Software License, Version 1.0
+
+ 
+(C) Copyright 2002-2005, Andy Clark.  All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The end-user documentation included with the redistribution,
+   if any, must include the following acknowledgment:  
+     "This product includes software developed by Andy Clark."
+   Alternately, this acknowledgment may appear in the software itself,
+   if and wherever such third-party acknowledgments normally appear.
+
+4. The names "CyberNeko" and "NekoHTML" must not be used to endorse
+   or promote products derived from this software without prior 
+   written permission. For written permission, please contact 
+   andyc@cyberneko.net.
+
+5. Products derived from this software may not be called "CyberNeko",
+   nor may "CyberNeko" appear in their name, without prior written
+   permission of the author.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText></extractedLicenseInfos><extractedLicenseInfos><licenseId>LicenseRef-Beerware-4.2</licenseId><comment/><name/><extractedText>"THE BEER-WARE LICENSE" (Revision 42):
+phk@FreeBSD.ORG wrote this file. As long as you retain this notice you
+can do whatever you want with this stuff. If we meet some day, and you think this stuff is worth it, you can buy me a beer in return Poul-Henning Kamp  &lt;/
+LicenseName: Beer-Ware License (Version 42)
+LicenseCrossReference:  http://people.freebsd.org/~phk/
+LicenseComment: 
+The beerware license has a couple of other standard variants.</extractedText></extractedLicenseInfos><extractedLicenseInfos><licenseId>LicenseRef-2</licenseId><comment/><name/><extractedText>This package includes the GRDDL parser developed by Hewlett Packard under the following license:
+� Copyright 2007 Hewlett-Packard Development Company, LP
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. 
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText></extractedLicenseInfos><extractedLicenseInfos><licenseId>LicenseRef-1</licenseId><comment/><name/><extractedText>/*
+ * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/</extractedText></extractedLicenseInfos><annotations><annotator>Person: Jane Doe ()</annotator><annotationDate>2010-01-29T18:30:22Z</annotationDate><annotationType>OTHER</annotationType><comment>Document level annotation</comment></annotations><relationships><relationshipType>COPY_OF</relationshipType><comment/><relatedSpdxElementId>DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement</relatedSpdxElementId></relationships><relationships><relationshipType>DESCRIBES</relationshipType><comment/><relatedSpdxElementId>SPDXRef-File</relatedSpdxElementId></relationships><relationships><relationshipType>CONTAINS</relationshipType><comment/><relatedSpdxElementId>SPDXRef-Package</relatedSpdxElementId></relationships><relationships><relationshipType>DESCRIBES</relationshipType><comment/><relatedSpdxElementId>SPDXRef-Package</relatedSpdxElementId></relationships><reviewers><reviewer>Person: Joe Reviewer</reviewer><reviewDate>2010-02-10T00:00:00Z</reviewDate><comment>This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses</comment></reviewers><reviewers><reviewer>Person: Suzanne Reviewer</reviewer><reviewDate>2011-03-13T00:00:00Z</reviewDate><comment>Another example reviewer.</comment></reviewers></Document></SpdxDocument>

--- a/examples/SPDXYAMLExample-2.0.yaml
+++ b/examples/SPDXYAMLExample-2.0.yaml
@@ -1,0 +1,494 @@
+---
+Document:
+  specVersion: "SPDX-2.0"
+  creationInfo:
+    creators:
+    - "Person: Jane Doe ()"
+    - "Tool: LicenseFind-1.0"
+    - "Organization: ExampleCodeInspect ()"
+    comment: "This package has been shipped in source and binary form.\nThe binaries\
+      \ were created with gcc 4.5.1 and expect to link to\ncompatible system run time\
+      \ libraries."
+    licenseListVersion: "1.19"
+    created: "2010-01-29T18:30:22Z"
+  spdxVersion: "SPDX-2.0"
+  dataLicense: "CC0-1.0"
+  id: "SPDXRef-DOCUMENT"
+  name: "SPDX-Tools-v2.0"
+  comment: "This document was created using SPDX 2.0 using licenses from the web site."
+  externalDocumentRefs:
+  - checksum:
+      algorithm: "checksumAlgorithm_sha1"
+      value: "d6a770ba38583ed4bb4525bd96e50461655d2759"
+    spdxDocumentNamespace: "http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301"
+    externalDocumentId: "DocumentRef-spdx-tool-1.2"
+    spdxDocument: null
+  documentDescribes:
+  - File:
+      name: "./package/foo.c"
+      id: "SPDXRef-File"
+      fileTypes:
+      - "fileType_source"
+      checksums:
+      - algorithm: "checksumAlgorithm_sha1"
+        value: "d6a770ba38583ed4bb4525bd96e50461655d2758"
+      - algorithm: "checksumAlgorithm_md5"
+        value: "624c1abb3664f4b35547e7c73864ad24"
+      licenseConcluded: "(LGPL-2.0 OR LicenseRef-2)"
+      licenseInfoFromFiles:
+      - "LicenseRef-2"
+      - "GPL-2.0"
+      licenseComments: "The concluded license was taken from the package level that\
+        \ the file was included in."
+      copyrightText: "Copyright 2008-2010 John Smith"
+      artifactOf:
+      - name: "Jena"
+        homePage: "http://www.openjena.org/"
+        projectUri: "http://subversion.apache.org/doap.rdf"
+      comment: "The concluded license was taken from the package level that the file\
+        \ was included in.\nThis information was found in the COPYING.txt file in\
+        \ the xyz directory."
+      noticeText: "Copyright (c) 2001 Aaron Lehmann aaroni@vitelus.com\n\nPermission\
+        \ is hereby granted, free of charge, to any person obtaining a copy of this\
+        \ software and associated documentation files (the �Software�), to deal in\
+        \ the Software without restriction, including without limitation the rights\
+        \ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\
+        \ copies of the Software, and to permit persons to whom the Software is furnished\
+        \ to do so, subject to the following conditions: \nThe above copyright notice\
+        \ and this permission notice shall be included in all copies or substantial\
+        \ portions of the Software.\n\nTHE SOFTWARE IS PROVIDED �AS IS', WITHOUT WARRANTY\
+        \ OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES\
+        \ OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.\
+        \  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,\
+        \ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,\
+        \ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\
+        \ DEALINGS IN THE SOFTWARE."
+      fileContributors:
+      - "The Regents of the University of California"
+      - "Modified by Paul Mundt lethal@linux-sh.org"
+      - "IBM Corporation"
+      fileDependencies: []
+      annotations:
+      - annotator: "Person: File Commenter"
+        annotationDate: "2011-01-29T18:30:22Z"
+        annotationType: "OTHER"
+        comment: "File level annotation"
+      relationships: []
+      copyright: "Copyright 2008-2010 John Smith"
+      sha1: "d6a770ba38583ed4bb4525bd96e50461655d2758"
+  - Package:
+      name: "glibc"
+      id: "SPDXRef-Package"
+      versionInfo: "2.11.1"
+      packageFileName: "glibc-2.11.1.tar.gz"
+      supplier: "Person: Jane Doe (jane.doe@example.com)"
+      originator: "Organization: ExampleCodeInspect (contact@example.com)"
+      downloadLocation: "http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz"
+      filesAnalyzed: true
+      packageVerificationCode:
+        value: "d6a770ba38583ed4bb4525bd96e50461655d2758"
+        excludedFileNames:
+        - "excludes: ./package.spdx"
+      checksums:
+      - algorithm: "checksumAlgorithm_md5"
+        value: "624c1abb3664f4b35547e7c73864ad24"
+      - algorithm: "checksumAlgorithm_sha256"
+        value: "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
+      - algorithm: "checksumAlgorithm_sha1"
+        value: "85ed0817af83a24ad8da68c2b5094de69833983c"
+      homepage: "http://ftp.gnu.org/gnu/glibc"
+      sourceInfo: "uses glibc-2_11-branch from git://sourceware.org/git/glibc.git."
+      licenseConcluded: "(LicenseRef-3 OR LGPL-2.0)"
+      licenseInfoFromFiles:
+      - "GPL-2.0"
+      - "LicenseRef-1"
+      - "LicenseRef-2"
+      licenseDeclared: "(LicenseRef-3 AND LGPL-2.0)"
+      licenseComments: "The license for this project changed with the release of version\
+        \ x.y.  The version of the project included here post-dates the license change."
+      copyrightText: "Copyright 2008-2010 John Smith"
+      summary: "GNU C library."
+      description: "The GNU C Library defines functions that are specified by the\
+        \ ISO C standard, as well as additional features specific to POSIX and other\
+        \ derivatives of the Unix operating system, and extensions specific to GNU\
+        \ systems."
+      comment: null
+      externalRefs:
+      - referenceCategory: "referenceCategory_security"
+        referenceType:
+          referenceTypeUri: "http://spdx.org/rdf/references/cpe23Type"
+        referenceLocator: "cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*"
+        comment: null
+      - referenceCategory: "referenceCategory_other"
+        referenceType:
+          referenceTypeUri: "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge"
+        referenceLocator: "acmecorp/acmenator/4.1.3-alpha"
+        comment: "This is the external ref for Acme"
+      annotations:
+      - annotator: "Person: Package Commenter"
+        annotationDate: "2011-01-29T18:30:22Z"
+        annotationType: "OTHER"
+        comment: "Package level annotation"
+      relationships:
+      - relationshipType: "CONTAINS"
+        comment: null
+        relatedSpdxElementId: "SPDXRef-JenaLib"
+      - relationshipType: "DYNAMIC_LINK"
+        comment: null
+        relatedSpdxElementId: "SPDXRef-Saxon"
+      files:
+      - File:
+          name: "./src/org/spdx/parser/DOAPProject.java"
+          id: "SPDXRef-DoapSource"
+          fileTypes:
+          - "fileType_source"
+          checksums:
+          - algorithm: "checksumAlgorithm_sha1"
+            value: "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+          licenseConcluded: "Apache-2.0"
+          licenseInfoFromFiles:
+          - "Apache-2.0"
+          licenseComments: null
+          copyrightText: "Copyright 2010, 2011 Source Auditor Inc."
+          artifactOf: []
+          comment: null
+          noticeText: null
+          fileContributors:
+          - "Open Logic Inc."
+          - "Black Duck Software In.c"
+          - "Source Auditor Inc."
+          - "SPDX Technical Team Members"
+          - "Protecode Inc."
+          fileDependencies:
+          - File:
+              name: "./lib-source/jena-2.6.3-sources.jar"
+              id: "SPDXRef-JenaLib"
+              fileTypes:
+              - "fileType_archive"
+              checksums:
+              - algorithm: "checksumAlgorithm_sha1"
+                value: "3ab4e1c67a2d28fced849ee1bb76e7391b93f125"
+              licenseConcluded: "LicenseRef-1"
+              licenseInfoFromFiles:
+              - "LicenseRef-1"
+              licenseComments: "This license is used by Jena"
+              copyrightText: "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006,\
+                \ 2007, 2008, 2009 Hewlett-Packard Development Company, LP"
+              artifactOf:
+              - name: "Jena"
+                homePage: "http://www.openjena.org/"
+                projectUri: null
+              comment: "This file belongs to Jena"
+              noticeText: null
+              fileContributors:
+              - "Hewlett Packard Inc."
+              - "Apache Software Foundation"
+              fileDependencies:
+              - File:
+                  name: "./lib-source/commons-lang3-3.1-sources.jar"
+                  id: "SPDXRef-CommonsLangSrc"
+                  fileTypes:
+                  - "fileType_archive"
+                  checksums:
+                  - algorithm: "checksumAlgorithm_sha1"
+                    value: "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
+                  licenseConcluded: "Apache-2.0"
+                  licenseInfoFromFiles:
+                  - "Apache-2.0"
+                  licenseComments: null
+                  copyrightText: "Copyright 2001-2011 The Apache Software Foundation"
+                  artifactOf:
+                  - name: "Apache Commons Lang"
+                    homePage: "http://commons.apache.org/proper/commons-lang/"
+                    projectUri: null
+                  comment: "This file is used by Jena"
+                  noticeText: "Apache Commons Lang\nCopyright 2001-2011 The Apache\
+                    \ Software Foundation\n\nThis product includes software developed\
+                    \ by\nThe Apache Software Foundation (http://www.apache.org/).\n\
+                    \nThis product includes software from the Spring Framework,\n\
+                    under the Apache License 2.0 (see: StringUtils.containsWhitespace())"
+                  fileContributors:
+                  - "Apache Software Foundation"
+                  fileDependencies: []
+                  annotations: []
+                  relationships: []
+                  copyright: "Copyright 2001-2011 The Apache Software Foundation"
+                  sha1: "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
+              annotations: []
+              relationships:
+              - relationshipType: "DYNAMIC_LINK"
+                comment: null
+                relatedSpdxElementId: "SPDXRef-Package"
+              copyright: "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006,\
+                \ 2007, 2008, 2009 Hewlett-Packard Development Company, LP"
+              sha1: "3ab4e1c67a2d28fced849ee1bb76e7391b93f125"
+          - File:
+              name: "./lib-source/commons-lang3-3.1-sources.jar"
+              id: "SPDXRef-CommonsLangSrc"
+              fileTypes:
+              - "fileType_archive"
+              checksums:
+              - algorithm: "checksumAlgorithm_sha1"
+                value: "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
+              licenseConcluded: "Apache-2.0"
+              licenseInfoFromFiles:
+              - "Apache-2.0"
+              licenseComments: null
+              copyrightText: "Copyright 2001-2011 The Apache Software Foundation"
+              artifactOf:
+              - name: "Apache Commons Lang"
+                homePage: "http://commons.apache.org/proper/commons-lang/"
+                projectUri: null
+              comment: "This file is used by Jena"
+              noticeText: "Apache Commons Lang\nCopyright 2001-2011 The Apache Software\
+                \ Foundation\n\nThis product includes software developed by\nThe Apache\
+                \ Software Foundation (http://www.apache.org/).\n\nThis product includes\
+                \ software from the Spring Framework,\nunder the Apache License 2.0\
+                \ (see: StringUtils.containsWhitespace())"
+              fileContributors:
+              - "Apache Software Foundation"
+              fileDependencies: []
+              annotations: []
+              relationships: []
+              copyright: "Copyright 2001-2011 The Apache Software Foundation"
+              sha1: "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
+          annotations: []
+          relationships: []
+          copyright: "Copyright 2010, 2011 Source Auditor Inc."
+          sha1: "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+      - File:
+          name: "./lib-source/jena-2.6.3-sources.jar"
+          id: "SPDXRef-JenaLib"
+          fileTypes:
+          - "fileType_archive"
+          checksums:
+          - algorithm: "checksumAlgorithm_sha1"
+            value: "3ab4e1c67a2d28fced849ee1bb76e7391b93f125"
+          licenseConcluded: "LicenseRef-1"
+          licenseInfoFromFiles:
+          - "LicenseRef-1"
+          licenseComments: "This license is used by Jena"
+          copyrightText: "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006,\
+            \ 2007, 2008, 2009 Hewlett-Packard Development Company, LP"
+          artifactOf:
+          - name: "Jena"
+            homePage: "http://www.openjena.org/"
+            projectUri: null
+          comment: "This file belongs to Jena"
+          noticeText: null
+          fileContributors:
+          - "Hewlett Packard Inc."
+          - "Apache Software Foundation"
+          fileDependencies:
+          - File:
+              name: "./lib-source/commons-lang3-3.1-sources.jar"
+              id: "SPDXRef-CommonsLangSrc"
+              fileTypes:
+              - "fileType_archive"
+              checksums:
+              - algorithm: "checksumAlgorithm_sha1"
+                value: "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
+              licenseConcluded: "Apache-2.0"
+              licenseInfoFromFiles:
+              - "Apache-2.0"
+              licenseComments: null
+              copyrightText: "Copyright 2001-2011 The Apache Software Foundation"
+              artifactOf:
+              - name: "Apache Commons Lang"
+                homePage: "http://commons.apache.org/proper/commons-lang/"
+                projectUri: null
+              comment: "This file is used by Jena"
+              noticeText: "Apache Commons Lang\nCopyright 2001-2011 The Apache Software\
+                \ Foundation\n\nThis product includes software developed by\nThe Apache\
+                \ Software Foundation (http://www.apache.org/).\n\nThis product includes\
+                \ software from the Spring Framework,\nunder the Apache License 2.0\
+                \ (see: StringUtils.containsWhitespace())"
+              fileContributors:
+              - "Apache Software Foundation"
+              fileDependencies: []
+              annotations: []
+              relationships: []
+              copyright: "Copyright 2001-2011 The Apache Software Foundation"
+              sha1: "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
+          annotations: []
+          relationships:
+          - relationshipType: "DYNAMIC_LINK"
+            comment: null
+            relatedSpdxElementId: "SPDXRef-Package"
+          copyright: "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007,\
+            \ 2008, 2009 Hewlett-Packard Development Company, LP"
+          sha1: "3ab4e1c67a2d28fced849ee1bb76e7391b93f125"
+      - File:
+          name: "./lib-source/commons-lang3-3.1-sources.jar"
+          id: "SPDXRef-CommonsLangSrc"
+          fileTypes:
+          - "fileType_archive"
+          checksums:
+          - algorithm: "checksumAlgorithm_sha1"
+            value: "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
+          licenseConcluded: "Apache-2.0"
+          licenseInfoFromFiles:
+          - "Apache-2.0"
+          licenseComments: null
+          copyrightText: "Copyright 2001-2011 The Apache Software Foundation"
+          artifactOf:
+          - name: "Apache Commons Lang"
+            homePage: "http://commons.apache.org/proper/commons-lang/"
+            projectUri: null
+          comment: "This file is used by Jena"
+          noticeText: "Apache Commons Lang\nCopyright 2001-2011 The Apache Software\
+            \ Foundation\n\nThis product includes software developed by\nThe Apache\
+            \ Software Foundation (http://www.apache.org/).\n\nThis product includes\
+            \ software from the Spring Framework,\nunder the Apache License 2.0 (see:\
+            \ StringUtils.containsWhitespace())"
+          fileContributors:
+          - "Apache Software Foundation"
+          fileDependencies: []
+          annotations: []
+          relationships: []
+          copyright: "Copyright 2001-2011 The Apache Software Foundation"
+          sha1: "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
+      sha1: "85ed0817af83a24ad8da68c2b5094de69833983c"
+  extractedLicenseInfos:
+  - licenseId: "LicenseRef-4"
+    comment: null
+    name: null
+    seeAlso: []
+    extractedText: "/*\n * (c) Copyright 2009 University of Bristol\n * All rights\
+      \ reserved.\n *\n * Redistribution and use in source and binary forms, with\
+      \ or without\n * modification, are permitted provided that the following conditions\n\
+      \ * are met:\n * 1. Redistributions of source code must retain the above copyright\n\
+      \ *    notice, this list of conditions and the following disclaimer.\n * 2.\
+      \ Redistributions in binary form must reproduce the above copyright\n *    notice,\
+      \ this list of conditions and the following disclaimer in the\n *    documentation\
+      \ and/or other materials provided with the distribution.\n * 3. The name of\
+      \ the author may not be used to endorse or promote products\n *    derived from\
+      \ this software without specific prior written permission.\n *\n * THIS SOFTWARE\
+      \ IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES,\
+      \ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY\
+      \ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL\
+      \ THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY,\
+      \ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF\
+      \ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS\
+      \ INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN\
+      \ CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE)\
+      \ ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF\
+      \ THE POSSIBILITY OF SUCH DAMAGE.\n*/"
+  - licenseId: "LicenseRef-3"
+    comment: "This is tye CyperNeko License"
+    name: "CyberNeko License"
+    seeAlso:
+    - "http://people.apache.org/~andyc/neko/LICENSE"
+    - "http://justasample.url.com"
+    extractedText: "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright\
+      \ 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in\
+      \ source and binary forms, with or without\nmodification, are permitted provided\
+      \ that the following conditions\nare met:\n\n1. Redistributions of source code\
+      \ must retain the above copyright\n   notice, this list of conditions and the\
+      \ following disclaimer. \n\n2. Redistributions in binary form must reproduce\
+      \ the above copyright\n   notice, this list of conditions and the following\
+      \ disclaimer in\n   the documentation and/or other materials provided with the\n\
+      \   distribution.\n\n3. The end-user documentation included with the redistribution,\n\
+      \   if any, must include the following acknowledgment:  \n     \"This product\
+      \ includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment\
+      \ may appear in the software itself,\n   if and wherever such third-party acknowledgments\
+      \ normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be\
+      \ used to endorse\n   or promote products derived from this software without\
+      \ prior \n   written permission. For written permission, please contact \n \
+      \  andyc@cyberneko.net.\n\n5. Products derived from this software may not be\
+      \ called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without\
+      \ prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS\
+      \ IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED\
+      \ TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR\
+      \ PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\n\
+      BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL\
+      \ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS\
+      \ OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER\
+      \ CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY,\
+      \ OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE\
+      \ USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+  - licenseId: "LicenseRef-Beerware-4.2"
+    comment: null
+    name: null
+    seeAlso: []
+    extractedText: "\"THE BEER-WARE LICENSE\" (Revision 42):\nphk@FreeBSD.ORG wrote\
+      \ this file. As long as you retain this notice you\ncan do whatever you want\
+      \ with this stuff. If we meet some day, and you think this stuff is worth it,\
+      \ you can buy me a beer in return Poul-Henning Kamp  </\nLicenseName: Beer-Ware\
+      \ License (Version 42)\nLicenseCrossReference:  http://people.freebsd.org/~phk/\n\
+      LicenseComment: \nThe beerware license has a couple of other standard variants."
+  - licenseId: "LicenseRef-2"
+    comment: null
+    name: null
+    seeAlso: []
+    extractedText: "This package includes the GRDDL parser developed by Hewlett Packard\
+      \ under the following license:\n� Copyright 2007 Hewlett-Packard Development\
+      \ Company, LP\n\nRedistribution and use in source and binary forms, with or\
+      \ without modification, are permitted provided that the following conditions\
+      \ are met: \n\nRedistributions of source code must retain the above copyright\
+      \ notice, this list of conditions and the following disclaimer. \nRedistributions\
+      \ in binary form must reproduce the above copyright notice, this list of conditions\
+      \ and the following disclaimer in the documentation and/or other materials provided\
+      \ with the distribution. \nThe name of the author may not be used to endorse\
+      \ or promote products derived from this software without specific prior written\
+      \ permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS\
+      \ OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\
+      \ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN\
+      \ NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\
+      \ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,\
+      \ PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;\
+      \ OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER\
+      \ IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)\
+      \ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE\
+      \ POSSIBILITY OF SUCH DAMAGE."
+  - licenseId: "LicenseRef-1"
+    comment: null
+    name: null
+    seeAlso: []
+    extractedText: "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006,\
+      \ 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n\
+      \ *\n * Redistribution and use in source and binary forms, with or without\n\
+      \ * modification, are permitted provided that the following conditions\n * are\
+      \ met:\n * 1. Redistributions of source code must retain the above copyright\n\
+      \ *    notice, this list of conditions and the following disclaimer.\n * 2.\
+      \ Redistributions in binary form must reproduce the above copyright\n *    notice,\
+      \ this list of conditions and the following disclaimer in the\n *    documentation\
+      \ and/or other materials provided with the distribution.\n * 3. The name of\
+      \ the author may not be used to endorse or promote products\n *    derived from\
+      \ this software without specific prior written permission.\n *\n * THIS SOFTWARE\
+      \ IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES,\
+      \ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY\
+      \ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL\
+      \ THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY,\
+      \ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF\
+      \ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS\
+      \ INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN\
+      \ CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE)\
+      \ ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF\
+      \ THE POSSIBILITY OF SUCH DAMAGE.\n*/"
+  annotations:
+  - annotator: "Person: Jane Doe ()"
+    annotationDate: "2010-01-29T18:30:22Z"
+    annotationType: "OTHER"
+    comment: "Document level annotation"
+  relationships:
+  - relationshipType: "DESCRIBES"
+    comment: null
+    relatedSpdxElementId: "SPDXRef-File"
+  - relationshipType: "COPY_OF"
+    comment: null
+    relatedSpdxElementId: "DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement"
+  - relationshipType: "CONTAINS"
+    comment: null
+    relatedSpdxElementId: "SPDXRef-Package"
+  - relationshipType: "DESCRIBES"
+    comment: null
+    relatedSpdxElementId: "SPDXRef-Package"
+  reviewers:
+  - reviewer: "Person: Suzanne Reviewer"
+    reviewDate: "2011-03-13T00:00:00Z"
+    comment: "Another example reviewer."
+  - reviewer: "Person: Joe Reviewer"
+    reviewDate: "2010-02-10T00:00:00Z"
+    comment: "This is just an example.  Some of the non-standard licenses look like\
+      \ they are actually BSD 3 clause licenses"


### PR DESCRIPTION
As discussed on 2019-04-23 tech team call, this commit adds sample SPDX files in JSON, XML and YAML format, along with a corresponding tag-value format version. These are intended for further discussion and iterating before finalizing any of the new formats.

The versions of the files used in this commit are taken from the comment at https://github.com/spdx/spdx-spec/issues/55#issuecomment-413063219, with the only changes being (1) converting CRLF to LF, and (2) changing the version number in the filenames to 2.0, since these are in fact SPDX v2.0 files.

cc @goneall

Signed-off-by: Steve Winslow <swinslow@gmail.com>