### PR TITLE
Fix issue #94 - somewhat confusing RDF documentation on ExternalRef

### DIFF
--- a/chapters/3-package-information.md
+++ b/chapters/3-package-information.md
@@ -975,7 +975,7 @@ Example:
 
     ExternalRef: OTHER LocationRef-acmeforge acmecorp/acmenator/4.1.3-alpha
 
-**3.21.6** RDF: property `target` in class `spdx:ExternalRef` in class `spdx:Package`
+**3.21.6** RDF: property `externalRef` in class `spdx:Package` of type `spdx:ExternalRef` 
 
 Example (for a listed location):
 
@@ -1029,7 +1029,7 @@ Example:
     security vulnerabilities (CVEs) which affect Vendor Product Version
     acmecorp:acmenator:6.6.6.</text>
 
-**3.22.6** RDF: Property `rdfs:comment` in class `spdx:ExternalRef` in class `spdx:Package`
+**3.22.6** RDF: Property `rdfs:comment` in class `spdx:ExternalRef`
 
     <spdx:Package rdf:about="...">
         ...


### PR DESCRIPTION
This should fix issue #94 

I fixed the property name and changed how the classes as documented to (hopefully) make it more clear.

We could document all the properties in the ExternalRef RDF class, but I think the examples make it pretty clear without the additional verbage.
Signed-off-by: Gary O'Neall <gary@sourceauditor.com>