### PR TITLE
Simplify enums for JSON and YAML

### DIFF
--- a/examples/SPDXJSONExample-v2.0.json
+++ b/examples/SPDXJSONExample-v2.0.json
@@ -13,7 +13,7 @@
     "comment" : "This document was created using SPDX 2.0 using licenses from the web site.",
     "externalDocumentRefs" : [ {
       "checksum" : {
-        "algorithm" : "checksumAlgorithm_sha1",
+        "algorithm" : "SHA1",
         "value" : "d6a770ba38583ed4bb4525bd96e50461655d2759"
       },
       "documentNamespace" : "http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301",
@@ -23,12 +23,12 @@
       "files" : [{
         "name" : "./package/foo.c",
         "id" : "SPDXRef-File",
-        "fileTypes" : [ "fileType_source" ],
+        "fileTypes" : [ "SOURCE" ],
         "checksums" : [ {
-          "algorithm" : "checksumAlgorithm_sha1",
+          "algorithm" : "SHA1",
           "value" : "d6a770ba38583ed4bb4525bd96e50461655d2758"
         }, {
-          "algorithm" : "checksumAlgorithm_md5",
+          "algorithm" : "MD5",
           "value" : "624c1abb3664f4b35547e7c73864ad24"
         } ],
         "licenseConcluded" : "(LGPL-2.0 OR LicenseRef-2)",
@@ -68,13 +68,13 @@
           "excludedFileNames" : [ "excludes: ./package.spdx" ]
         },
         "checksums" : [ {
-          "algorithm" : "checksumAlgorithm_md5",
+          "algorithm" : "MD5",
           "value" : "624c1abb3664f4b35547e7c73864ad24"
         }, {
-          "algorithm" : "checksumAlgorithm_sha256",
+          "algorithm" : "SHA256",
           "value" : "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
         }, {
-          "algorithm" : "checksumAlgorithm_sha1",
+          "algorithm" : "SHA1",
           "value" : "85ed0817af83a24ad8da68c2b5094de69833983c"
         } ],
         "homepage" : "http://ftp.gnu.org/gnu/glibc",
@@ -88,14 +88,14 @@
         "description" : "The GNU C Library defines functions that are specified by the ISO C standard, as well as additional features specific to POSIX and other derivatives of the Unix operating system, and extensions specific to GNU systems.",
         "comment" : null,
         "externalRefs" : [ {
-          "referenceCategory" : "referenceCategory_other",
+          "referenceCategory" : "OTHER",
           "referenceType" : {
             "referenceTypeUri" : "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge"
           },
           "referenceLocator" : "acmecorp/acmenator/4.1.3-alpha",
           "comment" : "This is the external ref for Acme"
         }, {
-          "referenceCategory" : "referenceCategory_security",
+          "referenceCategory" : "SECURITY",
           "referenceType" : {
             "referenceTypeUri" : "http://spdx.org/rdf/references/cpe23Type"
           },
@@ -112,9 +112,9 @@
           "File" : {
             "name" : "./src/org/spdx/parser/DOAPProject.java",
             "id" : "SPDXRef-DoapSource",
-            "fileTypes" : [ "fileType_source" ],
+            "fileTypes" : [ "SOURCE" ],
             "checksums" : [ {
-              "algorithm" : "checksumAlgorithm_sha1",
+              "algorithm" : "SHA1",
               "value" : "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
             } ],
             "licenseConcluded" : "Apache-2.0",
@@ -129,9 +129,9 @@
               "File" : {
                 "name" : "./lib-source/jena-2.6.3-sources.jar",
                 "id" : "SPDXRef-JenaLib",
-                "fileTypes" : [ "fileType_archive" ],
+                "fileTypes" : [ "ARCHIVE" ],
                 "checksums" : [ {
-                  "algorithm" : "checksumAlgorithm_sha1",
+                  "algorithm" : "SHA1",
                   "value" : "3ab4e1c67a2d28fced849ee1bb76e7391b93f125"
                 } ],
                 "licenseConcluded" : "LicenseRef-1",
@@ -150,9 +150,9 @@
                   "File" : {
                     "name" : "./lib-source/commons-lang3-3.1-sources.jar",
                     "id" : "SPDXRef-CommonsLangSrc",
-                    "fileTypes" : [ "fileType_archive" ],
+                    "fileTypes" : [ "ARCHIVE" ],
                     "checksums" : [ {
-                      "algorithm" : "checksumAlgorithm_sha1",
+                      "algorithm" : "SHA1",
                       "value" : "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
                     } ],
                     "licenseConcluded" : "Apache-2.0",
@@ -181,9 +181,9 @@
               "File" : {
                 "name" : "./lib-source/commons-lang3-3.1-sources.jar",
                 "id" : "SPDXRef-CommonsLangSrc",
-                "fileTypes" : [ "fileType_archive" ],
+                "fileTypes" : [ "ARCHIVE" ],
                 "checksums" : [ {
-                  "algorithm" : "checksumAlgorithm_sha1",
+                  "algorithm" : "SHA1",
                   "value" : "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
                 } ],
                 "licenseConcluded" : "Apache-2.0",
@@ -212,9 +212,9 @@
           "File" : {
             "name" : "./lib-source/jena-2.6.3-sources.jar",
             "id" : "SPDXRef-JenaLib",
-            "fileTypes" : [ "fileType_archive" ],
+            "fileTypes" : [ "ARCHIVE" ],
             "checksums" : [ {
-              "algorithm" : "checksumAlgorithm_sha1",
+              "algorithm" : "SHA1",
               "value" : "3ab4e1c67a2d28fced849ee1bb76e7391b93f125"
             } ],
             "licenseConcluded" : "LicenseRef-1",
@@ -233,9 +233,9 @@
               "File" : {
                 "name" : "./lib-source/commons-lang3-3.1-sources.jar",
                 "id" : "SPDXRef-CommonsLangSrc",
-                "fileTypes" : [ "fileType_archive" ],
+                "fileTypes" : [ "ARCHIVE" ],
                 "checksums" : [ {
-                  "algorithm" : "checksumAlgorithm_sha1",
+                  "algorithm" : "SHA1",
                   "value" : "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
                 } ],
                 "licenseConcluded" : "Apache-2.0",
@@ -264,9 +264,9 @@
           "File" : {
             "name" : "./lib-source/commons-lang3-3.1-sources.jar",
             "id" : "SPDXRef-CommonsLangSrc",
-            "fileTypes" : [ "fileType_archive" ],
+            "fileTypes" : [ "ARCHIVE" ],
             "checksums" : [ {
-              "algorithm" : "checksumAlgorithm_sha1",
+              "algorithm" : "SHA1",
               "value" : "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
             } ],
             "licenseConcluded" : "Apache-2.0",

--- a/examples/SPDXYAMLExample-2.0.yaml
+++ b/examples/SPDXYAMLExample-2.0.yaml
@@ -18,7 +18,7 @@ Document:
   comment: This document was created using SPDX 2.0 using licenses from the web site.
   externalDocumentRefs:
   - checksum:
-      algorithm: checksumAlgorithm_sha1
+      algorithm: SHA1
       value: d6a770ba38583ed4bb4525bd96e50461655d2759
     documentNamespace: http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301
     externalDocumentId: DocumentRef-spdx-tool-1.2
@@ -27,11 +27,11 @@ Document:
     - name: "./package/foo.c"
       id: SPDXRef-File
       fileTypes:
-      - fileType_source
+      - SOURCE
       checksums:
-      - algorithm: checksumAlgorithm_sha1
+      - algorithm: SHA1
         value: d6a770ba38583ed4bb4525bd96e50461655d2758
-      - algorithm: checksumAlgorithm_md5
+      - algorithm: MD5
         value: 624c1abb3664f4b35547e7c73864ad24
       licenseConcluded: "(LGPL-2.0 OR LicenseRef-2)"
       licenseInfoFromFiles:
@@ -88,11 +88,11 @@ Document:
         excludedFileNames:
         - 'excludes: ./package.spdx'
       checksums:
-      - algorithm: checksumAlgorithm_md5
+      - algorithm: MD5
         value: 624c1abb3664f4b35547e7c73864ad24
-      - algorithm: checksumAlgorithm_sha256
+      - algorithm: SHA256
         value: 11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd
-      - algorithm: checksumAlgorithm_sha1
+      - algorithm: SHA1
         value: 85ed0817af83a24ad8da68c2b5094de69833983c
       homepage: http://ftp.gnu.org/gnu/glibc
       sourceInfo: uses glibc-2_11-branch from git://sourceware.org/git/glibc.git.
@@ -111,12 +111,12 @@ Document:
         of the Unix operating system, and extensions specific to GNU systems.
       comment: 
       externalRefs:
-      - referenceCategory: referenceCategory_other
+      - referenceCategory: OTHER
         referenceType:
           referenceTypeUri: http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge
         referenceLocator: acmecorp/acmenator/4.1.3-alpha
         comment: This is the external ref for Acme
-      - referenceCategory: referenceCategory_security
+      - referenceCategory: SECURITY
         referenceType:
           referenceTypeUri: http://spdx.org/rdf/references/cpe23Type
         referenceLocator: cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*
@@ -131,9 +131,9 @@ Document:
           name: "./src/org/spdx/parser/DOAPProject.java"
           id: SPDXRef-DoapSource
           fileTypes:
-          - fileType_source
+          - SOURCE
           checksums:
-          - algorithm: checksumAlgorithm_sha1
+          - algorithm: SHA1
             value: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
           licenseConcluded: Apache-2.0
           licenseInfoFromFiles:
@@ -154,9 +154,9 @@ Document:
               name: "./lib-source/jena-2.6.3-sources.jar"
               id: SPDXRef-JenaLib
               fileTypes:
-              - fileType_archive
+              - ARCHIVE
               checksums:
-              - algorithm: checksumAlgorithm_sha1
+              - algorithm: SHA1
                 value: 3ab4e1c67a2d28fced849ee1bb76e7391b93f125
               licenseConcluded: LicenseRef-1
               licenseInfoFromFiles:
@@ -178,9 +178,9 @@ Document:
                   name: "./lib-source/commons-lang3-3.1-sources.jar"
                   id: SPDXRef-CommonsLangSrc
                   fileTypes:
-                  - fileType_archive
+                  - ARCHIVE
                   checksums:
-                  - algorithm: checksumAlgorithm_sha1
+                  - algorithm: SHA1
                     value: c2b4e1c67a2d28fced849ee1bb76e7391b93f125
                   licenseConcluded: Apache-2.0
                   licenseInfoFromFiles:
@@ -215,9 +215,9 @@ Document:
               name: "./lib-source/commons-lang3-3.1-sources.jar"
               id: SPDXRef-CommonsLangSrc
               fileTypes:
-              - fileType_archive
+              - ARCHIVE
               checksums:
-              - algorithm: checksumAlgorithm_sha1
+              - algorithm: SHA1
                 value: c2b4e1c67a2d28fced849ee1bb76e7391b93f125
               licenseConcluded: Apache-2.0
               licenseInfoFromFiles:
@@ -251,9 +251,9 @@ Document:
           name: "./lib-source/jena-2.6.3-sources.jar"
           id: SPDXRef-JenaLib
           fileTypes:
-          - fileType_archive
+          - ARCHIVE
           checksums:
-          - algorithm: checksumAlgorithm_sha1
+          - algorithm: SHA1
             value: 3ab4e1c67a2d28fced849ee1bb76e7391b93f125
           licenseConcluded: LicenseRef-1
           licenseInfoFromFiles:
@@ -275,9 +275,9 @@ Document:
               name: "./lib-source/commons-lang3-3.1-sources.jar"
               id: SPDXRef-CommonsLangSrc
               fileTypes:
-              - fileType_archive
+              - ARCHIVE
               checksums:
-              - algorithm: checksumAlgorithm_sha1
+              - algorithm: SHA1
                 value: c2b4e1c67a2d28fced849ee1bb76e7391b93f125
               licenseConcluded: Apache-2.0
               licenseInfoFromFiles:
@@ -312,9 +312,9 @@ Document:
           name: "./lib-source/commons-lang3-3.1-sources.jar"
           id: SPDXRef-CommonsLangSrc
           fileTypes:
-          - fileType_archive
+          - ARCHIVE
           checksums:
-          - algorithm: checksumAlgorithm_sha1
+          - algorithm: SHA1
             value: c2b4e1c67a2d28fced849ee1bb76e7391b93f125
           licenseConcluded: Apache-2.0
           licenseInfoFromFiles:


### PR DESCRIPTION
This switches to use the tag-value style of enums in the JSON and
YAML examples for v2.2.

Fixes #155

Signed-off-by: Steve Winslow <steve@swinslow.net>