### PR TITLE
Fix RDF example for ExternalDocumentRef

### DIFF
--- a/chapters/2-document-creation-information.md
+++ b/chapters/2-document-creation-information.md
@@ -201,9 +201,8 @@ The ExternalDocumentRef contains two properties:
 
 Example:
 
-    <externalDocumentRef>
+    <externalDocumentRef rdf:ID="DocumentRef-spdx-tool-1.2">
         <ExternalDocumentRef>
-            <spdx:externalDocumentId>DocumentRef-spdx-tool-1.2</spdx:externalDocumentId>
             <spdxDocument rdf:about=”http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82...” />
             <checksum>
                 <Checksum>


### PR DESCRIPTION
The RDF is defined to have 2 properties (`spdxDocument` and `checksum`).  The example has the DocumentRef ID as a property.  It should be the ID for the `externalDocumentRef` property.