### PR TITLE
Remove multi-line license exprs and mandatory parens

### DIFF
--- a/chapters/appendix-IV-SPDX-license-expressions.md
+++ b/chapters/appendix-IV-SPDX-license-expressions.md
@@ -41,6 +41,8 @@ A valid `<license-expression>` string consists of either:
 
 There MUST NOT be whitespace between a license-id and any following `+`. This supports easy parsing and backwards compatibility. There MUST be whitespace on either side of the operator "WITH". There MUST be whitespace and/or parentheses on either side of the operators `AND` and `OR`.
 
+In the `tag:value` format, a license expression MUST be on a single line, and MUST NOT include a line break in the middle of the expression.
+
 ## Simple License Expressions <a name="simple-expr"></a>
 
 A simple `<license-expression>` is composed one of the following:
@@ -59,7 +61,11 @@ Some examples:
 
 ## Composite License Expressions <a name="composite-expr"></a>
 
-More expressive composite license expressions can be constructed using "OR", "AND", and "WITH" operators similar to constructing mathematical expressions using arithmetic operators. For the `tag:value` format, any license expression that consists of more than one license identifier and/or LicenseRef, should be encapsulated by parentheses: "( )". This has been specified to facilitate expression parsing. Nested parentheses can also be used to specify an order of precedence which is discussed in more detail in subsection (4).
+More expressive composite license expressions can be constructed using "OR", "AND", and "WITH" operators similar to constructing mathematical expressions using arithmetic operators.
+
+For the `tag:value` format, any license expression that consists of more than one license identifier and/or LicenseRef, may optionally be encapsulated by parentheses: "( )".
+
+Nested parentheses can also be used to specify an order of precedence which is discussed in more detail in subsection (4).
 
 ### 1) Disjunctive "OR" Operator
 
@@ -67,11 +73,11 @@ If presented with a choice between two or more licenses, use the disjunctive bin
 
 For example, when given a choice between the LGPL-2.1-only or MIT licenses, a valid expression would be:
 
-    (LGPL-2.1-only OR MIT)
+    LGPL-2.1-only OR MIT
 
 An example representing a choice between three different licenses would be:
 
-(LGPL-2.1-only OR MIT OR BSD-3-Clause)
+    LGPL-2.1-only OR MIT OR BSD-3-Clause
 
 ### 2) Conjunctive "AND" Operator
 
@@ -79,11 +85,11 @@ If required to simultaneously comply with two or more licenses, use the conjunct
 
 For example, when one is required to comply with both the LGPL-2.1-only or MIT licenses, a valid expression would be:
 
-    (LGPL-2.1-only AND MIT)
+    LGPL-2.1-only AND MIT
 
 An example where all three different licenses apply would be:
 
-    (LGPL-2.1-only AND MIT AND BSD-2-Clause)
+    LGPL-2.1-only AND MIT AND BSD-2-Clause
 
 ### 3) Exception "WITH" Operator
 
@@ -91,7 +97,7 @@ Sometimes a set of license terms apply except under special circumstances. In th
 
 For example, when the Bison exception is to be applied to GPL-2.0-or-later, the expression would be:
 
-    (GPL-2.0-or-later WITH Bison-exception-2.2)
+    GPL-2.0-or-later WITH Bison-exception-2.2
 
 The current set of valid exceptions can be found in [Appendix I, section 2](appendix-I-SPDX-license-list.md#I.2). For the most up to date set of exceptions please see [spdx.org/licenses](https://spdx.org/licenses). If the applicable exception is not found on the SPDX License Exception List, then use a single `<license-ref>` to represent the entire license terms (including the exception).
 
@@ -116,7 +122,7 @@ When required to express an order of precedence that is different from the defau
 
 For instance, the following expression:
 
-    (MIT AND (LGPL-2.1-or-later OR BSD-3-Clause))
+    MIT AND (LGPL-2.1-or-later OR BSD-3-Clause)
 
 states the OR operator should be applied before the AND operator. That is, one should first select between the LGPL-2.1-or-later or the BSD-3-Clause license before applying the MIT license.
 

--- a/chapters/appendix-V-using-SPDX-short-identifiers-in-source-files.md
+++ b/chapters/appendix-V-using-SPDX-short-identifiers-in-source-files.md
@@ -37,17 +37,18 @@ Examples:
 
 ## Representing Multiple Licenses
 
-Multiple licenses can be represented using a SPDX license expression as defined in Appendix IV. A set of licenses must be enclosed in parentheses (this is a convention for SPDX expressions). As further described there:
+Multiple licenses can be represented using a SPDX license expression as defined in Appendix IV. A set of licenses may optionally be enclosed in parentheses, but are not required to be enclosed. As further described there:
 
 1. When there is a choice between licenses ("disjunctive license"), they should be separated with "OR". If presented with a choice between two or more licenses, use the disjunctive binary "OR" operator to construct a new license expression.
 2. Similarly when multiple licenses need to be simultaneously applied ("conjunctive license"), they should be separated with "AND". If required to simultaneously comply with two or more licenses, use the conjunctive binary "AND" operator to construct a new license expression.
 3. In some cases, a set of license terms apply except under special circumstances, in this case, use the "WITH" operator followed by one of the [recognized exception identifiers](https://spdx.org/licenses/exceptions-index.html).
+4. The expression MUST be on a single line, and MUST NOT include a line break in the middle of the expression.
 
 Examples:
 
-    SPDX-License-Identifier: (GPL-2.0-only OR MIT)
-    SPDX-License-Identifier: (LGPL-2.1-only AND BSD-2-Clause)
-    SPDX-License-Identifier: (GPL-2.0-or-later WITH Bison-exception-2.2)
+    SPDX-License-Identifier: GPL-2.0-only OR MIT
+    SPDX-License-Identifier: LGPL-2.1-only AND BSD-2-Clause
+    SPDX-License-Identifier: GPL-2.0-or-later WITH Bison-exception-2.2
     
 
 Please see [Appendix IV of SPDX 2.2 Specification](./appendix-IV-SPDX-license-expressions.md) for more examples and details of the license expression specific syntax.


### PR DESCRIPTION
This changes appendices IV and V to prohibit multiple lines (e.g.,
line breaks) in a single license expression. This is applicable
for both tag-value SPDX documents as well as short-form license
identifier expressions in source code.

Because multiple lines are no longer permitted, this also makes
the outer set of parentheses optional, rather than mandatory, for
license expressions with more than one license identifier.

Fixes #44
Fixes #45
Fixes #52

Signed-off-by: Steve Winslow <steve@swinslow.net>