### PR TITLE
Add JSON schema

### DIFF
--- a/examples/SPDXJSONExample-v2.0.spdx.json
+++ b/examples/SPDXJSONExample-v2.0.spdx.json
@@ -12,14 +12,14 @@
     "dataLicense" : "CC0-1.0",
     "comment" : "This document was created using SPDX 2.0 using licenses from the web site.",
     "externalDocumentRefs" : [ {
+      "externalDocumentId" : "DocumentRef-spdx-tool-1.2",
       "checksum" : {
         "algorithm" : "SHA1",
         "checksumValue" : "d6a770ba38583ed4bb4525bd96e50461655d2759"
       },
-      "externalDocumentId" : "DocumentRef-spdx-tool-1.2",
       "spdxDocument" : "http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301"
     } ],
-    "hasExtractedLicensingInfo" : [ {
+    "hasExtractedLicensingInfos" : [ {
       "extractedText" : "\"THE BEER-WARE LICENSE\" (Revision 42):\nphk@FreeBSD.ORG wrote this file. As long as you retain this notice you\ncan do whatever you want with this stuff. If we meet some day, and you think this stuff is worth it, you can buy me a beer in return Poul-Henning Kamp  </\nLicenseName: Beer-Ware License (Version 42)\nLicenseCrossReference:  http://people.freebsd.org/~phk/\nLicenseComment: \nThe beerware license has a couple of other standard variants.",
       "licenseId" : "LicenseRef-Beerware-4.2"
     }, {
@@ -39,6 +39,11 @@
       "licenseId" : "LicenseRef-1"
     } ],
     "annotations" : [ {
+      "annotationDate" : "2010-01-29T18:30:22Z",
+      "annotationType" : "OTHER",
+      "annotator" : "Person: Jane Doe ()",
+      "comment" : "Document level annotation"
+    }, {
       "annotationDate" : "2011-03-13T00:00:00Z",
       "annotationType" : "REVIEW",
       "annotator" : "Person: Suzanne Reviewer",
@@ -48,11 +53,6 @@
       "annotationType" : "REVIEW",
       "annotator" : "Person: Joe Reviewer",
       "comment" : "This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses"
-    }, {
-      "annotationDate" : "2010-01-29T18:30:22Z",
-      "annotationType" : "OTHER",
-      "annotator" : "Person: Jane Doe ()",
-      "comment" : "Document level annotation"
     } ],
     "documentNamespace" : "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301",
     "documentDescribes" : [ "SPDXRef-File", "SPDXRef-Package" ],
@@ -84,7 +84,7 @@
       } ],
       "description" : "The Saxon package is a collection of tools for processing XML documents.",
       "downloadLocation" : "https://sourceforge.net/projects/saxon/files/Saxon-B/8.8.0.7/saxonb8-8-0-7j.zip/download",
-      "filesAnalyzed" : "false",
+      "filesAnalyzed" : false,
       "homepage" : "http://saxon.sourceforge.net/",
       "licenseComments" : "Other versions available for a commercial license",
       "licenseConcluded" : "MPL-1.0",
@@ -104,11 +104,11 @@
         "algorithm" : "SHA256",
         "checksumValue" : "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
       }, {
-        "algorithm" : "MD5",
-        "checksumValue" : "624c1abb3664f4b35547e7c73864ad24"
-      }, {
         "algorithm" : "SHA1",
         "checksumValue" : "85ed0817af83a24ad8da68c2b5094de69833983c"
+      }, {
+        "algorithm" : "MD5",
+        "checksumValue" : "624c1abb3664f4b35547e7c73864ad24"
       } ],
       "copyrightText" : "Copyright 2008-2010 John Smith",
       "description" : "The GNU C Library defines functions that are specified by the ISO C standard, as well as additional features specific to POSIX and other derivatives of the Unix operating system, and extensions specific to GNU systems.",
@@ -116,20 +116,20 @@
       "externalRefs" : [ {
         "referenceCategory" : "SECURITY",
         "referenceLocator" : "cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*",
-        "referenceType" : { }
+        "referenceType" : "http://spdx.org/rdf/references/cpe23Type"
       }, {
         "comment" : "This is the external ref for Acme",
         "referenceCategory" : "OTHER",
         "referenceLocator" : "acmecorp/acmenator/4.1.3-alpha",
-        "referenceType" : { }
+        "referenceType" : "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge"
       } ],
-      "filesAnalyzed" : "true",
+      "filesAnalyzed" : true,
       "hasFiles" : [ "SPDXRef-JenaLib", "SPDXRef-DoapSource", "SPDXRef-CommonsLangSrc" ],
       "homepage" : "http://ftp.gnu.org/gnu/glibc",
       "licenseComments" : "The license for this project changed with the release of version x.y.  The version of the project included here post-dates the license change.",
-      "licenseConcluded" : "(LGPL-2.0-only OR LicenseRef-1)",
-      "licenseDeclared" : "(LGPL-2.0-only AND LicenseRef-1)",
-      "licenseInfoFromFiless" : [ "GPL-2.0-only", "LicenseRef-2", "LicenseRef-0" ],
+      "licenseConcluded" : "(LGPL-2.0-only OR LicenseRef-3)",
+      "licenseDeclared" : "(LGPL-2.0-only AND LicenseRef-3)",
+      "licenseInfoFromFiles" : [ "GPL-2.0-only", "LicenseRef-2", "LicenseRef-1" ],
       "name" : "glibc",
       "originator" : "Organization: ExampleCodeInspect (contact@example.com)",
       "packageFileName" : "glibc-2.11.1.tar.gz",
@@ -168,8 +168,8 @@
       "fileName" : "./lib-source/jena-2.6.3-sources.jar",
       "fileTypes" : [ "ARCHIVE" ],
       "licenseComments" : "This license is used by Jena",
-      "licenseConcluded" : "LicenseRef-0",
-      "licenseInfoInFiles" : [ "LicenseRef-0" ]
+      "licenseConcluded" : "LicenseRef-1",
+      "licenseInfoInFiles" : [ "LicenseRef-1" ]
     }, {
       "SPDXID" : "SPDXRef-CommonsLangSrc",
       "checksums" : [ {
@@ -219,20 +219,20 @@
       "name" : "from linux kernel",
       "ranges" : [ {
         "endPointer" : {
-          "offset" : "420",
+          "lineNumber" : 23,
           "reference" : "SPDXRef-DoapSource"
         },
         "startPointer" : {
-          "offset" : "310",
+          "lineNumber" : 5,
           "reference" : "SPDXRef-DoapSource"
         }
       }, {
         "endPointer" : {
-          "lineNumber" : "23",
+          "offset" : 420,
           "reference" : "SPDXRef-DoapSource"
         },
         "startPointer" : {
-          "lineNumber" : "5",
+          "offset" : 310,
           "reference" : "SPDXRef-DoapSource"
         }
       } ],
@@ -240,20 +240,20 @@
     } ],
     "relationships" : [ {
       "spdxElementId" : "SPDXRef-DOCUMENT",
-      "relatedSpdxElement" : "DocumentRef-0:SPDXRef-ToolsElement",
-      "relationshipType" : "COPY_OF"
-    }, {
-      "spdxElementId" : "SPDXRef-DOCUMENT",
       "relatedSpdxElement" : "SPDXRef-File",
       "relationshipType" : "DESCRIBES"
     }, {
       "spdxElementId" : "SPDXRef-DOCUMENT",
       "relatedSpdxElement" : "SPDXRef-Package",
-      "relationshipType" : "CONTAINS"
+      "relationshipType" : "DESCRIBES"
+    }, {
+      "spdxElementId" : "SPDXRef-DOCUMENT",
+      "relatedSpdxElement" : "DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement",
+      "relationshipType" : "COPY_OF"
     }, {
       "spdxElementId" : "SPDXRef-DOCUMENT",
       "relatedSpdxElement" : "SPDXRef-Package",
-      "relationshipType" : "DESCRIBES"
+      "relationshipType" : "CONTAINS"
     }, {
       "spdxElementId" : "SPDXRef-Package",
       "relatedSpdxElement" : "SPDXRef-JenaLib",

--- a/schemas/spdx-schema.json
+++ b/schemas/spdx-schema.json
@@ -1,0 +1,570 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "$id" : "http://spdx.org/rdf/terms",
+  "title" : "SPDX 2.2",
+  "type" : "object",
+  "properties" : {
+    "Document" : {
+      "type" : "object",
+      "properties" : {
+        "hasExtractedLicensingInfos" : {
+          "description" : "Indicates that a particular ExtractedLicensingInfo was defined in the subject SpdxDocument.",
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "properties" : {
+              "seeAlsos" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string"
+                }
+              },
+              "name" : {
+                "description" : "Identify name of this SpdxElement.",
+                "type" : "string"
+              },
+              "comment" : {
+                "type" : "string"
+              },
+              "licenseId" : {
+                "description" : "A human readable short form license identifier for a license. The license ID is iether on the standard license oist or the form \"LicenseRef-\"[idString] where [idString] is a unique string containing letters, numbers, \".\", \"-\" or \"+\".",
+                "type" : "string"
+              },
+              "extractedText" : {
+                "description" : "Verbatim license or licensing notice text that was discovered.",
+                "type" : "string"
+              }
+            },
+            "description" : "An ExtractedLicensingInfo represents a license or licensing notice that was found in the package. Any license text that is recognized as a license may be represented as a License rather than an ExtractedLicensingInfo."
+          }
+        },
+        "name" : {
+          "description" : "Identify name of this SpdxElement.",
+          "type" : "string"
+        },
+        "comment" : {
+          "type" : "string"
+        },
+        "annotations" : {
+          "description" : "Provide additional information about an SpdxElement.",
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "properties" : {
+              "annotationDate" : {
+                "description" : "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                "type" : "string"
+              },
+              "comment" : {
+                "type" : "string"
+              },
+              "annotator" : {
+                "description" : "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
+                "type" : "string"
+              },
+              "annotationType" : {
+                "description" : "Type of the annotation.",
+                "type" : "string",
+                "enum" : [ "OTHER", "REVIEW" ]
+              }
+            },
+            "description" : "An Annotation is a comment on an SpdxItem by an agent."
+          }
+        },
+        "describesPackages" : {
+          "description" : "The describesPackage property relates an SpdxDocument to the package which it describes.",
+          "type" : "array",
+          "items" : {
+            "description" : "SPDX ID for Package.  The describesPackage property relates an SpdxDocument to the package which it describes.",
+            "type" : "string"
+          }
+        },
+        "dataLicense" : {
+          "description" : "License expression for dataLicense.  Compliance with the SPDX specification includes populating the SPDX fields therein with data related to such fields (\"SPDX-Metadata\"). The SPDX specification contains numerous fields where an SPDX document creator may provide relevant explanatory text in SPDX-Metadata. Without opining on the lawfulness of \"database rights\" (in jurisdictions where applicable), such explanatory text is copyrightable subject matter in most Berne Convention countries. By using the SPDX specification, or any portion hereof, you hereby agree that any copyright rights (as determined by your jurisdiction) in any SPDX-Metadata, including without limitation explanatory text, shall be subject to the terms of the Creative Commons CC0 1.0 Universal license. For SPDX-Metadata not containing any copyright rights, you hereby agree and acknowledge that the SPDX-Metadata is provided to you \"as-is\" and without any representations or warranties of any kind concerning the SPDX-Metadata, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non-infringement, or the absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law.",
+          "type" : "string"
+        },
+        "externalDocumentRefs" : {
+          "description" : "Identify any external SPDX documents referenced within this SPDX document.",
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "properties" : {
+              "externalDocumentId" : {
+                "description" : "externalDocumentId is a string containing letters, numbers, ., - and/or + which uniquely identifies an external document within this document.",
+                "type" : "string"
+              },
+              "checksum" : {
+                "type" : "object",
+                "properties" : {
+                  "algorithm" : {
+                    "description" : "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
+                    "type" : "string",
+                    "enum" : [ "SHA256", "SHA1", "MD5" ]
+                  },
+                  "checksumValue" : {
+                    "description" : "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
+                    "type" : "string"
+                  }
+                },
+                "description" : "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
+              },
+              "spdxDocument" : {
+                "description" : "SPDX ID for SpdxDocument.  A propoerty containing an SPDX document.",
+                "type" : "string"
+              }
+            },
+            "description" : "Information about an external SPDX document reference including the checksum. This allows for verification of the external references."
+          }
+        },
+        "spdxVersion" : {
+          "description" : "Provide a reference number that can be used to understand how to parse and interpret the rest of the file. It will enable both future changes to the specification and to support backward compatibility. The version number consists of a major and minor version indicator. The major field will be incremented when incompatible changes between versions are made (one or more sections are created, modified or deleted). The minor field will be incremented when backwards compatible changes are made.",
+          "type" : "string"
+        },
+        "creationInfo" : {
+          "type" : "object",
+          "properties" : {
+            "comment" : {
+              "type" : "string"
+            },
+            "created" : {
+              "description" : "Identify when the SPDX file was originally created. The date is to be specified according to combined date and time in UTC format as specified in ISO 8601 standard. This field is distinct from the fields in section 8, which involves the addition of information during a subsequent review.",
+              "type" : "string"
+            },
+            "creators" : {
+              "description" : "Identify who (or what, in the case of a tool) created the SPDX file. If the SPDX file was created by an individual, indicate the person's name. If the SPDX file was created on behalf of a company or organization, indicate the entity name. If the SPDX file was created using a software tool, indicate the name and version for that tool. If multiple participants or tools were involved, use multiple instances of this field. Person name or organization name may be designated as “anonymous” if appropriate.",
+              "type" : "array",
+              "items" : {
+                "description" : "Identify who (or what, in the case of a tool) created the SPDX file. If the SPDX file was created by an individual, indicate the person's name. If the SPDX file was created on behalf of a company or organization, indicate the entity name. If the SPDX file was created using a software tool, indicate the name and version for that tool. If multiple participants or tools were involved, use multiple instances of this field. Person name or organization name may be designated as “anonymous” if appropriate.",
+                "type" : "string"
+              },
+              "minItems" : 1
+            },
+            "licenseListVersion" : {
+              "description" : "An optional field for creators of the SPDX file to provide the version of the SPDX License List used when the SPDX file was created.",
+              "type" : "string"
+            }
+          },
+          "description" : "One instance is required for each SPDX file produced. It provides the necessary information for forward and backward compatibility for processing tools."
+        },
+        "packages" : {
+          "description" : "Packages referenced in the SPDX document",
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "properties" : {
+              "annotations" : {
+                "description" : "Provide additional information about an SpdxElement.",
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "annotationDate" : {
+                      "description" : "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                      "type" : "string"
+                    },
+                    "comment" : {
+                      "type" : "string"
+                    },
+                    "annotator" : {
+                      "description" : "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
+                      "type" : "string"
+                    },
+                    "annotationType" : {
+                      "description" : "Type of the annotation.",
+                      "type" : "string",
+                      "enum" : [ "OTHER", "REVIEW" ]
+                    }
+                  },
+                  "description" : "An Annotation is a comment on an SpdxItem by an agent."
+                }
+              },
+              "supplier" : {
+                "description" : "The name and, optionally, contact information of the person or organization who was the immediate supplier of this package to the recipient. The supplier may be different than originator when the software has been repackaged. Values of this property must conform to the agent and tool syntax.",
+                "type" : "string"
+              },
+              "homepage" : {
+                "type" : "string"
+              },
+              "packageVerificationCode" : {
+                "type" : "object",
+                "properties" : {
+                  "packageVerificationCodeValue" : {
+                    "description" : "The actual package verification code as a hex encoded value.",
+                    "type" : "string"
+                  },
+                  "packageVerificationCodeExcludedFiles" : {
+                    "description" : "A file that was excluded when calculating the package verification code. This is usually a file containing SPDX data regarding the package. If a package contains more than one SPDX file all SPDX files must be excluded from the package verification code. If this is not done it would be impossible to correctly calculate the verification codes in both files.",
+                    "type" : "array",
+                    "items" : {
+                      "description" : "A file that was excluded when calculating the package verification code. This is usually a file containing SPDX data regarding the package. If a package contains more than one SPDX file all SPDX files must be excluded from the package verification code. If this is not done it would be impossible to correctly calculate the verification codes in both files.",
+                      "type" : "string"
+                    }
+                  }
+                },
+                "description" : "A manifest based verification code (the algorithm is defined in section 4.7 of the full specification) of the SPDX Item. This allows consumers of this data and/or database to determine if an SPDX item they have in hand is identical to the SPDX item from which the data was produced. This algorithm works even if the SPDX document is included in the SPDX item."
+              },
+              "checksums" : {
+                "description" : "The checksum property provides a mechanism that can be used to verify that the contents of a File or Package have not changed.",
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "algorithm" : {
+                      "description" : "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
+                      "type" : "string",
+                      "enum" : [ "SHA256", "SHA1", "MD5" ]
+                    },
+                    "checksumValue" : {
+                      "description" : "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
+                      "type" : "string"
+                    }
+                  },
+                  "description" : "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
+                }
+              },
+              "downloadLocation" : {
+                "description" : "The URI at which this package is available for download. Private (i.e., not publicly reachable) URIs are acceptable as values of this property. The values http://spdx.org/rdf/terms#none and http://spdx.org/rdf/terms#noassertion may be used to specify that the package is not downloadable or that no attempt was made to determine its download location, respectively.",
+                "type" : "string"
+              },
+              "filesAnalyzed" : {
+                "description" : "Indicates whether the file content of this package has been available for or subjected to analysis when creating the SPDX document. If false indicates packages that represent metadata or URI references to a project, product, artifact, distribution or a component. If set to false, the package must not contain any files.",
+                "type" : "boolean"
+              },
+              "externalRefs" : {
+                "description" : "An External Reference allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package.",
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "comment" : {
+                      "type" : "string"
+                    },
+                    "referenceCategory" : {
+                      "description" : "Category for the external reference",
+                      "type" : "string",
+                      "enum" : [ "OTHER", "SECURITY", "PACKAGE_MANAGER" ]
+                    },
+                    "referenceLocator" : {
+                      "description" : "The unique string with no spaces necessary to access the package-specific information, metadata, or content within the target location. The format of the locator is subject to constraints defined by the <type>.",
+                      "type" : "string"
+                    },
+                    "referenceType" : {
+                      "description" : "Type of the external reference. These are definined in an appendix in the SPDX specification.",
+                      "type" : "string"
+                    }
+                  },
+                  "description" : "An External Reference allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package."
+                }
+              },
+              "licenseComments" : {
+                "description" : "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+                "type" : "string"
+              },
+              "name" : {
+                "description" : "Identify name of this SpdxElement.",
+                "type" : "string"
+              },
+              "hasFiles" : {
+                "description" : "Indicates that a particular file belongs to a package.",
+                "type" : "array",
+                "items" : {
+                  "description" : "SPDX ID for File.  Indicates that a particular file belongs to a package.",
+                  "type" : "string"
+                }
+              },
+              "comment" : {
+                "type" : "string"
+              },
+              "copyrightText" : {
+                "description" : "The text of copyright declarations recited in the Package or File.",
+                "type" : "string"
+              },
+              "summary" : {
+                "description" : "Provides a short description of the package.",
+                "type" : "string"
+              },
+              "originator" : {
+                "description" : "The name and, optionally, contact information of the person or organization that originally created the package. Values of this property must conform to the agent and tool syntax.",
+                "type" : "string"
+              },
+              "packageFileName" : {
+                "description" : "The base name of the package file name. For example, zlib-1.2.5.tar.gz.",
+                "type" : "string"
+              },
+              "versionInfo" : {
+                "description" : "Provides an indication of the version of the package that is described by this SpdxDocument.",
+                "type" : "string"
+              },
+              "licenseInfoFromFiles" : {
+                "description" : "The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.",
+                "type" : "array",
+                "items" : {
+                  "description" : "License expression for licenseInfoFromFiles.  The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.",
+                  "type" : "string"
+                },
+                "minItems" : 1
+              },
+              "sourceInfo" : {
+                "description" : "Allows the producer(s) of the SPDX document to describe how the package was acquired and/or changed from the original source.",
+                "type" : "string"
+              },
+              "description" : {
+                "description" : "Provides a detailed description of the package.",
+                "type" : "string"
+              }
+            }
+          }
+        },
+        "files" : {
+          "description" : "Files referenced in the SPDX document",
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "properties" : {
+              "fileTypes" : {
+                "description" : "The type of the file.",
+                "type" : "array",
+                "items" : {
+                  "description" : "The type of the file.",
+                  "type" : "string",
+                  "enum" : [ "OTHER", "DOCUMENTATION", "IMAGE", "VIDEO", "ARCHIVE", "SPDX", "APPLICATION", "SOURCE", "BINARY", "TEXT", "AUDIO" ]
+                }
+              },
+              "annotations" : {
+                "description" : "Provide additional information about an SpdxElement.",
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "annotationDate" : {
+                      "description" : "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                      "type" : "string"
+                    },
+                    "comment" : {
+                      "type" : "string"
+                    },
+                    "annotator" : {
+                      "description" : "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
+                      "type" : "string"
+                    },
+                    "annotationType" : {
+                      "description" : "Type of the annotation.",
+                      "type" : "string",
+                      "enum" : [ "OTHER", "REVIEW" ]
+                    }
+                  },
+                  "description" : "An Annotation is a comment on an SpdxItem by an agent."
+                }
+              },
+              "checksums" : {
+                "description" : "The checksum property provides a mechanism that can be used to verify that the contents of a File or Package have not changed.",
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "algorithm" : {
+                      "description" : "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
+                      "type" : "string",
+                      "enum" : [ "SHA256", "SHA1", "MD5" ]
+                    },
+                    "checksumValue" : {
+                      "description" : "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
+                      "type" : "string"
+                    }
+                  },
+                  "description" : "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
+                },
+                "minItems" : 1
+              },
+              "noticeText" : {
+                "description" : "This field provides a place for the SPDX file creator to record potential legal notices found in the file. This may or may not include copyright statements.",
+                "type" : "string"
+              },
+              "artifactOfs" : {
+                "description" : "Indicates the project in which the SpdxElement originated. Tools must preserve doap:homepage and doap:name properties and the URI (if one is known) of doap:Project resources that are values of this property. All other properties of doap:Projects are not directly supported by SPDX and may be dropped when translating to or from some SPDX formats.",
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : { }
+                }
+              },
+              "licenseComments" : {
+                "description" : "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+                "type" : "string"
+              },
+              "name" : {
+                "description" : "Identify name of this SpdxElement.",
+                "type" : "string"
+              },
+              "fileName" : {
+                "description" : "The name of the file relative to the root of the package.",
+                "type" : "string"
+              },
+              "comment" : {
+                "type" : "string"
+              },
+              "copyrightText" : {
+                "description" : "The text of copyright declarations recited in the Package or File.",
+                "type" : "string"
+              },
+              "fileContributors" : {
+                "description" : "This field provides a place for the SPDX file creator to record file contributors. Contributors could include names of copyright holders and/or authors who may not be copyright holders yet contributed to the file content.",
+                "type" : "array",
+                "items" : {
+                  "description" : "This field provides a place for the SPDX file creator to record file contributors. Contributors could include names of copyright holders and/or authors who may not be copyright holders yet contributed to the file content.",
+                  "type" : "string"
+                }
+              },
+              "licenseInfoInFiles" : {
+                "description" : "Licensing information that was discovered directly in the subject file. This is also considered a declared license for the file.",
+                "type" : "array",
+                "items" : {
+                  "description" : "License expression for licenseInfoInFile.  Licensing information that was discovered directly in the subject file. This is also considered a declared license for the file.",
+                  "type" : "string"
+                },
+                "minItems" : 1
+              },
+              "licenseInfoFromFiles" : {
+                "description" : "The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.",
+                "type" : "array",
+                "items" : {
+                  "description" : "License expression for licenseInfoFromFiles.  The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.",
+                  "type" : "string"
+                },
+                "minItems" : 1
+              },
+              "fileDependencies" : {
+                "type" : "array",
+                "items" : {
+                  "description" : "SPDX ID for File",
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        },
+        "snippets" : {
+          "description" : "Snippets referenced in the SPDX document",
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "properties" : {
+              "ranges" : {
+                "description" : "This field defines the byte range in the original host file (in X.2) that the snippet information applies to",
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "startPointer" : {
+                      "type" : "object",
+                      "properties" : {
+                        "reference" : {
+                          "description" : "SPDX ID for File",
+                          "type" : "string"
+                        }
+                      }
+                    },
+                    "endPointer" : {
+                      "type" : "object",
+                      "properties" : {
+                        "reference" : {
+                          "description" : "SPDX ID for File",
+                          "type" : "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "minItems" : 1
+              },
+              "licenseComments" : {
+                "description" : "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+                "type" : "string"
+              },
+              "name" : {
+                "description" : "Identify name of this SpdxElement.",
+                "type" : "string"
+              },
+              "snippetFromFile" : {
+                "description" : "SPDX ID for File.  File containing the SPDX element (e.g. the file contaning a snippet).",
+                "type" : "string"
+              },
+              "comment" : {
+                "type" : "string"
+              },
+              "copyrightText" : {
+                "description" : "The text of copyright declarations recited in the Package or File.",
+                "type" : "string"
+              },
+              "licenseInfoInSnippets" : {
+                "description" : "Licensing information that was discovered directly in the subject snippet. This is also considered a declared license for the snippet.",
+                "type" : "array",
+                "items" : {
+                  "description" : "License expression for licenseInfoInSnippet.  Licensing information that was discovered directly in the subject snippet. This is also considered a declared license for the snippet.",
+                  "type" : "string"
+                },
+                "minItems" : 1
+              },
+              "annotations" : {
+                "description" : "Provide additional information about an SpdxElement.",
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "annotationDate" : {
+                      "description" : "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                      "type" : "string"
+                    },
+                    "comment" : {
+                      "type" : "string"
+                    },
+                    "annotator" : {
+                      "description" : "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
+                      "type" : "string"
+                    },
+                    "annotationType" : {
+                      "description" : "Type of the annotation.",
+                      "type" : "string",
+                      "enum" : [ "OTHER", "REVIEW" ]
+                    }
+                  },
+                  "description" : "An Annotation is a comment on an SpdxItem by an agent."
+                }
+              },
+              "licenseInfoFromFiles" : {
+                "description" : "The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.",
+                "type" : "array",
+                "items" : {
+                  "description" : "License expression for licenseInfoFromFiles.  The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.",
+                  "type" : "string"
+                },
+                "minItems" : 1
+              }
+            }
+          }
+        },
+        "relationships" : {
+          "description" : "Relationships referenced in the SPDX document",
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "properties" : {
+              "comment" : {
+                "type" : "string"
+              },
+              "relationshipType" : {
+                "description" : "Describes the type of relationship between two SPDX elements.",
+                "type" : "string",
+                "enum" : [ "VARIANT_OF", "PATCH_FOR", "COPY_OF", "CONTAINED_BY", "DATA_FILE_OF", "OPTIONAL_COMPONENT_OF", "ANCESTOR_OF", "GENERATES", "CONTAINS", "FILE_ADDED", "DESCRIBES", "PREREQUISITE_FOR", "HAS_PREREQUISITE", "DYNAMIC_LINK", "DESCRIBED_BY", "METAFILE_OF", "PATCH_APPLIED", "FILE_MODIFIED", "DISTRIBUTION_ARTIFACT", "DOCUMENTATION_OF", "GENERATED_FROM", "STATIC_LINK", "OTHER", "BUILD_TOOL_OF", "TEST_CASE_OF", "FILE_DELETED", "DESCENDANT_OF", "PACKAGE_OF", "EXPANDED_FROM_ARCHIVE" ]
+              },
+              "relatedSpdxElement" : {
+                "description" : "SPDX ID for SpdxElement.  A related SpdxElement.",
+                "type" : "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The JSON schema was generated from the OWL ontology document.

There is also a minor fix to the JSON example to match the generated schema.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>