### PR TITLE
Add ability to use NONE & NOASSERTION to relationships

### DIFF
--- a/chapters/1-rationale.md
+++ b/chapters/1-rationale.md
@@ -116,4 +116,6 @@ In an SPDX document, Relationship elements can be used to indicate relationships
 
 **1.9.7** A new appendix "SPDX Lite" has been added to document a lightweight subset of the SPDX specification for scenarios where a full SPDX document is not required. See [Appendix VIII](appendix-VIII-SPDX-Lite.md) for more information.
 
-**1.9.8** Miscellaneous bug fixes and non-breaking improvements as reported on the mailing list and reported as issues on the [spdx-spec GitHub repository](https://github.com/spdx/spdx-spec).
+**1.9.8** Additional relationship options have been added to enable expression of different forms of dependencies between SPDX elements.   As well, NONE and NOASSERTION keywords are now permitted to be used with relationships to indicated what is unknown.
+
+**1.9.9** Miscellaneous bug fixes and non-breaking improvements as reported on the mailing list and reported as issues on the [spdx-spec GitHub repository](https://github.com/spdx/spdx-spec).

--- a/chapters/7-relationships-between-SPDX-elements.md
+++ b/chapters/7-relationships-between-SPDX-elements.md
@@ -2,7 +2,13 @@
 
 ## 7.1 Relationship <a name="7.1"></a>
 
-**7.1.1** Purpose: This field provides information about the relationship between two SPDX elements. For example, you can represent a relationship between two different Files, between a Package and a File, between two Packages, or between one SPDXDocument and another SPDXDocument. The relationships between two elements that are supported are:
+**7.1.1** Purpose: This field provides information about the relationship between two SPDX elements. For example, you can represent a relationship between two different Files, between a Package and a File, between two Packages, or between one SPDXDocument and another SPDXDocument. 
+
+In cases where there are "known unknowns", the use of the keyword "NOASSERTION" can be used on the right hand side of a relationship to indicate that the author is not asserting whether there are other SPDX elements (package/file/snippet) are connected by relationships or not.  ie. There could be some, but the author is not asserting one way or another.  
+
+Similarly, the use of the keywords "NONE" can be used to indicate that an SPDX element (package/file/snippet) has no other elements connected by some relationship to it.
+
+The relationships between two SPDX elements that are supported are:
 
 | Relationship           | Description | Example |
 |------------------------|-------------|---------|

--- a/chapters/7-relationships-between-SPDX-elements.md
+++ b/chapters/7-relationships-between-SPDX-elements.md
@@ -4,9 +4,9 @@
 
 **7.1.1** Purpose: This field provides information about the relationship between two SPDX elements. For example, you can represent a relationship between two different Files, between a Package and a File, between two Packages, or between one SPDXDocument and another SPDXDocument. 
 
-In cases where there are "known unknowns", the use of the keyword NOASSERTION" can be used on the right hand side of a relationship to indicate that the author is not asserting whether there are other SPDX elements (package/file/snippet) are connected by relationships or not.  ie. There could be some, but the author is not asserting one way or another.  
+In cases where there are "known unknowns", the use of the keyword `NOASSERTION` can be used on the right hand side of a relationship to indicate that the author is not asserting whether there are other SPDX elements (package/file/snippet) are connected by relationships or not.  ie. There could be some, but the author is not asserting one way or another.  
 
-Similarly, the use of the keywords "NONE" can be used to indicate that an SPDX element (package/file/snippet) has no other elements connected by some relationship to it.
+Similarly, the use of the keywords `NONE` can be used to indicate that an SPDX element (package/file/snippet) has no other elements connected by some relationship to it.
 
 The relationships between two SPDX elements that are supported are:
 

--- a/chapters/7-relationships-between-SPDX-elements.md
+++ b/chapters/7-relationships-between-SPDX-elements.md
@@ -4,7 +4,7 @@
 
 **7.1.1** Purpose: This field provides information about the relationship between two SPDX elements. For example, you can represent a relationship between two different Files, between a Package and a File, between two Packages, or between one SPDXDocument and another SPDXDocument. 
 
-In cases where there are "known unknowns", the use of the keyword "NOASSERTION" can be used on the right hand side of a relationship to indicate that the author is not asserting whether there are other SPDX elements (package/file/snippet) are connected by relationships or not.  ie. There could be some, but the author is not asserting one way or another.  
+In cases where there are "known unknowns", the use of the keyword NOASSERTION" can be used on the right hand side of a relationship to indicate that the author is not asserting whether there are other SPDX elements (package/file/snippet) are connected by relationships or not.  ie. There could be some, but the author is not asserting one way or another.  
 
 Similarly, the use of the keywords "NONE" can be used to indicate that an SPDX element (package/file/snippet) has no other elements connected by some relationship to it.
 
@@ -16,8 +16,9 @@ The relationships between two SPDX elements that are supported are:
 | DESCRIBED_BY           | Is to be used when SPDXRef-A is described by SPDXREF-Document                                         | The package ‘WildFly’ is described by SPDX document `Wildfly.spdx`. |
 | CONTAINS               | Is to be used when SPDXRef-A contains SPDXRef-B.                                                      | An ARCHIVE file `bar.tgz` contains a SOURCE file `foo.c`. |
 | CONTAINED_BY           | Is to be used when SPDXRef-A is contained by SPDXRef-B.                                               | A SOURCE file `foo.c` is contained by ARCHIVE file `bar.tgz` |
-| DEPENDENCY_MANIFEST_OF | Is to be used when SPDXRef-A is a manifest file that lists a set of dependencies for SPDXRef-B        | A file `package.json` is the dependency manifest of a package `foo`. Note that only one manifest should be used to define the same dependency graph. | 
+| DEPENDS_ON             | Is to be used when SPDXRef-A depends on SPDXRef-B. | Package A depends on the presence of package B in order to build and run |
 | DEPENDENCY_OF          | Is to be used when SPDXRef-A is dependency of SPDXRef-B.                                              | A is explicitly stated as a dependency of B in a machine-readable file. Use when a package manager does not define scopes.|
+| DEPENDENCY_MANIFEST_OF | Is to be used when SPDXRef-A is a manifest file that lists a set of dependencies for SPDXRef-B        | A file `package.json` is the dependency manifest of a package `foo`. Note that only one manifest should be used to define the same dependency graph. | 
 | BUILD\_DEPENDENCY_OF   | Is to be used when SPDXRef-A is a build dependency of SPDXRef-B.                                      | A is in the `compile` scope of B in a Maven project. |
 | DEV\_DEPENDENCY_OF     | Is to be used when SPDXRef-A is development dependency of SPDXRef-B.                                  | A is in the `devDependencies` scope of B in a Maven project. |
 | OPTIONAL\_DEPENDENCY_OF| Is to be used when SPDXRef-A is an optional dependency of SPDXRef-B.                                  | Use when building the code will proceed even if a dependency cannot be found, fails to install, or is only installed on a specific platform. For example A is in the `optionalDependencies` scope of npm project B. |
@@ -63,13 +64,17 @@ The relationships between two SPDX elements that are supported are:
 
 **7.1.4** Data Format:
 
-    ["DocumentRef-"[idstring]":"]SPDXID <relationship> ["DocumentRef-"[idstring]":"]SPDXID
+    ["DocumentRef-"[idstring]":"]SPDXID <relationship> ["DocumentRef-"[idstring]":"]SPDXID | `NONE` | `NOASSERTION`
 
 where "DocumentRef-"`[idstring]`":" is an optional reference to an external SPDX document as described in [section 2.6](2-document-creation-information.md#2.6)
 
 where `SPDXID` is a string containing letters, numbers, `.` and/or `-`. as described in sections (2.3, 3.2, 4.2).
 
 where `<relationship>` is one of the documented relationship types in table 7.1.1.
+
+where `NONE` can be used to explicitly indicate there are NO other relationships.
+
+where `NOASSERTION` can be used to explicitly indicate its not clear if there are relationships that may apply or not.
 
 **7.1.5** Tag: `Relationship:`
 
@@ -82,6 +87,14 @@ Examples:
     Relationship: SPDXRef-DOCUMENT AMENDS DocumentRef-SPDXA:SPDXRef-DOCUMENT
 
     RelationshipComment: This current document is an amendment of the SPDXA document.
+    
+    Relationship: SPDXRef-CarolCompression DEPENDS_ON NONE
+    
+    RelationshipComment: The package CarolCompression can be treated as a root with no dependencies.
+    
+    Relationship: SPDXRef-BobBrowser DEPENDS_ON NOASSERTION
+    
+    RelationshipComment: The package BobBrowser may have other packages required as dependencies, but the author has insufficient information to threat this as other than unknown at this point in time.
 
 **7.1.6** RDF: Property `relationship` in any SpdxElement
 

--- a/chapters/7-relationships-between-SPDX-elements.md
+++ b/chapters/7-relationships-between-SPDX-elements.md
@@ -76,7 +76,7 @@ where `<relationship>` is one of the documented relationship types in table 7.1.
 
 where `NONE` can be used to explicitly indicate there are NO other relationships.
 
-where `NOASSERTION` can be used to explicitly indicate its not clear if there are relationships that may apply or not.
+where `NOASSERTION` can be used to explicitly indicate it is not clear if there are relationships that may apply or not.
 
 **7.1.5** Tag: `Relationship:`
 
@@ -92,11 +92,11 @@ Examples:
     
     Relationship: SPDXRef-CarolCompression DEPENDS_ON NONE
     
-    RelationshipComment: The package CarolCompression can be treated as a root with no dependencies.
+    RelationshipComment: The package CarolCompression can be considered as a root with no dependencies.
     
-    Relationship: SPDXRef-BobBrowser DEPENDS_ON NOASSERTION
+    Relationship: SPDXRef-BobBrowser CONTAINS NOASSERTION
     
-    RelationshipComment: The package BobBrowser may have other packages required as dependencies, but the author has insufficient information to threat this as other than unknown at this point in time.
+    RelationshipComment: The package BobBrowser may have other packages embedded in it, but the author has insufficient information to treat this as other than unknown at this point in time.
 
 **7.1.6** RDF: Property `relationship` in any SpdxElement
 

--- a/chapters/7-relationships-between-SPDX-elements.md
+++ b/chapters/7-relationships-between-SPDX-elements.md
@@ -8,6 +8,8 @@ In cases where there are "known unknowns", the use of the keyword `NOASSERTION` 
 
 Similarly, the use of the keywords `NONE` can be used to indicate that an SPDX element (package/file/snippet) has no other elements connected by some relationship to it.
 
+The use of `NOASSERTION`or `NONE` is not mandatory for any relationship. If no relationship of a particular type is specified, then the document author is not presumed to be asserting whether or not there are relationships of that type. If some relationships of a particular type are specified, then the document author is not presumed to be asserting whether there are more possible relationships of that type.
+
 The relationships between two SPDX elements that are supported are:
 
 | Relationship           | Description | Example |


### PR DESCRIPTION
In the NTIA Framing Workgroup Phase 1, there was the requirement to be able to specify the known-unknowns (see: section 2.4.1 in https://www.ntia.gov/files/ntia/publications/framingsbom_20191112.pdf)  

Based on discussion in ISSUE #137, the use of the keywords of NONE and NOASSERTION can extend to represent these concepts, and be used with relationships.   To support tooling and different formats,  these keywords are initially being limited to be on the right hand side of a relationship.  

In order to be able to express these concepts "DEPENDS_ON" relationship has been introduced, to be the mirror of the "DEPENDENCY_OF". 