### PR TITLE
Update Specification Version from 2.1.0 to 2.2.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Git itself use this approach. When you merge something it will generate a commit
 
 ### Minor Changes
 Minor changes such as markup and typo fixes may be submitted directly to this repository (either as [issues][] or [pull-requests][]) without previous discussion.
-Please submit all minor changes against the `development/v2.2` branch which is the draft of the next version of the SPDX specification to be released.
+Please submit all minor changes against the `development/v2.3` branch which is the draft of the next version of the SPDX specification to be released.
 
 ### Major Changes
 Any change that break backwards compatibility or requires significant tooling changes is considered a major change.

--- a/chapters/1-rationale.md
+++ b/chapters/1-rationale.md
@@ -28,7 +28,7 @@ Companies and organizations (collectively “Organizations”) are widely using 
 
 **1.4.7** Annotations: Information about when and by whom the SPDX file was reviewed
 
-![Overview of SPDX 2.1 document contents](img/spdx-2.1-document.png)
+![Overview of SPDX 2.2 document contents](img/spdx-2.2-document.png)
 
 ## 1.5 What is not covered in the specification? <a name="1.5"></a>
 

--- a/chapters/2-document-creation-information.md
+++ b/chapters/2-document-creation-information.md
@@ -24,14 +24,14 @@ Fields:
 
 Example:
 
-    SPDXVersion: SPDX-2.1
+    SPDXVersion: SPDX-2.2
 
 **2.1.6** RDF: `spdx:specVersion`
 
 Example:
 
     <SpdxDocument rdf:about="...">
-       <specVersion>SPDX-2.1</specVersion>
+       <specVersion>SPDX-2.2</specVersion>
     </SpdxDocument>
 
 This specification uses the prefix `rdf:` to refer to the [RDF/XML][rdf] namespace:

--- a/chapters/appendix-III-RDF-data-model-implementation-and-identifier-syntax.md
+++ b/chapters/appendix-III-RDF-data-model-implementation-and-identifier-syntax.md
@@ -2,11 +2,11 @@
 
 SPDX ® Vocabulary Specification
 
-See: [http://spdx.org/rdf/ontology/spdx-2-1](http://spdx.org/rdf/ontology/spdx-2-1)
+See: [http://spdx.org/rdf/ontology/spdx-2-2](http://spdx.org/rdf/ontology/spdx-2-2)
 
-Version: 2.1
+Version: 2.2
 
-![SPDX 2.1 RD Ontology](img/spdx-2.1-rdf-ontology.png)
+![SPDX 2.2 RD Ontology](img/spdx-2.2-rdf-ontology.png)
 
 Licensed under the [Creative Commons Attribution License 3.0 Unported](http://creativecommons.org/licenses/by/3.0/).
 

--- a/chapters/appendix-V-using-SPDX-short-identifiers-in-source-files.md
+++ b/chapters/appendix-V-using-SPDX-short-identifiers-in-source-files.md
@@ -49,6 +49,6 @@ Examples:
     SPDX-License-Identifier: (LGPL-2.1 AND BSD-2-CLAUSE)
     SPDX-License-Identifier: (GPL-2.0+ WITH Bison-exception-2.2)
 
-Please see [Appendix IV of SPDX 2.1 Specification](./appendix-IV-SPDX-license-expressions.md) for more examples and details of the license expression specific syntax.
+Please see [Appendix IV of SPDX 2.2 Specification](./appendix-IV-SPDX-license-expressions.md) for more examples and details of the license expression specific syntax.
 
 If you can’t express the license(s) as an expression using identifiers from the SPDX list, it is probably best to just put the text of your license header in the file (if there is a standard header), or refer to a neutral site URL where the text can be found. To request a license be added to the SPDX License List, please follow the process described here: [http://spdx.org/spdx-license-list/request-new-license-or-exception](http://spdx.org/spdx-license-list/request-new-license-or-exception).

--- a/chapters/index.md
+++ b/chapters/index.md
@@ -1,4 +1,4 @@
-# The Software Package Data Exchange (SPDX®) Specification Version 2.2-DRAFT
+# The Software Package Data Exchange (SPDX®) Specification Version 2.2
 
 Copyright © 2010-2019 Linux Foundation and its Contributors.
 This work is licensed under the Creative Commons Attribution License 3.0 Unported (CC-BY-3.0) reproduced in its entirety in [Appendix VII](appendix-VII-creative-commons-attribution-license-3.0-unported.md) herein. All other rights are expressly reserved.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: specification v2.1.1
+site_name: specification v2.2.0
 docs_dir: chapters
 theme: readthedocs
 extra_css:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name = "spdx_specification",
-    version = "2.1.1",
+    version = "2.2.0",
     author = "Linux Foundation and its Contributors",
     author_email = "opensource@steenbe.nl",
     description = ("The Software Package Data Exchange® (SPDX®) specification is a standard format for communicating the components, licenses and copyrights associated with software packages."),


### PR DESCRIPTION
Note that this does point at non-existent 2.2 RDF images and ontology which should be resolved before publishing.