### PR TITLE
Add a relationship for distributed components 

### DIFF
--- a/chapters/7-relationships-between-SPDX-elements.md
+++ b/chapters/7-relationships-between-SPDX-elements.md
@@ -35,6 +35,7 @@
 | AMENDS                 | Is to be used when (current) SPDXRef-DOCUMENT amends the SPDX information in SPDXRef-B.               | (Current) SPDX document A version 2 contains a correction to a previous version of the SPDX document A version 1. Note the reserved identifier SPDXRef-DOCUMENT for the current document is required. |
 | PREREQUISITE_FOR       | Is to be used when SPDXRef-A is a prerequisite for SPDXRef-B | A library `bar.dll` is aprerequisite or dependency for APPLICATION `foo.exe`|
 | HAS_PREREQUISITE       | Is to be used when SPDXRef-A has as a prerequisite SPDXRef-B | An APPLICATION `foo.exe` has prerequisite or dependency of `bar.dll` |
+| DISTRIBUTED_COMPONENT  | Is to be used when SPDXRef-A is an included component of SPDXRef-B and is distributed or conveyed     | A server based APPLICATION `server.war` includes a JavaScript file which is distributed to the client browser `React.js` |
 | OTHER                  | Is to be used for a relationship which has not been defined in the formal SPDX specification. A description of the relationship should be included in the Relationship comments field. | |
 
 **7.1.2** Intent: Here, this field is a reasonable estimation of the relation between two identified elements (i.e. files or packages, or documents), from a developer perspective.


### PR DESCRIPTION
Adding this relationship will support the use case where an auditor, analyst, package supplier or packager would like to communicate specific components that are distributed to clients.  For example, JavaScript files which are intended to run on the client machine.

The receiver of the SPDX document would then be able to use this information to determine license obligations for the distributed components.
 
Signed-off-by: Gary O'Neall <gary@sourceauditor.com>