### PR TITLE
Add a JSON-LD context file

### DIFF
--- a/ontology/spdx-ontology.context.json
+++ b/ontology/spdx-ontology.context.json
@@ -1,0 +1,469 @@
+{
+  "@context" : {
+    "spdx" : "http://spdx.org/rdf/terms#",
+    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "owl" : "http://www.w3.org/2002/07/owl#",
+    "doap" : "http://usefulinc.com/ns/doap#",
+    "rdfpointer" : "http://www.w3.org/2009/pointers#",
+    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+    "xmlschema" : "http://www.w3.org/2001/XMLSchema#",
+    "licenseConcluded" : {
+      "@id" : "spdx:licenseConcluded",
+      "@type" : "spdx:AnyLicenseInfo"
+    },
+    "referencesFile" : {
+      "@id" : "spdx:referencesFile",
+      "@type" : "spdx:File"
+    },
+    "licenseException" : {
+      "@id" : "spdx:licenseException",
+      "@type" : "spdx:LicenseException"
+    },
+    "referenceType" : {
+      "@id" : "spdx:referenceType",
+      "@type" : "spdx:ReferenceType"
+    },
+    "packageVerificationCode" : {
+      "@id" : "spdx:packageVerificationCode",
+      "@type" : "spdx:PackageVerificationCode"
+    },
+    "dataLicense" : {
+      "@id" : "spdx:dataLicense",
+      "@type" : "spdx:AnyLicenseInfo"
+    },
+    "member" : {
+      "@id" : "rdfs:member"
+    },
+    "members" : {
+      "@id" : "spdx:members",
+      "@type" : "spdx:AnyLicenseInfo",
+      "@container" : "@set"
+    },
+    "algorithm" : {
+      "@id" : "spdx:algorithm",
+      "@type" : "spdx:ChecksumAlgorithm"
+    },
+    "relatedSpdxElement" : {
+      "@id" : "spdx:relatedSpdxElement",
+      "@type" : "spdx:SpdxElement"
+    },
+    "licenseInfoFromFiles" : {
+      "@id" : "spdx:licenseInfoFromFiles",
+      "@type" : "spdx:SimpleLicensingInfo",
+      "@container" : "@set"
+    },
+    "licenseInfoInFile" : {
+      "@id" : "spdx:licenseInfoInFile",
+      "@type" : "spdx:AnyLicenseInfo"
+    },
+    "licenseInfoInFiles" : {
+      "@id" : "spdx:licenseInfoInFiles",
+      "@type" : "spdx:AnyLicenseInfo",
+      "@container" : "@set"
+    },
+    "licenseInfoInSnippet" : {
+      "@id" : "spdx:licenseInfoInSnippet",
+      "@type" : "spdx:AnyLicenseInfo"
+    },
+    "licenseInfoInSnippets" : {
+      "@id" : "spdx:licenseInfoInSnippets",
+      "@type" : "spdx:AnyLicenseInfo",
+      "@container" : "@set"
+    },
+    "usedBy" : {
+      "@id" : "spdx:usedBy"
+    },
+    "annotation" : {
+      "@id" : "spdx:annotation",
+      "@type" : "spdx:Annotation"
+    },
+    "annotations" : {
+      "@id" : "spdx:annotations",
+      "@type" : "spdx:Annotation",
+      "@container" : "@set"
+    },
+    "agent" : {
+      "@id" : "spdx:agent"
+    },
+    "externalDocumentRef" : {
+      "@id" : "spdx:externalDocumentRef",
+      "@type" : "spdx:ExternalDocumentRef"
+    },
+    "externalDocumentRefs" : {
+      "@id" : "spdx:externalDocumentRefs",
+      "@type" : "spdx:ExternalDocumentRef",
+      "@container" : "@set"
+    },
+    "startPointer" : {
+      "@id" : "rdfpointer:startPointer",
+      "@type" : "rdfpointer:SinglePointer"
+    },
+    "reference" : {
+      "@id" : "rdfpointer:reference",
+      "@type" : "spdx:File"
+    },
+    "reviewed" : {
+      "@id" : "spdx:reviewed"
+    },
+    "creationInfo" : {
+      "@id" : "spdx:creationInfo",
+      "@type" : "spdx:CreationInfo"
+    },
+    "checksum" : {
+      "@id" : "spdx:checksum",
+      "@type" : "spdx:Checksum"
+    },
+    "checksums" : {
+      "@id" : "spdx:checksums",
+      "@type" : "spdx:Checksum",
+      "@container" : "@set"
+    },
+    "annotationType" : {
+      "@id" : "spdx:annotationType",
+      "@type" : "spdx:AnnotationType"
+    },
+    "describesPackage" : {
+      "@id" : "spdx:describesPackage",
+      "@type" : "spdx:Package"
+    },
+    "describesPackages" : {
+      "@id" : "spdx:describesPackages",
+      "@type" : "spdx:Package",
+      "@container" : "@set"
+    },
+    "relationshipType" : {
+      "@id" : "spdx:relationshipType",
+      "@type" : "spdx:RelationshipType"
+    },
+    "hasExtractedLicensingInfo" : {
+      "@id" : "spdx:hasExtractedLicensingInfo",
+      "@type" : "spdx:ExtractedLicensingInfo"
+    },
+    "hasExtractedLicensingInfos" : {
+      "@id" : "spdx:hasExtractedLicensingInfos",
+      "@type" : "spdx:ExtractedLicensingInfo",
+      "@container" : "@set"
+    },
+    "spdxDocument" : {
+      "@id" : "spdx:spdxDocument",
+      "@type" : "spdx:SpdxDocument"
+    },
+    "artifactOf" : {
+      "@id" : "spdx:artifactOf",
+      "@type" : "doap:Project"
+    },
+    "artifactOfs" : {
+      "@id" : "spdx:artifactOfs",
+      "@type" : "doap:Project",
+      "@container" : "@set"
+    },
+    "snippetFromFile" : {
+      "@id" : "spdx:snippetFromFile",
+      "@type" : "spdx:File"
+    },
+    "referenceCategory" : {
+      "@id" : "spdx:referenceCategory",
+      "@type" : "spdx:ReferenceCategory"
+    },
+    "range" : {
+      "@id" : "spdx:range",
+      "@type" : "rdfpointer:StartEndPointer"
+    },
+    "ranges" : {
+      "@id" : "spdx:ranges",
+      "@type" : "rdfpointer:StartEndPointer",
+      "@container" : "@set"
+    },
+    "externalRef" : {
+      "@id" : "spdx:externalRef",
+      "@type" : "spdx:ExternalRef"
+    },
+    "externalRefs" : {
+      "@id" : "spdx:externalRefs",
+      "@type" : "spdx:ExternalRef",
+      "@container" : "@set"
+    },
+    "endPointer" : {
+      "@id" : "rdfpointer:endPointer",
+      "@type" : "rdfpointer:SinglePointer"
+    },
+    "relationship" : {
+      "@id" : "spdx:relationship",
+      "@type" : "spdx:Relationship"
+    },
+    "relationships" : {
+      "@id" : "spdx:relationships",
+      "@type" : "spdx:Relationship",
+      "@container" : "@set"
+    },
+    "fileType" : {
+      "@id" : "spdx:fileType",
+      "@type" : "spdx:FileType"
+    },
+    "fileTypes" : {
+      "@id" : "spdx:fileTypes",
+      "@type" : "spdx:FileType",
+      "@container" : "@set"
+    },
+    "licenseDeclared" : {
+      "@id" : "spdx:licenseDeclared",
+      "@type" : "spdx:AnyLicenseInfo"
+    },
+    "hasFile" : {
+      "@id" : "spdx:hasFile",
+      "@type" : "spdx:File"
+    },
+    "hasFiles" : {
+      "@id" : "spdx:hasFiles",
+      "@type" : "spdx:File",
+      "@container" : "@set"
+    },
+    "fileDependency" : {
+      "@id" : "spdx:fileDependency",
+      "@type" : "spdx:File"
+    },
+    "fileDependencies" : {
+      "@id" : "spdx:fileDependencies",
+      "@type" : "spdx:File",
+      "@container" : "@set"
+    },
+    "sourceInfo" : {
+      "@id" : "spdx:sourceInfo",
+      "@type" : "xmlschema:string"
+    },
+    "noticeText" : {
+      "@id" : "spdx:noticeText",
+      "@type" : "xmlschema:string"
+    },
+    "standardLicenseTemplate" : {
+      "@id" : "spdx:standardLicenseTemplate",
+      "@type" : "xmlschema:string"
+    },
+    "name" : {
+      "@id" : "spdx:name",
+      "@type" : "xmlschema:string"
+    },
+    "checksumValue" : {
+      "@id" : "spdx:checksumValue",
+      "@type" : "xmlschema:hexBinary"
+    },
+    "locatorFormat" : {
+      "@id" : "spdx:locatorFormat",
+      "@type" : "xmlschema:string"
+    },
+    "extractedText" : {
+      "@id" : "spdx:extractedText",
+      "@type" : "xmlschema:string"
+    },
+    "standardLicenseHeader" : {
+      "@id" : "spdx:standardLicenseHeader",
+      "@type" : "xmlschema:string"
+    },
+    "reviewer" : {
+      "@id" : "spdx:reviewer",
+      "@type" : "xmlschema:string"
+    },
+    "licenseListVersion" : {
+      "@id" : "spdx:licenseListVersion",
+      "@type" : "xmlschema:string"
+    },
+    "documentation" : {
+      "@id" : "spdx:documentation",
+      "@type" : "xmlschema:anyURI"
+    },
+    "packageVerificationCodeExcludedFile" : {
+      "@id" : "spdx:packageVerificationCodeExcludedFile",
+      "@type" : "xmlschema:string"
+    },
+    "packageVerificationCodeExcludedFiles" : {
+      "@id" : "spdx:packageVerificationCodeExcludedFiles",
+      "@type" : "xmlschema:string",
+      "@container" : "@set"
+    },
+    "snippetName" : {
+      "@id" : "spdx:snippetName"
+    },
+    "fileName" : {
+      "@id" : "spdx:fileName",
+      "@type" : "xmlschema:string"
+    },
+    "packageName" : {
+      "@id" : "spdx:packageName",
+      "@type" : "xmlschema:string"
+    },
+    "copyrightText" : {
+      "@id" : "spdx:copyrightText",
+      "@type" : "rdfs:Literal"
+    },
+    "specVersion" : {
+      "@id" : "spdx:specVersion",
+      "@type" : "xmlschema:string"
+    },
+    "isFsfLibre" : {
+      "@id" : "spdx:isFsfLibre",
+      "@type" : "xmlschema:boolean"
+    },
+    "comment" : {
+      "@id" : "rdfs:comment"
+    },
+    "licenseText" : {
+      "@id" : "spdx:licenseText",
+      "@type" : "xmlschema:string"
+    },
+    "description" : {
+      "@id" : "spdx:description",
+      "@type" : "xmlschema:string"
+    },
+    "seeAlso" : {
+      "@id" : "rdfs:seeAlso"
+    },
+    "seeAlsos" : {
+      "@id" : "rdfs:seeAlsos",
+      "@container" : "@set"
+    },
+    "licenseExceptionText" : {
+      "@id" : "spdx:licenseExceptionText",
+      "@type" : "xmlschema:string"
+    },
+    "contextualExample" : {
+      "@id" : "spdx:contextualExample",
+      "@type" : "xmlschema:string"
+    },
+    "summary" : {
+      "@id" : "spdx:summary",
+      "@type" : "xmlschema:string"
+    },
+    "externalReferenceSite" : {
+      "@id" : "spdx:externalReferenceSite",
+      "@type" : "xmlschema:anyURI"
+    },
+    "filesAnalyzed" : {
+      "@id" : "spdx:filesAnalyzed",
+      "@type" : "xmlschema:boolean"
+    },
+    "versionInfo" : {
+      "@id" : "spdx:versionInfo",
+      "@type" : "xmlschema:string"
+    },
+    "created" : {
+      "@id" : "spdx:created",
+      "@type" : "xmlschema:dateTime"
+    },
+    "lineNumber" : {
+      "@id" : "rdfpointer:lineNumber",
+      "@type" : "xmlschema:positiveInteger"
+    },
+    "offset" : {
+      "@id" : "rdfpointer:offset",
+      "@type" : "xmlschema:positiveInteger"
+    },
+    "spdxVersion" : {
+      "@id" : "spdx:spdxVersion",
+      "@type" : "xmlschema:string"
+    },
+    "date" : {
+      "@id" : "spdx:date",
+      "@type" : "xmlschema:dateTime"
+    },
+    "annotationDate" : {
+      "@id" : "spdx:annotationDate"
+    },
+    "example" : {
+      "@id" : "spdx:example",
+      "@type" : "xmlschema:string"
+    },
+    "fileContributor" : {
+      "@id" : "spdx:fileContributor",
+      "@type" : "xmlschema:string"
+    },
+    "fileContributors" : {
+      "@id" : "spdx:fileContributors",
+      "@type" : "xmlschema:string",
+      "@container" : "@set"
+    },
+    "licenseId" : {
+      "@id" : "spdx:licenseId",
+      "@type" : "xmlschema:string"
+    },
+    "referenceLocator" : {
+      "@id" : "spdx:referenceLocator",
+      "@type" : "xmlschema:string"
+    },
+    "packageVerificationCodeValue" : {
+      "@id" : "spdx:packageVerificationCodeValue",
+      "@type" : "xmlschema:hexBinary"
+    },
+    "isDeprecatedLicenseId" : {
+      "@id" : "spdx:isDeprecatedLicenseId",
+      "@type" : "xmlschema:boolean"
+    },
+    "homepage" : {
+      "@id" : "doap:homepage",
+      "@type" : "xmlschema:anyURI"
+    },
+    "supplier" : {
+      "@id" : "spdx:supplier",
+      "@type" : "xmlschema:string"
+    },
+    "reviewDate" : {
+      "@id" : "spdx:reviewDate",
+      "@type" : "xmlschema:dateTime"
+    },
+    "licenseExceptionId" : {
+      "@id" : "spdx:licenseExceptionId",
+      "@type" : "xmlschema:string"
+    },
+    "standardLicenseHeaderTemplate" : {
+      "@id" : "spdx:standardLicenseHeaderTemplate",
+      "@type" : "xmlschema:string"
+    },
+    "packageFileName" : {
+      "@id" : "spdx:packageFileName",
+      "@type" : "xmlschema:string"
+    },
+    "licenseComments" : {
+      "@id" : "spdx:licenseComments",
+      "@type" : "xmlschema:string"
+    },
+    "downloadLocation" : {
+      "@id" : "spdx:downloadLocation",
+      "@type" : "xmlschema:anyURI"
+    },
+    "originator" : {
+      "@id" : "spdx:originator",
+      "@type" : "xmlschema:string"
+    },
+    "externalDocumentId" : "@id",
+    "creator" : {
+      "@id" : "spdx:creator",
+      "@type" : "xmlschema:string"
+    },
+    "creators" : {
+      "@id" : "spdx:creators",
+      "@type" : "xmlschema:string",
+      "@container" : "@set"
+    },
+    "annotator" : {
+      "@id" : "spdx:annotator",
+      "@type" : "xmlschema:string"
+    },
+    "isOsiApproved" : {
+      "@id" : "spdx:isOsiApproved",
+      "@type" : "xmlschema:boolean"
+    },
+    "term_status" : {
+      "@id" : "http://www.w3.org/2003/06/sw-vocab-status/ns#term_status"
+    },
+    "deprecatedProperty" : {
+      "@id" : "owl:deprecatedProperty"
+    },
+    "deprecatedClass" : {
+      "@id" : "owl:deprecatedClass"
+    },
+    "Document" : {
+      "@type" : "spdx:SpdxDocument",
+      "@id" : "spdx:spdxDocument"
+    },
+    "SPDXID" : "@id"
+  }
+}


### PR DESCRIPTION
Replaces PR #205 

Add a JSON-LD context file defining linked data for properties and property types.

This context file can be quite useful for tools developers needing the types for JSON properties.

This file includes types and property URI's for all of the properties defined in the ontology OWL file.

It also includes properties unique to the JSON format:
- plural form for arrays of properties
- SPDX identifiers
- SPDX external document reference ID's
- "Document" property

Note that some of the plural forms do have issues as they are machine generated.

This file is generated by a utility which converts the RDF OWL document:  https://github.com/goneall/Spdx-Tools-Java/blob/master/src/main/java/org/spdx/tools/RdfSchemaToJsonContext.java

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>