### PR TITLE
Attribution text field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 * Added clarification of the meaning of `Package` with an SPDX document.
 * Added [SPDX Lite](chapters/appendix-VIII-SPDX-Lite.md) which defines a minimal subset of SPDX for scenarios not requiring full SPDX documents.
 * Added [SPDX File Tags](chapters/appendix-IX-file-tags.md) which defines a mechanism to add file-specific information from SPDX-defined fields to source code files.
-* Added optional field to be able to convey AttributionText information for packages & files.
+* Added optional field to be able to convey attribution text information for packages & files.
 
 See also the [SPDX specification 2.2 release announcement](TODO)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 * Added clarification of the meaning of `Package` with an SPDX document.
 * Added [SPDX Lite](chapters/appendix-VIII-SPDX-Lite.md) which defines a minimal subset of SPDX for scenarios not requiring full SPDX documents.
 * Added [SPDX File Tags](chapters/appendix-IX-file-tags.md) which defines a mechanism to add file-specific information from SPDX-defined fields to source code files.
+* Added optional field to be able to convey AttributionText information for packages & files.
 
 See also the [SPDX specification 2.2 release announcement](TODO)
 

--- a/chapters/3-package-information.md
+++ b/chapters/3-package-information.md
@@ -1050,33 +1050,33 @@ Example:
     
 ## 3.23 Package Attribution Text <a name="3.23"></a>
 
-**4.15.1** Purpose: This field provides a place for the SPDX data creator to record all attributions at the package level that are required to be communicated. These typically include copyright statement(s), license text, and a disclaimer.
+**3.23.1** Purpose: This field provides a place for the SPDX data creator to record, at the package level, acknowledgements that may be required to be communicated in some contexts. This is not meant to include the package's actual complete license text (see `PackageLicenseConcluded`, `PackageLicenseDeclared` and `PackageLicenseInfoFromFiles`), and may or may not include copyright notices (see also `PackageCopyrightText`). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.
 
-**4.15.2** Intent: The intent is to provide the recipient of the SPDX file with all the legally required attributions at a package level, therefore complying with the license obligations.
+**3.23.2** Intent: The intent is to provide the recipient of the SPDX file with acknowledgement content at a package level, to assist redistributors of the package with reproducing those acknowledgements. This field does not necessarily indicate where, or in which contexts, the acknowledgements need to be reproduced (such as end-user documentation, advertising materials, etc.) and the SPDX data creator may or may not explain elsewhere how they intend for this field to be used.
 
-**4.15.3** Cardinality: Optional, one or many.
+**3.23.3** Cardinality: Optional, one or many.
 
-**4.15.4** Data Format: free form text that can (and usually will) span multiple lines.  
+**3.23.4** Data Format: free form text that can span multiple lines.
 
-**4.15.5** Tag: `AttributionText:`
+**3.23.5** Tag: `PackageAttributionText:`
 
 In `tag:value` format multiple lines are delimited by `<text> .. </text>`.
 
 Example: 
 
-    AttributionText: <text>
-All advertising materials mentioning features or use of this software must display the
-following acknowledgement:  This product includes software developed by the AT&T.
+    PackageAttributionText: <text>
+    All advertising materials mentioning features or use of this software must display the
+    following acknowledgement:  This product includes software developed by the AT&T.
     </text>
 
-**4.15.6** RDF: property 'attributionText' in class 'spdx:Package'
+**3.23.6** RDF: property 'attributionText' in class 'spdx:Package'
 
 Example:
 
     <Package rdf:about="...">
            	<attributionText>
-All advertising materials mentioning features or use of this software must display the
-following acknowledgement:  This product includes software developed by the AT&T.
+                All advertising materials mentioning features or use of this software must display the
+                following acknowledgement:  This product includes software developed by the AT&T.
            	</attributionText>
     </Package>
 

--- a/chapters/3-package-information.md
+++ b/chapters/3-package-information.md
@@ -1047,6 +1047,38 @@ Example:
         </spdx:externalRef>
         ...
     </spdx:package>
+    
+## 3.23 Package Attribution Text <a name="3.23"></a>
+
+**4.15.1** Purpose: This field provides a place for the SPDX data creator to record all attributions at the package level that are required to be communicated. These typically include copyright statement(s), license text, and a disclaimer.
+
+**4.15.2** Intent: The intent is to provide the recipient of the SPDX file with all the legally required attributions at a package level, therefore complying with the license obligations.
+
+**4.15.3** Cardinality: Optional, one or many.
+
+**4.15.4** Data Format: free form text that can (and usually will) span multiple lines.  
+
+**4.15.5** Tag: `AttributionText:`
+
+In `tag:value` format multiple lines are delimited by `<text> .. </text>`.
+
+Example: 
+
+    AttributionText: <text>
+All advertising materials mentioning features or use of this software must display the
+following acknowledgement:  This product includes software developed by the AT&T.
+    </text>
+
+**4.15.6** RDF: property 'attributionText' in class 'spdx:Package'
+
+Example:
+
+    <Package rdf:about="...">
+           	<attributionText>
+All advertising materials mentioning features or use of this software must display the
+following acknowledgement:  This product includes software developed by the AT&T.
+           	</attributionText>
+    </Package>
 
 
 [Bazaar]: http://bazaar.canonical.com/

--- a/chapters/4-file-information.md
+++ b/chapters/4-file-information.md
@@ -536,27 +536,23 @@ Example:
 
 ## 4.15 File Attribution Text <a name="4.15"></a>
 
-**4.15.1** Purpose: This field provides a place for the SPDX data creator to record all attributions found in the file that are required to be communicated. These typically include copyright statement(s), license text, and a disclaimer.
+**4.15.1** Purpose: This field provides a place for the SPDX data creator to record, at the file level, acknowledgements that may be required to be communicated in some contexts. This is not meant to include the file's actual complete license text (see `LicenseConcluded` and `LicenseInfoInFile`), and may or may not include copyright notices (see also `FileCopyrightText`). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.
 
-**4.15.2** Intent: The intent is to provide the recipient of the SPDX file with all the legally required attributions in the file, therefore complying with the license obligations.
+**4.15.2** Intent: The intent is to provide the recipient of the SPDX file with acknowledgement content at a file level, to assist redistributors of the file with reproducing those acknowledgements. This field does not necessarily indicate where, or in which contexts, the acknowledgements need to be reproduced (such as end-user documentation, advertising materials, etc.) and the SPDX data creator may or may not explain elsewhere how they intend for this field to be used.
 
 **4.15.3** Cardinality: Optional, one or many.
 
-**4.15.4** Data Format: free form text that can (and usually will) span multiple lines.  
+**4.15.4** Data Format: free form text that can span multiple lines.
 
-**4.15.5** Tag: `AttributionText:`
+**4.15.5** Tag: `FileAttributionText:`
 
 In `tag:value` format multiple lines are delimited by `<text> .. </text>`.
 
 Example: 
 
-    AttributionText: <text>
-    #   Copyright (C) 2004 Free Software Foundation, Inc.
-    #   Written by Scott James Remnant, 2004
-    #
-    # This file is free software; the Free Software Foundation gives
-    # unlimited permission to copy and/or distribute it, with or without
-    # modifications, as long as this notice is preserved.
+    FileAttributionText: <text>
+    All advertising materials mentioning features or use of this software must display the
+    following acknowledgement:  This product includes software developed by the AT&T.
     </text>
 
 **4.15.6** RDF: property 'attributionText' in class 'spdx:File'
@@ -565,12 +561,8 @@ Example:
 
     <File rdf:about="...">
            	<attributionText>
-    #   Copyright (C) 2004 Free Software Foundation, Inc.
-    #   Written by Scott James Remnant, 2004
-    #
-    # This file is free software; the Free Software Foundation gives
-    # unlimited permission to copy and/or distribute it, with or without
-    # modifications, as long as this notice is preserved.
+                All advertising materials mentioning features or use of this software must display the
+                following acknowledgement:  This product includes software developed by the AT&T.
            	</attributionText>
     </File>
 

--- a/chapters/4-file-information.md
+++ b/chapters/4-file-information.md
@@ -534,19 +534,59 @@ Example:
         <fileContributor> IBM Corporation </fileContributor>
     </File>
 
-## 4.15 File Dependencies (deprecated) <a name="4.15"></a>
+## 4.15 File Attribution Text <a name="4.15"></a>
 
-This field is deprecated since SPDX 2.0 in favor of using [Section 7](7-relationships-between-SPDX-elements.md) which provides more granularity about relationships.
+**4.15.1** Purpose: This field provides a place for the SPDX data creator to record all attributions found in the file that are required to be communicated. These typically include copyright statement(s), license text, and a disclaimer.
 
-**4.15.1** Purpose: The field provides a place for the SPDX file creator to record a list of other files (referenceable within this SPDX file) which the file is a derivative of and/or depends on for the build (e.g., source file or build script for a binary program or library). The list of files may not necessarily represent the list of all file dependencies, but possibly the ones that impact the licensing and/or may be needed as part of the file distribution obligation.
-
-**4.15.2** Intent: Here, the intent is to provide the recipient of the SPDX file with file dependency information based on the build system that created the file. These other files may impact the licensing of the file and/or may be required to satisfy the distribution obligation of the file (e.g., source files subject to a copyleft license).
+**4.15.2** Intent: The intent is to provide the recipient of the SPDX file with all the legally required attributions in the file, therefore complying with the license obligations.
 
 **4.15.3** Cardinality: Optional, one or many.
 
-**4.15.4** Data Format: Reference to the file within the SPDX document. For the `tag:value` format, this will be the filename. For the RDF format, it will be a reference to the actual file node.
+**4.15.4** Data Format: free form text that can (and usually will) span multiple lines.  
 
-**4.15.5** Tag: `FileDependency:`
+**4.15.5** Tag: `AttributionText:`
+
+In `tag:value` format multiple lines are delimited by `<text> .. </text>`.
+
+Example: 
+
+    AttributionText: <text>
+    #   Copyright (C) 2004 Free Software Foundation, Inc.
+    #   Written by Scott James Remnant, 2004
+    #
+    # This file is free software; the Free Software Foundation gives
+    # unlimited permission to copy and/or distribute it, with or without
+    # modifications, as long as this notice is preserved.
+    </text>
+
+**4.15.6** RDF: property 'attributionText' in class 'spdx:File'
+
+Example:
+
+    <File rdf:about="...">
+           	<attributionText>
+    #   Copyright (C) 2004 Free Software Foundation, Inc.
+    #   Written by Scott James Remnant, 2004
+    #
+    # This file is free software; the Free Software Foundation gives
+    # unlimited permission to copy and/or distribute it, with or without
+    # modifications, as long as this notice is preserved.
+           	</attributionText>
+    </File>
+
+## 4.16 File Dependencies (deprecated) <a name="4.16"></a>
+
+This field is deprecated since SPDX 2.0 in favor of using [Section 7](7-relationships-between-SPDX-elements.md) which provides more granularity about relationships.
+
+**4.16.1** Purpose: The field provides a place for the SPDX file creator to record a list of other files (referenceable within this SPDX file) which the file is a derivative of and/or depends on for the build (e.g., source file or build script for a binary program or library). The list of files may not necessarily represent the list of all file dependencies, but possibly the ones that impact the licensing and/or may be needed as part of the file distribution obligation.
+
+**4.16.2** Intent: Here, the intent is to provide the recipient of the SPDX file with file dependency information based on the build system that created the file. These other files may impact the licensing of the file and/or may be required to satisfy the distribution obligation of the file (e.g., source files subject to a copyleft license).
+
+**4.16.3** Cardinality: Optional, one or many.
+
+**4.16.4** Data Format: Reference to the file within the SPDX document. For the `tag:value` format, this will be the filename. For the RDF format, it will be a reference to the actual file node.
+
+**4.16.5** Tag: `FileDependency:`
 
 Example:
 
@@ -554,7 +594,7 @@ Example:
     FileDependency:./busybox-1.20.2/shell/match.c
     FileDependency:./busybox-1.20.2/shell/ash.c
 
-**4.15.6** RDF: Property `spdx:fileDependency` in class `spdx:File`
+**4.16.6** RDF: Property `spdx:fileDependency` in class `spdx:File`
 
 Example:
 


### PR DESCRIPTION
Add in the Attribution Text field to Package and File level,  per discussion in issue https://github.com/spdx/spdx-spec/issues/28.   This makes it easier for tools to satisfy terms found in some licenses (like BSD-4-Clause, etc.). 