### PR TITLE
Address case sensitivity for license expressions

### DIFF
--- a/chapters/appendix-IV-SPDX-license-expressions.md
+++ b/chapters/appendix-IV-SPDX-license-expressions.md
@@ -43,6 +43,14 @@ There MUST NOT be whitespace between a license-id and any following `+`. This su
 
 In the `tag:value` format, a license expression MUST be on a single line, and MUST NOT include a line break in the middle of the expression.
 
+## Case sensitivity <a name="case-sensitivity"></a>
+
+License expression operators (`AND`, `OR` and `WITH`) should be matched in a *case-sensitive* manner.
+
+License identifiers (including license exception identifiers) used in SPDX documents or source code files should be matched in a *case-insensitive* manner. In other words, `MIT`, `Mit` and `mIt` should all be treated as the same identifier and referring to the same license.
+
+However, please be aware that it is often important to match with the case of the canonical identifier on the [SPDX License List](https://spdx.org/licenses). This is because the canonical identifier's case is used in the URL of the license's or exception's entry on the List, and because the canonical identifier is translated to a URI in RDF documents.
+
 ## Simple License Expressions <a name="simple-expr"></a>
 
 A simple `<license-expression>` is composed one of the following:


### PR DESCRIPTION
This commit attempts to reflect the outcome of the discussion at
identifiers should be matched in a case-sensitive manner.

Specifically it attempts to reflect the comment at
regarding the outcome of the tech team discussion on 2018-06-05.

Closes #63 

Replacement for PR #222 due to merge conflicts

Signed-off-by: Steve Winslow <steve@swinslow.net>