### PR TITLE
Use field name spdxID

### DIFF
--- a/chapters/2-base-profile.md
+++ b/chapters/2-base-profile.md
@@ -79,7 +79,7 @@ Information about the SPDX document itself.
                 fontsize = 10
         ]
 
-        DocumentMetadata [label = "{DocumentMetadata|+ spdxVersion : string\l+ dataLicense : SPDXExpression\l+ SPDXID : string\l+ documentNamespace : string\l+ documentName : string\l+ created : DateTime\l+ creators : Identity[1..*]\l+ externalDocumentReferences : ExternalDocumentReference[0..*]\l|}"]
+        DocumentMetadata [label = "{DocumentMetadata|+ spdxVersion : string\l+ dataLicense : SPDXExpression\l+ spdxID : SPDXREF-DOC\l+ documentNamespace : string\l+ documentName : string\l+ created : DateTime\l+ creators : Identity[1..*]\l+ externalDocumentReferences : ExternalDocumentReference[0..*]\l|}"]
       }
 %}
 ### 2.2.2 Metadata


### PR DESCRIPTION
All but one of the Document Metadata fields have a consistent name format (spdxVersion, dataLicense, etc).   SPDXID is the name of a type, not a field.  The field name should be spdxID.

The type could be SPDXID rather than string, but if the string can have only a single value, it should be a constant string type matching the regex ^SPDXRef-Document$.   (The name of the constant string type SPDXREF-DOC is arbitrary.)