### PR TITLE
chapters/appendix-VI: Add container registries

### DIFF
--- a/chapters/appendix-VI-external-repository-identifiers.md
+++ b/chapters/appendix-VI-external-repository-identifiers.md
@@ -118,6 +118,54 @@ External Reference Site: [http://bower.io/](http://bower.io/)
 Documentation: [http://bower.io/docs/api/#install](http://bower.io/docs/api/#install)
 
 ***
+When <category> = `CONTAINER-IMAGE`:
+***
+
+## `<type>` Dockerhub <a name="dockerhub"></a>
+
+### `<locator>` Information
+
+Locator Format:
+
+    repo:tag
+    ^[^:]+:[^:]+$
+
+    repo@digest_type:digest
+    ^[^@]+@[^:]+$
+
+Contextual Example:
+
+    debian:buster
+
+    debian@sha256:2f04d3d33b6027bb74ecc81397abe780649ec89f1a2af18d7022737d0482cefe
+
+External Reference Site: [https://hub.docker.com](https://hub.docker.com)
+
+Documentation: [https://docs.docker.com/](https://docs.docker.com/)
+
+## `<type>` Google Container Registry <a name="gcr"></a>
+
+### `<locator>` Information
+
+Locator Format:
+
+    domain/repo:tag
+    ^[^\/]+\/^[^:]+:[^:]+$
+
+    domain/repo@digest_type:digest
+    ^[^\/]+\/^[^@]+@[^:]+$
+
+Contextual Example:
+
+    gcr.io/distroless/static:latest
+
+    gcr.io/distroless/static@sha256:9b60270ec0991bc4f14bda475e8cae75594d8197d0ae58576ace84694aa75d7a
+
+External Reference Site: [https://cloud.google.com/container-registry/](https://cloud.google.com/container-registry/)
+
+Documentation: [https://cloud.google.com/docs/](https://cloud.google.com/docs/)
+
+***
 When <category> = `OTHER`:
 ***
 


### PR DESCRIPTION
A container image can be considered as a package. These packages
are consumed from container registries. Dockerhub is a public
registry that many single use container images are downloaded.
Google Container Registries are used to download container images
for Kubernetes. This change adds a category type called
CONTAINER-IMAGE and adds to it two types: 'Dockerhub' and
'Google Container Registry'.

The most popular local client used to download these images is
Docker. The docker client defaults to Dockerhub. As a result, the
repo doesn't have a 'domain' name associated with it. If anyone
were to receive a tarball of this container image, they will just
find the repo and tag name.

For other registries though, docker will add the domain name to
the container image. For example, if you used docker to work with
images from GCR, you will find the domain name as part of the repo
name.

Other public container registries can be added to this category

This change resolves issue #140 

Signed-off-by: Nisha K <nishak@vmware.com>