### PR TITLE
dataLicense can be only one license (CC0-1.0)

### DIFF
--- a/chapters/2-base-profile.md
+++ b/chapters/2-base-profile.md
@@ -79,7 +79,7 @@ Information about the SPDX document itself.
                 fontsize = 10
         ]
 
-        DocumentMetadata [label = "{DocumentMetadata|+ spdxVersion : string\l+ dataLicense : SPDXExpression\l+ SPDXID : string\l+ documentNamespace : string\l+ documentName : string\l+ created : DateTime\l+ creators : Identity[1..*]\l+ externalDocumentReferences : ExternalDocumentReference[0..*]\l|}"]
+        DocumentMetadata [label = "{DocumentMetadata|+ spdxVersion : string\l+ dataLicense : CC0-LICENSEID\l+ SPDXID : string\l+ documentNamespace : string\l+ documentName : string\l+ created : DateTime\l+ creators : Identity[1..*]\l+ externalDocumentReferences : ExternalDocumentReference[0..*]\l|}"]
       }
 %}
 ### 2.2.2 Metadata


### PR DESCRIPTION
According to the description: "By using the SPDX specification ..., you hereby agree that any copyright rights ... shall be subject to the terms of the Creative Commons CC0 1.0 Universal license."

The value of Document Information / dataLicense thus cannot be any arbitrary SPDXExpression, it must be only the expression "CC0-1.0" as shown in the examples.  For consistency with the Description, the schema should specify that any other value of dataLicense is invalid.

(Note: the name of the constant type CC0-LICENSEID is arbitrary as long as it is a string matching the regex ^CC0-1\\.0$).