### PR TITLE
Fix various typos and errors

### DIFF
--- a/chapters/1-rationale.md
+++ b/chapters/1-rationale.md
@@ -14,7 +14,7 @@ Companies and organizations (collectively “Organizations”) are widely using 
 
 ## 1.4 What does this specification cover? <a name="1.4"></a>
 
-**1.4.1** SPDX Document Creation Information: Meta data to associate analysis results with a specific version of the SPDX file and license for use, and provide information on how, when, and by whom the SPDX file was created.
+**1.4.1** SPDX Document Creation Information: Metadata to associate analysis results with a specific version of the SPDX file and license for use, and provide information on how, when, and by whom the SPDX file was created.
 
 **1.4.2** Package Information: Facts that are common properties of an entire package.
 
@@ -88,11 +88,11 @@ In addition to the supported formats, the following format is in development wit
 
 | Format      | Extension   |
 | ----------- | ----------- |
-| `tag:value` | *.spdx      |
+| tag:value   | *.spdx      |
 | RDF         | *.spdx.rdf  |
 | JSON        | *.spdx.json |
 | XML         | *.spdx.xml  |
-| YAML        | *.spdx.yaml or *.spdx.yml |
+| YAML        | \*.spdx.yaml or \*.spdx.yml |
 
 **1.7.10** The convention in this specification is for the RDF examples to use `rdf:about="..."` to represent that a proper Universal Resource Indicator (URI) should be present.
 
@@ -116,6 +116,6 @@ In addition to the supported formats, the following format is in development wit
 
 **1.9.3** A new appendix "SPDX Lite" has been added to document a lightweight subset of the SPDX specification for scenarios where a full SPDX document is not required. See [Appendix VIII](appendix-VIII-SPDX-Lite.md) for more information.
 
-**1.9.4** Additional relationship options have been added to enable expression of different forms of dependencies between SPDX elements.   As well, NONE and NOASSERTION keywords are now permitted to be used with relationships to indicated what is unknown.
+**1.9.4** Additional relationship options have been added to enable expression of different forms of dependencies between SPDX elements. As well, NONE and NOASSERTION keywords are now permitted to be used with relationships to indicate what is unknown.
 
 **1.9.5** Miscellaneous bug fixes and non-breaking improvements as reported on the mailing list and reported as issues on the [spdx-spec GitHub repository](https://github.com/spdx/spdx-spec).

--- a/chapters/2-document-creation-information.md
+++ b/chapters/2-document-creation-information.md
@@ -72,7 +72,7 @@ Example:
 
 **2.3.3** Cardinality: Mandatory, one.
 
-**2.3.4** DataFormat: `SPDXRef-DOCUMENT`
+**2.3.4** Data Format: `SPDXRef-DOCUMENT`
 
 **2.3.5** Tag: `SPDXID:`
 
@@ -96,7 +96,7 @@ Example:
 
 **2.4.3** Cardinality: Mandatory, one.
 
-**2.4.4** DataFormat: Single line of text.
+**2.4.4** Data Format: Single line of text.
 
 **2.4.5** Tag: `DocumentName:`
 
@@ -203,7 +203,7 @@ Example:
 
     <externalDocumentRef rdf:ID="DocumentRef-spdx-tool-1.2">
         <ExternalDocumentRef>
-            <spdxDocument rdf:about=”http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82...” />
+            <spdxDocument rdf:about="http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82..." />
             <checksum>
                 <Checksum>
                     <algorithm rdf:resource="checksumAlgorithm_sha1"/>
@@ -255,9 +255,9 @@ Example:
 
 **2.8.4** Data Format: Single line of text with the following keywords:
 
-    ”Person: person name” and optional “(email)”
-    "Organization: organization” and optional “(email)”
-    "Tool: toolidentifier-version”
+    "Person: person name" and optional "(email)"
+    "Organization: organization" and optional "(email)"
+    "Tool: toolidentifier-version"
 
 **2.8.5** Tag: `Creator:`
 

--- a/chapters/3-package-information.md
+++ b/chapters/3-package-information.md
@@ -6,12 +6,12 @@ Cardinality: Optional, one or many.
 
 In `tag:value` format, the order in which package and files occur is syntactically significant.
 
-A new Package Information section is denoted by the [Package Name](#3.1) field.
-All Package Information fields must be grouped together before the start of a [Files section](4-file-information.md), if file(s) are present.
-All files contained in a package must immediately follow the applicable Package Information.
-A new Package Information section (via Package Name) denotes the start of another package.
-Sub-packages should not be nested inside a Package Information section, but should be separate and should use a Relationship to clarify.
-Annotations and Relationships for the package may appear after the Package Information before any file information.
+* A new Package Information section is denoted by the [Package Name](#3.1) field.
+* All Package Information fields must be grouped together before the start of a [Files section](4-file-information.md), if file(s) are present.
+* All files contained in a package must immediately follow the applicable Package Information.
+* A new Package Information section (via Package Name) denotes the start of another package.
+* Sub-packages should not be nested inside a Package Information section, but should be separate and should use a Relationship to clarify.
+* Annotations and Relationships for the package may appear after the Package Information before any file information.
 
 Fields:
 
@@ -181,7 +181,7 @@ Example:
 
 ## 3.6 Package Originator <a name="3.6"></a>
 
-**3.6.1** Purpose: If the package identified in the SPDX file originated from a different person or organization than identified as Package Supplier (see [section 3.5](#3.5) above), this field identifies from where or whom the package originally came. In some cases a package may be created and originally distributed by a different third party than the Package Supplier of the package. For example, the SPDX file identifies the package [glibc][] and [Red Hat][RedHat] as the Package Supplier, but the [Free Software Foundation][FSF] is the Package Originator.
+**3.6.1** Purpose: If the package identified in the SPDX file originated from a different person or organization than identified as Package Supplier (see [section 3.5](#3.5) above), this field identifies from where or whom the package originally came. In some cases a package may be created and originally distributed by a different third party than the Package Supplier of the package. For example, the SPDX file identifies the package [glibc][] and [Red Hat][] as the Package Supplier, but the [Free Software Foundation][FSF] is the Package Originator.
 
 Use `NOASSERTION` if:
 
@@ -431,9 +431,9 @@ Example:
 
 Some examples:
 
-A bundle of external products: Package A can be metadata about Packages and their dependencies. It may also be a loosely organized manifest of references to Packages involved in a product or project. Build or execution may transitively discover more Packages and dependencies. All of these referenced Packages can have their own SPDX Documents. In this case, Package A may be defined with its File Analyzed attribute set to `false`. Package A includes External Document References to SPDX documents containing Packages referenced in all the available relationships. The Relationships section then relates the SPDX documents and contained SPDX elements with appropriate semantics per the dependencies in the scope of Package A.
-Package relation to external product: Package A can have a STATIC_LINK relationship to Package B, but the binary representation of Package B is furnished by the build process and thus not contained in the file list of Package A. In this case, Package B needs to be defined with its Files Analyzed attribute set to false and all the other attributes subject to the subsequently defined constraints. Then, the relationship between Package A and Package B can be documented as described in [Section 7](7-relationships-between-SPDX-elements.md).
-File derived from external product: Package A contains multiple files derived from an outside project. Rather than use the `artifactOf*` attributes (Sections 4.9-4.11) to describe the relation of these files to their project, the outside project can be represented by another package, Package B, whose [`FilesAnalyzed`](#3.8) attribute is set to `false`. Each of the binary files can then have a relationship to package B (Section 6). This allows the outside project to be represented by a single SPDX identifier (the identifier of Package B). It also allows the relationship(s) between the outside project and each of the files be represented in much more detail.
+1. **A bundle of external products**: Package A can be metadata about Packages and their dependencies. It may also be a loosely organized manifest of references to Packages involved in a product or project. Build or execution may transitively discover more Packages and dependencies. All of these referenced Packages can have their own SPDX Documents. In this case, Package A may be defined with its File Analyzed attribute set to `false`. Package A includes External Document References to SPDX documents containing Packages referenced in all the available relationships. The Relationships section then relates the SPDX documents and contained SPDX elements with appropriate semantics per the dependencies in the scope of Package A.
+2. **Package relation to external product**: Package A can have a STATIC_LINK relationship to Package B, but the binary representation of Package B is furnished by the build process and thus not contained in the file list of Package A. In this case, Package B needs to be defined with its Files Analyzed attribute set to false and all the other attributes subject to the subsequently defined constraints. Then, the relationship between Package A and Package B can be documented as described in [Section 7](7-relationships-between-SPDX-elements.md).
+3. **File derived from external product**: Package A contains multiple files derived from an outside project. Rather than use the `artifactOf*` attributes (Sections 4.9-4.11) to describe the relation of these files to their project, the outside project can be represented by another package, Package B, whose [`FilesAnalyzed`](#3.8) attribute is set to `false`. Each of the binary files can then have a relationship to package B (Section 6). This allows the outside project to be represented by a single SPDX identifier (the identifier of Package B). It also allows the relationship(s) between the outside project and each of the files be represented in much more detail.
 
 **3.8.3** Cardinality: Optional, one.  If omitted, the default value of `true` is assumed.
 
@@ -466,11 +466,11 @@ Example:
 **3.9.4** Algorithm:
 
     verificationcode = 0
-    filelist = templist = “”
+    filelist = templist = ""
     for all files in the package {
-        if file is an “excludes” file, skip it /* exclude SPDX analysis file(s) */
+        if file is an "excludes" file, skip it /* exclude SPDX analysis file(s) */
 
-            append templist with “SHA1(file)/n”
+            append templist with "SHA1(file)/n"
         }
     sort templist in ascending order by SHA1 value
     filelist = templist with "/n"s removed. /* ordered sequence of SHA1 values with no separators */
@@ -906,7 +906,7 @@ Example:
     as well as additional features specific to POSIX and other derivatives of the Unix operating system,
     and extensions specific to GNU systems.</text>
 
-3.19.6  RDF:  property `spdx:description` in class `spdx:Package`
+**3.19.6** RDF: property `spdx:description` in class `spdx:Package`
 
 Example:
 
@@ -1015,7 +1015,7 @@ The referenceType value for a non-listed location consists of the SPDX document 
 
 **3.22.2** Intent: To inform a human consumer why the reference exists, what kind of information, content or metadata can be extracted. The target's relationship to artifactOf values of files in the package may need to be explained here. If the reference is BINARY, its relationship to PackageDownloadLocation may need to be explained. If the reference is SOURCE, its relationship to PackageDownloadLocation and SourceInformation may need to be explained.
 
-**3.22.3** Cardinality: Conditional (Optional, one) for each [External Reference][#3.21).
+**3.22.3** Cardinality: Conditional (Optional, one) for each [External Reference](#3.21).
 
 **3.22.4** Data format: Free form text that can span multiple lines.
 
@@ -1071,7 +1071,7 @@ Example:
     following acknowledgement:  This product includes software developed by the AT&T.
     </text>
 
-**3.23.6** RDF: property 'attributionText' in class 'spdx:Package'
+**3.23.6** RDF: property `attributionText` in class `spdx:Package`
 
 Example:
 

--- a/chapters/4-file-information.md
+++ b/chapters/4-file-information.md
@@ -4,13 +4,13 @@ One instance of the File Information is required for each file in the software p
 
 When implementing `tag:value` format, the positioning of File elements is syntactically significant:
 
-Files are assumed to be associated with the Package Information that immediately precedes it, if a package exists.
-Presence of a new Package Information signals the end of the set of files associated with the preceding package, unless an explicit Relationship is used.
-If a package contains files, the File Information section must follow its Package Information section.
-If a File is not part of any package, it must precede any Package Information section reference in the SPDX document.
-The first field to start off the description of a File must be the File Name in `tag:value` format.
-File information is associated with the File Name that precedes it.
-Annotations on the file and Relationships from the file may appear after the file information, before the next file or Package Information section.
+* Files are assumed to be associated with the Package Information that immediately precedes it, if a package exists.
+* Presence of a new Package Information signals the end of the set of files associated with the preceding package, unless an explicit Relationship is used.
+* If a package contains files, the File Information section must follow its Package Information section.
+* If a File is not part of any package, it must precede any Package Information section reference in the SPDX document.
+* The first field to start off the description of a File must be the File Name in `tag:value` format.
+* File information is associated with the File Name that precedes it.
+* Annotations on the file and Relationships from the file may appear after the file information, before the next file or Package Information section.
 
 When implementing file information in RDF, the `spdx:hasFile` property is used to associate the package with the file.
 
@@ -49,7 +49,7 @@ Example:
 
 **4.2.3** Cardinality: Mandatory, one.
 
-**4.2.4** DataFormat: "SPDXRef-"`[idstring]`
+**4.2.4** Data Format: "SPDXRef-"`[idstring]`
 
 where `[idstring]` is a unique string containing letters, numbers, `.` and/or `-`.
 
@@ -65,7 +65,7 @@ Example using `xml:base:`
 
     <rdf:RDF xml:base="http://acme.com/spdxdocs/acmeproj/v1.2/1BE2A4FF-5F1A-48D3-8483-28A9B0349A1B"
         ...
-        <File rdf:ID=”SPDXRef-1”>
+        <File rdf:ID="SPDXRef-1">
             ...
         </File>
 
@@ -190,7 +190,7 @@ A valid SPDX License Expression as defined in [Appendix IV](appendix-IV-SPDX-lic
 
 If the Concluded License is not the same as the License Information in File, a written explanation should be provided in the Comments on License field [(section 4.7)](#4.7). With respect to `NOASSERTION`, a written explanation in the Comments on License field [(section 4.7)](#4.7) is preferred.
 
-**4.5.2** Intent: Here, the intent is for the SPDX file creator to analyze the License Information in file [(section 4.6)](#4.6) and other objective information, e.g., “COPYING FILE,” along with the results from any scanning tools, to arrive at a reasonably objective conclusion as to what license governs the file.
+**4.5.2** Intent: Here, the intent is for the SPDX file creator to analyze the License Information in File [(section 4.6)](#4.6) and other objective information, e.g., “COPYING FILE,” along with the results from any scanning tools, to arrive at a reasonably objective conclusion as to what license governs the file.
 
 **4.5.3** Cardinality: Mandatory, one.
 
@@ -555,7 +555,7 @@ Example:
     following acknowledgement:  This product includes software developed by the AT&T.
     </text>
 
-**4.15.6** RDF: property 'attributionText' in class 'spdx:File'
+**4.15.6** RDF: property `attributionText` in class `spdx:File`
 
 Example:
 

--- a/chapters/5-snippet-information.md
+++ b/chapters/5-snippet-information.md
@@ -6,10 +6,10 @@ Each instance of Snippet Information needs to be associated with a specific File
 
 When implementing `tag:value` format, the positioning of Snippet elements is syntactically significant:
 
-If a File contains Snippets, the Snippet Information section should follow a related File Information section (if it exists in the document).
-Presence of a new file or package section signals the end of the set of snippets associated with the original file, unless an explicit Relationship is used.
-The first field to start off the description of a Snippet must be the Snippet Identifier in `tag:value` format.
-Annotations on the Snippet and Relationships from the Snippet may appear after the Snippet Information, before the next file or Package section.
+* If a File contains Snippets, the Snippet Information section should follow a related File Information section (if it exists in the document).
+* Presence of a new file or package section signals the end of the set of snippets associated with the original file, unless an explicit Relationship is used.
+* The first field to start off the description of a Snippet must be the Snippet Identifier in `tag:value` format.
+* Annotations on the Snippet and Relationships from the Snippet may appear after the Snippet Information, before the next file or Package section.
 
 ## 5.1 Snippet SPDX Identifier <a name="5.1"></a>
 
@@ -19,7 +19,7 @@ Annotations on the Snippet and Relationships from the Snippet may appear after t
 
 **5.1.3** Cardinality: Mandatory, one.
 
-**5.1.4** DataFormat: `SPDXRef-[idstring]`
+**5.1.4** Data Format: `SPDXRef-[idstring]`
 
 where `[idstring]` is a unique string containing letters, numbers, `.` and/or `-`.
 
@@ -35,7 +35,7 @@ Example using xml:base:
 
     <rdf:RDF xml:base="http://acme.com/spdxdocs/acmeproj/v1.2/1BE2A4FF-5F1A-48D3-8483-28A9B0349A1B"
         ...
-        <Snippet rdf:ID=”SPDXRef-1”>
+        <Snippet rdf:ID="SPDXRef-1">
             ...
         </Snippet>
 
@@ -53,15 +53,11 @@ Example using document URI:
 
 **5.2.3** Cardinality: Mandatory, one.
 
-**5.2.4** DataFormat: ["DocumentRef-"[idstring]":"] SPDXID
+**5.2.4** Data Format: ["DocumentRef-"[idstring]":"] SPDXID
 
-where `DocumentRef-[idstring]`: is an optional reference to an external
+where `DocumentRef-[idstring]`: is an optional reference to an external SPDX document as described in [section 2.6](2-document-creation-information.md#2.6)
 
-SPDX document as described in [section 2.6](2-document-creation-information.md#2.6)
-
-where `SPDXID` is a string containing letters, numbers, `.` and/or `-`. as
-
-described in sections (2.3, 3.2, 4.2).
+where `SPDXID` is a string containing letters, numbers, `.` and/or `-`. as described in sections (2.3, 3.2, 4.2).
 
 **5.2.5** Tag: `SnippetFromFileSPDXID:`
 
@@ -77,15 +73,15 @@ Example (snippet from a File in an External SPDX Doc):
 
 Example (snippet from a File in local SPDX Doc):
 
-    <Snippet “rdf:ID=”SPDXRef-1”>
-        <snippetFromFile rdf:about=”#SPDXRef-filecontainingsnippet”>
+    <Snippet rdf:ID="SPDXRef-1">
+        <snippetFromFile rdf:about="#SPDXRef-filecontainingsnippet">
             ...
         </Snippet>
 
 Example (snippet from a File in an External SPDX Doc):
 
-    <Snippet “rdf:ID=”SPDXRef-1”>
-        <snippetFromFile rdf:about=”http://foo.org/ExternalDocument1#SPDXRef-filecontainingsnippet”>
+    <Snippet rdf:ID="SPDXRef-1">
+        <snippetFromFile rdf:about="http://foo.org/ExternalDocument1#SPDXRef-filecontainingsnippet">
         ...
     </Snippet>
 
@@ -93,7 +89,7 @@ Example (snippet from a File in an External SPDX Doc):
 
 **5.3.1** Purpose: This field defines the byte range in the original host file (in [5.2](#5.2)) that the snippet information applies to.
 
-**5.3.2** Intent: A range of bytes is independent of various formatting concerns, and the most accurate way of referring to the differences. The choice was made to start the numbering of the byte range at 1 to be consistent with the W3C pointer method vocabulary (see http://www.w3.org/TR/Pointers-in-RDF10/).
+**5.3.2** Intent: A range of bytes is independent of various formatting concerns, and the most accurate way of referring to the differences. The choice was made to start the numbering of the byte range at 1 to be consistent with the W3C pointer method vocabulary (see [http://www.w3.org/TR/Pointers-in-RDF10/](http://www.w3.org/TR/Pointers-in-RDF10/)).
 
 **5.3.3** Cardinality: Mandatory, one.
 
@@ -147,7 +143,7 @@ Example:
 
 **5.4.1** Purpose: This optional field defines the line range in the original host file (in [5.2](#5.2)) that the snippet information applies to. If there is a disagreement between the byte range and line range, the byte range values will take precedence.
 
-**5.4.2** Intent: A range of lines is a convenient reference for those files where there is a known line delimiter. The choice was made to start the numbering of the lines at 1 to be consistent with the W3C pointer method vocabulary (see http://www.w3.org/TR/Pointers-in-RDF10/).
+**5.4.2** Intent: A range of lines is a convenient reference for those files where there is a known line delimiter. The choice was made to start the numbering of the lines at 1 to be consistent with the W3C pointer method vocabulary (see [http://www.w3.org/TR/Pointers-in-RDF10/](http://www.w3.org/TR/Pointers-in-RDF10/)).
 
 **5.4.3** Cardinality: Optional, one.
 
@@ -164,7 +160,7 @@ Example:
 
     SnippetLineRange: 5:23
 
-**5.4.6** RDF: properties `spdx:byteRange` in class `spdx:Snippet`. The RDF uses the W3C proposed pointer method vocabulary (see http://www.w3.org/TR/Pointers-in-RDF10/)
+**5.4.6** RDF: properties `spdx:byteRange` in class `spdx:Snippet`. The RDF uses the W3C proposed pointer method vocabulary (see [http://www.w3.org/TR/Pointers-in-RDF10/](http://www.w3.org/TR/Pointers-in-RDF10/))
 
 Supported classes from the pointer method vocabulary are `StartEndPointer` and `LineCharPointer`. Supported properties from the pointer method vocabulary include:
 
@@ -337,7 +333,7 @@ Example:
 
 Example:
 
-    <Snippet rdf:about="...”>
+    <Snippet rdf:about="...">
         ...
         <licenseComments>
             The concluded license was taken from package xyz, from which the snippet
@@ -432,7 +428,7 @@ Example:
 
     SnippetName: from linux kernel
 
-5.10.6 RDF: Property `spdx:snippetName` in class `spdx:Snippet`
+**5.10.6** RDF: Property `spdx:snippetName` in class `spdx:Snippet`
 
 Example:
 

--- a/chapters/6-other-licensing-information-detected.md
+++ b/chapters/6-other-licensing-information-detected.md
@@ -1,6 +1,6 @@
 # 6 Other Licensing Information Detected
 
-This section is used for any detected, declared or concluded licenses that are NOT on the SPDX License List. For the most up-to-date version of the list see: http://spdx.org/licenses/. The SPDX License List can also be found here in [Appendix I](appendix-I-SPDX-license-list.md).
+This section is used for any detected, declared or concluded licenses that are NOT on the SPDX License List. For the most up-to-date version of the list see: [https://spdx.org/licenses/](https://spdx.org/licenses/). The SPDX License List can also be found here in [Appendix I](appendix-I-SPDX-license-list.md).
 
 One instance should be created for every unique license or licensing information reference detected in package that does not match one of the licenses on the SPDX License List. Each license instance should have the following fields.
 

--- a/chapters/7-relationships-between-SPDX-elements.md
+++ b/chapters/7-relationships-between-SPDX-elements.md
@@ -14,48 +14,48 @@ The relationships between two SPDX elements that are supported are:
 
 | Relationship           | Description | Example |
 |------------------------|-------------|---------|
-| DESCRIBES              | Is to be used when SPDXRef-DOCUMENT describes SPDXRef-A                                               | An SPDX document `WildFly.spdx` describes package ‘WildFly’. Note this is a logical relationship to help organize related items within an SPDX document that is mandatory if more than one package or set of files (not in a package) is present. |
-| DESCRIBED_BY           | Is to be used when SPDXRef-A is described by SPDXREF-Document                                         | The package ‘WildFly’ is described by SPDX document `Wildfly.spdx`. |
+| DESCRIBES              | Is to be used when SPDXRef-DOCUMENT describes SPDXRef-A.                                              | An SPDX document `WildFly.spdx` describes package ‘WildFly’. Note this is a logical relationship to help organize related items within an SPDX document that is mandatory if more than one package or set of files (not in a package) is present. |
+| DESCRIBED_BY           | Is to be used when SPDXRef-A is described by SPDXREF-Document.                                        | The package ‘WildFly’ is described by SPDX document `Wildfly.spdx`. |
 | CONTAINS               | Is to be used when SPDXRef-A contains SPDXRef-B.                                                      | An ARCHIVE file `bar.tgz` contains a SOURCE file `foo.c`. |
 | CONTAINED_BY           | Is to be used when SPDXRef-A is contained by SPDXRef-B.                                               | A SOURCE file `foo.c` is contained by ARCHIVE file `bar.tgz` |
-| DEPENDS_ON             | Is to be used when SPDXRef-A depends on SPDXRef-B. | Package A depends on the presence of package B in order to build and run |
+| DEPENDS_ON             | Is to be used when SPDXRef-A depends on SPDXRef-B.                                                    | Package A depends on the presence of package B in order to build and run |
 | DEPENDENCY_OF          | Is to be used when SPDXRef-A is dependency of SPDXRef-B.                                              | A is explicitly stated as a dependency of B in a machine-readable file. Use when a package manager does not define scopes.|
-| DEPENDENCY_MANIFEST_OF | Is to be used when SPDXRef-A is a manifest file that lists a set of dependencies for SPDXRef-B        | A file `package.json` is the dependency manifest of a package `foo`. Note that only one manifest should be used to define the same dependency graph. | 
+| DEPENDENCY_MANIFEST_OF | Is to be used when SPDXRef-A is a manifest file that lists a set of dependencies for SPDXRef-B.       | A file `package.json` is the dependency manifest of a package `foo`. Note that only one manifest should be used to define the same dependency graph. | 
 | BUILD\_DEPENDENCY_OF   | Is to be used when SPDXRef-A is a build dependency of SPDXRef-B.                                      | A is in the `compile` scope of B in a Maven project. |
-| DEV\_DEPENDENCY_OF     | Is to be used when SPDXRef-A is development dependency of SPDXRef-B.                                  | A is in the `devDependencies` scope of B in a Maven project. |
-| OPTIONAL\_DEPENDENCY_OF| Is to be used when SPDXRef-A is an optional dependency of SPDXRef-B.                                  | Use when building the code will proceed even if a dependency cannot be found, fails to install, or is only installed on a specific platform. For example A is in the `optionalDependencies` scope of npm project B. |
-| PROVIDED\_DEPENDENCY_OF| Is to be used when SPDXRef-A is a to be provided dependency of SPDXRef-B.                               | A is in the `provided` scope of B in a Maven project, indicating that the project expects it to be provided by for instance by the container or JDK. |
-| TEST\_DEPENDENCY_OF    | Is to be used when SPDXRef-A is test dependency of SPDXRef-B.                                         | A is in the `test` scope of B in a Maven project. |
-| RUNTIME\_DEPENDENCY_OF | Is to be used when SPDXRef-A is dependency required for during the execution of SPDXRef-B.            | A is in the `runtime` scope of B in a Maven project. |
+| DEV\_DEPENDENCY_OF     | Is to be used when SPDXRef-A is a development dependency of SPDXRef-B.                                | A is in the `devDependencies` scope of B in a Maven project. |
+| OPTIONAL\_DEPENDENCY_OF| Is to be used when SPDXRef-A is an optional dependency of SPDXRef-B.                                  | Use when building the code will proceed even if a dependency cannot be found, fails to install, or is only installed on a specific platform. For example, A is in the `optionalDependencies` scope of npm project B. |
+| PROVIDED\_DEPENDENCY_OF| Is to be used when SPDXRef-A is a to be provided dependency of SPDXRef-B.                             | A is in the `provided` scope of B in a Maven project, indicating that the project expects it to be provided, for instance, by the container or JDK. |
+| TEST\_DEPENDENCY_OF    | Is to be used when SPDXRef-A is a test dependency of SPDXRef-B.                                       | A is in the `test` scope of B in a Maven project. |
+| RUNTIME\_DEPENDENCY_OF | Is to be used when SPDXRef-A is a dependency required for the execution of SPDXRef-B.                 | A is in the `runtime` scope of B in a Maven project. |
 | EXAMPLE_OF             | Is to be used when SPDXRef-A is an example of SPDXRef-B.                                              | The file or snippet that illustrates how to use an application or library. |
-| GENERATES              | Is to be used when SPDXRef-A generates the SPDXRef-B.                                                 | A SOURCE file `makefile.mk` generates a BINARY file `a.out` |
+| GENERATES              | Is to be used when SPDXRef-A generates SPDXRef-B.                                                     | A SOURCE file `makefile.mk` generates a BINARY file `a.out` |
 | GENERATED_FROM         | Is to be used when SPDXRef-A was generated from SPDXRef-B.                                            | A BINARY file `a.out` has been generated from a SOURCE file `makefile.mk`. A BINARY file `foolib.a` is generated from a SOURCE file `bar.c`. |
-| ANCESTOR_OF            | Is to be used when SPDXRef-A is an ancestor (same lineage but pre-dates) SPDXRef-B                    | A SOURCE file `makefile.mk` is a version of the original ancestor SOURCE file ‘makefile2.mk’ |
+| ANCESTOR_OF            | Is to be used when SPDXRef-A is an ancestor (same lineage but pre-dates) SPDXRef-B.                   | A SOURCE file `makefile.mk` is a version of the original ancestor SOURCE file ‘makefile2.mk’ |
 | DESCENDANT_OF          | Is to be used when SPDXRef-A is a descendant of (same lineage but postdates) SPDXRef-B.               | A SOURCE file `makefile2.mk` is a descendant of the original SOURCE file ‘makefile.mk’ |
 | VARIANT_OF             | Is to be used when SPDXRef-A is a variant of (same lineage but not clear which came first) SPDXRef-B. | A SOURCE file `makefile2.mk` is a variant of SOURCE file `makefile.mk` if they differ by some edit, but there is no way to tell which came first (no reliable date information). |
 | DISTRIBUTION_ARTIFACT  | Is to be used when distributing SPDXRef-A requires that SPDXRef-B also be distributed.                | A BINARY file `foo.o` requires that the ARCHIVE file `bar-sources.tgz` be made available on distribution. |
 | PATCH_FOR              | Is to be used when SPDXRef-A is a patch file for (to be applied to) SPDXRef-B.                        | A SOURCE file `foo.diff` is a patch file for SOURCE file `foo.c`. |
 | PATCH_APPLIED          | Is to be used when SPDXRef-A is a patch file that has been applied to SPDXRef-B.                      | A SOURCE file `foo.diff` is a patch file that has been applied to SOURCE file ‘foo-patched.c’. |
 | COPY_OF                | Is to be used when SPDXRef-A is an exact copy of SPDXRef-B.                                           | A BINARY file `alib.a` is an exact copy of BINARY file `a2lib.a`. |
-| FILE_ADDED             | Is to be used when SPDXRef-A is a file added to SPDXRef-B.                                            | A SOURCE file `foo.c` has been added to package ARCHIVE `bar.tgz`. |
-| FILE_DELETED           | Is to be used when SPDXRef-A is a file was deleted from to SPDXRef-B.                                 | A SOURCE file `foo.diff` has been deleted from package ARCHIVE `bar.tgz`. |
+| FILE_ADDED             | Is to be used when SPDXRef-A is a file that was added to SPDXRef-B.                                   | A SOURCE file `foo.c` has been added to package ARCHIVE `bar.tgz`. |
+| FILE_DELETED           | Is to be used when SPDXRef-A is a file that was deleted from SPDXRef-B.                               | A SOURCE file `foo.diff` has been deleted from package ARCHIVE `bar.tgz`. |
 | FILE_MODIFIED          | Is to be used when SPDXRef-A is a file that was modified from SPDXRef-B.                              | A SOURCE file `foo.c` has been modified from SOURCE file `foo.orig.c`. |
 | EXPANDED\_FROM_ARCHIVE | Is to be used when SPDXRef-A is expanded from the archive SPDXRef-B.                                  | A SOURCE file `foo.c`, has been expanded from the archive ARCHIVE file `xyz.tgz`. |
 | DYNAMIC_LINK           | Is to be used when SPDXRef-A dynamically links to SPDXRef-B.                                          | An APPLICATION file ‘myapp’ dynamically links to BINARY file `zlib.so`. |
 | STATIC_LINK            | Is to be used when SPDXRef-A statically links to SPDXRef-B.                                           | An APPLICATION file ‘myapp’ statically links to BINARY `zlib.a`. |
 | DATA\_FILE_OF          | Is to be used when SPDXRef-A is a data file used in SPDXRef-B.                                        | An IMAGE file ‘kitty.jpg’ is a data file of an APPLICATION ‘hellokitty’. |
 | TEST\_CASE_OF          | Is to be used when SPDXRef-A is a test case used in testing SPDXRef-B.                                | A SOURCE file `testMyCode.java` is a unit test file used to test an APPLICATION MyPackage. |
-| BUILD\_TOOL_OF         | Is to be used when SPDXRef-A is used to to build SPDXRef-B.                                           | A SOURCE file `makefile.mk` is used to build an APPLICATION ‘zlib’. |
+| BUILD\_TOOL_OF         | Is to be used when SPDXRef-A is used to build SPDXRef-B.                                              | A SOURCE file `makefile.mk` is used to build an APPLICATION ‘zlib’. |
 | DEV\_TOOL_OF           | Is to be used when SPDXRef-A is used as a development tool for SPDXRef-B.                             | Any tool used for development such as a code debugger. |
 | TEST\_OF               | Is to be used when SPDXRef-A is used for testing SPDXRef-B.                                           | Generic relationship for cases where it's clear that something is used for testing but unclear whether it's TEST\_CASE_OF or TEST\_TOOL_OF. |
-| TEST\_TOOL_OF          | Is to be used when SPDXRef-A is used as a test tool for SPDXRef-B.                                    | Any tool used to test the code sucha as ESlint. |
+| TEST\_TOOL_OF          | Is to be used when SPDXRef-A is used as a test tool for SPDXRef-B.                                    | Any tool used to test the code such as ESlint. |
 | DOCUMENTATION_OF       | Is to be used when SPDXRef-A provides documentation of SPDXRef-B.                                     | A DOCUMENTATION file `readme.txt` documents the APPLICATION ‘zlib’. |
 | OPTIONAL\_COMPONENT_OF | Is to be used when SPDXRef-A is an optional component of SPDXRef-B.                                   | A SOURCE file `fool.c` (which is in the contributors directory) may or may not be included in the build of APPLICATION ‘atthebar’. |
 | METAFILE_OF            | Is to be used when SPDXRef-A is a metafile of SPDXRef-B.                                              | A SOURCE file `pom.xml` is a metafile of the APPLICATION ‘Apache Xerces’. |
 | PACKAGE_OF             | Is to be used when SPDXRef-A is used as a package as part of SPDXRef-B.                               | A Linux distribution contains an APPLICATION package gawk as part of the distribution MyLinuxDistro. |
 | AMENDS                 | Is to be used when (current) SPDXRef-DOCUMENT amends the SPDX information in SPDXRef-B.               | (Current) SPDX document A version 2 contains a correction to a previous version of the SPDX document A version 1. Note the reserved identifier SPDXRef-DOCUMENT for the current document is required. |
-| PREREQUISITE_FOR       | Is to be used when SPDXRef-A is a prerequisite for SPDXRef-B | A library `bar.dll` is aprerequisite or dependency for APPLICATION `foo.exe`|
-| HAS_PREREQUISITE       | Is to be used when SPDXRef-A has as a prerequisite SPDXRef-B | An APPLICATION `foo.exe` has prerequisite or dependency of `bar.dll` |
+| PREREQUISITE_FOR       | Is to be used when SPDXRef-A is a prerequisite for SPDXRef-B.                                         | A library `bar.dll` is a prerequisite or dependency for APPLICATION `foo.exe`|
+| HAS_PREREQUISITE       | Is to be used when SPDXRef-A has as a prerequisite SPDXRef-B.                                         | An APPLICATION `foo.exe` has prerequisite or dependency on `bar.dll` |
 | OTHER                  | Is to be used for a relationship which has not been defined in the formal SPDX specification. A description of the relationship should be included in the Relationship comments field. | |
 
 **7.1.2** Intent: Here, this field is a reasonable estimation of the relation between two identified elements (i.e. files or packages, or documents), from a developer perspective.
@@ -102,7 +102,7 @@ Examples:
 
 Examples:
 
-    <SpdxElement rdf:about=”#SPDXRef-45”>
+    <SpdxElement rdf:about="#SPDXRef-45">
         <relationship>
             <Relationship>
                 <spdx:relatedSpdxElement>

--- a/chapters/8-annotations.md
+++ b/chapters/8-annotations.md
@@ -10,9 +10,9 @@
 
 **8.1.4** Data Format: Single line of text with the following keywords.
 
-    ”Person: person name” and optional  “(email)”
-    "Organization: organization” and optional “(email)”
-    "Tool: tool identifier - version”
+    "Person: person name" and optional  "(email)"
+    "Organization: organization" and optional "(email)"
+    "Tool: tool identifier - version"
 
 **8.1.5**  Tag: `Annotator:`
 
@@ -95,7 +95,7 @@ Example:
 
 **8.4.3** Cardinality: Conditional (Mandatory, one), if there is an Annotation.
 
-**8.4.4** DataFormat: `[DocumentRef-[idstring]:]SPDXID`
+**8.4.4** Data Format: `[DocumentRef-[idstring]:]SPDXID`
 
 where:
 
@@ -116,13 +116,13 @@ Example:
 
 For RDF, the annotations are a property of the SPDX element it is annotationg.
 
-    <SpdxElement rdf:about=”#SPDXRef-45”>
+    <SpdxElement rdf:about="#SPDXRef-45">
         <annotation>
             <Annotation>
                 ...
             </Annotation>
         </annotation>
-    </SpdxElement rdf:about=”#SPDXRef-45”>
+    </SpdxElement rdf:about="#SPDXRef-45">
 
 ## 8.5 Annotation Comment <a name="8.5"></a>
 

--- a/chapters/9-review-information-deprecated.md
+++ b/chapters/9-review-information-deprecated.md
@@ -1,6 +1,6 @@
 # 9 Review Information (deprecated)
 
-The review information section is included for compatibility with SPDX 1.2, and is deprecated since SPDX 2.0. Any review information should use an Annotation (as described in [section 8](./8-annotations.md)) with an annotation type of `annotationType_review`.
+The review information section is included for compatibility with SPDX 1.2, and is deprecated since SPDX 2.0. Any review information should use an Annotation (as described in [section 8](./8-annotations.md)) with an annotation type of `REVIEW`.
 
 Review information can be added after the initial SPDX file has been created. The set of fields are optional and multiple instances can be added. Once a Reviewer entry is added, the Review Date associated with the review is mandatory. The Created date should not be modified as a result of the addition of information regarding the conduct of a review. A Review Comments is optional.
 
@@ -18,9 +18,9 @@ This field has been deprecated since SPDX 2.0.
 
 **9.1.4** Data Format: Single line of text with the following keywords.
 
-    ”Person: person name” and optional “(email)”
-    "Organization: organization” and optional “(email)”
-    "Tool: tool identifier - version”
+    "Person: person name" and optional "(email)"
+    "Organization: organization" and optional "(email)"
+    "Tool: tool identifier - version"
 
 **9.1.5** Tag: `Reviewer:`
 

--- a/chapters/appendix-I-SPDX-license-list.md
+++ b/chapters/appendix-I-SPDX-license-list.md
@@ -4,7 +4,7 @@ The SPDX License List is a list of commonly found licenses and exceptions used f
 
 * [License Exceptions][exceptions]: The list of commonly found exceptions to open source licenses, which can be used with the License Expression operator, "WITH" to create a license with an exception.
 * [Master Files][master-files]: The HTML pages you see here are generated from the master files for the SPDX License List. The master files include a spreadsheet listing all the licenses, deprecated licenses, and license exceptions; and the text for each license in a .txt file. These files are available in a Git repository.
-* Overview: For general information about the SPDX License List, including principles for inclusion of a license and an explanation of the fields contained on the list.
+* [Overview][overview]: For general information about the SPDX License List, including principles for inclusion of a license and an explanation of the fields contained on the list.
 * [Matching Guidelines][matching]: Guidelines for what constitutes a license match to the SPDX License List. For licenses that include markup, the license text on the HTML pages here will display omitable text in blue and replaceable text in red (see Guideline #2 for more information).
 * [Request New License][new-license]: For instructions on how to propose additional licenses or license exceptions be added to the SPDX License List.
 
@@ -12,6 +12,7 @@ The SPDX License List is a list of commonly found licenses and exceptions used f
 [matching]: https://spdx.org/spdx-license-list/matching-guidelines
 [master-files]: https://github.com/spdx/license-list-XML
 [new-license]: https://github.com/spdx/license-list-XML/blob/master/CONTRIBUTING.md
+[overview]: https://spdx.org/spdx-license-list/license-list-overview
 
 The following table contains the full names and short identifiers for the SPDX License List, v3.8 which was released 2020-02-09. For the full and most up-to-date version of the SPDX License List as well as other related information, please see [http://spdx.org/licenses/](http://spdx.org/licenses/)
 

--- a/chapters/appendix-III-RDF-data-model-implementation-and-identifier-syntax.md
+++ b/chapters/appendix-III-RDF-data-model-implementation-and-identifier-syntax.md
@@ -6,7 +6,7 @@ See: [http://spdx.org/rdf/ontology/spdx-2-2](http://spdx.org/rdf/ontology/spdx-2
 
 Version: 2.2
 
-![SPDX 2.2 RD Ontology](img/spdx-2.2-rdf-ontology.png)
+![SPDX 2.2 RDF Ontology](img/spdx-2.2-rdf-ontology.png)
 
 Licensed under the [Creative Commons Attribution License 3.0 Unported](http://creativecommons.org/licenses/by/3.0/).
 

--- a/chapters/appendix-IV-SPDX-license-expressions.md
+++ b/chapters/appendix-IV-SPDX-license-expressions.md
@@ -55,8 +55,8 @@ However, please be aware that it is often important to match with the case of th
 
 A simple `<license-expression>` is composed one of the following:
 
-* An SPDX License List Short Form Identifier. For example: GPL-2.0-only
-* An SPDX License List Short Form Identifier with a unary "+" operator suffix to represent the current version of the license or any later version. For example: GPL-2.0+
+* An SPDX License List Short Form Identifier. For example: CDDL-1.0
+* An SPDX License List Short Form Identifier with a unary "+" operator suffix to represent the current version of the license or any later version. For example: CDDL-1.0+
 * A SPDX user defined license reference: ["DocumentRef-"1\*(idstring)":"]"LicenseRef-"1*(idstring)
 
 Some examples:

--- a/chapters/appendix-V-using-SPDX-short-identifiers-in-source-files.md
+++ b/chapters/appendix-V-using-SPDX-short-identifiers-in-source-files.md
@@ -14,7 +14,7 @@ Identifying the license for open source software is critical for both reporting 
 * An SPDX short identifier is immutable.
 * Easy lookups and cross-references to the SPDX License List website.
 
-To the extent that a source file contains existing copyright and license information, it is the SPDX project’s recommendation that SPDX short identifiers be used to supplement, not replace that information. When there is a standard header provided by the license author, it is recommended to use such standard header (alone or in combination with the SPDX short identifier). If using SPDX short identifiers in individual files, it is recommended to reproduce the full license in the projects LICENSE file and indicate that SPDX short identifiers are being used to refer to it. For links to projects illustrating these scenarios, see [the examples on the SPDX WIKI page about Meta_Tags](https://wiki.spdx.org/view/Technical_Team/SPDX_Meta_Tags#Examples).
+To the extent that a source file contains existing copyright and license information, it is the SPDX project’s recommendation that SPDX short identifiers be used to supplement, not replace that information. When there is a standard header provided by the license author, it is recommended to use such standard header (alone or in combination with the SPDX short identifier). If using SPDX short identifiers in individual files, it is recommended to reproduce the full license in the projects LICENSE file and indicate that SPDX short identifiers are being used to refer to it. For links to projects illustrating these scenarios, see [https://spdx.org/ids-where](https://spdx.org/ids-where).
 
 ## Format for SPDX-License-Identifier
 
@@ -24,7 +24,7 @@ The SPDX License Identifier syntax may consist of a single license (represented 
 
 The tag should appear on its own line in the source file, generally as part of a comment.
 
-SPDX-License-Identifier: <SPDX License Expression>
+SPDX-License-Identifier: \<SPDX License Expression\>
 
 ## Representing Single License
 
@@ -32,7 +32,7 @@ A single license is represented by using the short identifier from [SPDX license
 
 Examples:
 
-    SPDX-License-Identifier: GPL-2.0+
+    SPDX-License-Identifier: CDDL-1.0+
     SPDX-License-Identifier: MIT
 
 ## Representing Multiple Licenses

--- a/chapters/appendix-VIII-SPDX-Lite.md
+++ b/chapters/appendix-VIII-SPDX-Lite.md
@@ -1,59 +1,59 @@
-# Appendix-VIII SPDX Lite
+# Appendix VIII: SPDX Lite
 
 ## 1. Explanation of SPDX Lite 
 
-The SPDX Lite profile defines a subset of the SPDX specification, from the point of view of use cases in some industries. SPDX Lite aims at the balance between the SPDX standard and actual workflows in some industries. 
+The SPDX Lite profile defines a subset of the SPDX specification, from the point of view of use cases in some industries. SPDX Lite aims at the balance between the SPDX standard and actual workflows in some industries.
 
-The SPDX Lite profile consists of mandatory fields from the Document Creation and Package Information sections and other basic information. 
+The SPDX Lite profile consists of mandatory fields from the Document Creation and Package Information sections and other basic information.
 
-The mandatory part of the Package information in the SPDX Lite is basic but useful for complying with licenses. It is easy to understand licensing information by reading an SPDX Lite file. It is easy to create manually an SPDX Lite file by anyone who does not have enough knowledge about licensing infomation, so that tools are not necessarily required to create an SPDX Lite file. 
+The mandatory part of the Package information in SPDX Lite is basic but useful for complying with licenses. It is easy to understand licensing information by reading an SPDX Lite file. It is easy to create manually an SPDX Lite file by anyone who does not have enough knowledge about licensing infomation, so that tools are not necessarily required to create an SPDX Lite file.
 
-The SPDX Lite has the affinity with SPDX tools due to its containing the mandatory part of the Document Creation and Package Information in the SPDX Lite. 
+SPDX Lite has affinity with SPDX tools due to its containing the mandatory part of the Document Creation and Package Information in the SPDX Lite definition.
 
-An SPDX Lite document can be used parallel with an SPDX documents in software supply chains. 
+An SPDX Lite document can be used in parallel with SPDX documents in software supply chains.
 
 
 ## 2. Format of SPDX Lite
 
-The SPDX Lite profile is the subset of the SPDX specification. The SPDX Lite consists of mandatory fields of the Document Creation and Package Information and other basic information. Cardinality of each item is not changed.
+The SPDX Lite profile is a subset of the SPDX specification. SPDX Lite consists of mandatory fields of the Document Creation and Package Information sections and other basic information. Cardinality of each item is not changed.
 
-The mandatory part of the Document Creation section (which are SPDX Version, Data License, SPDX Identifier, Document Name, SPDX Document Namespace, Creator and Created) is used for keeping the compatibility with other SPDX documents.
+The mandatory part of the Document Creation section (which consists of SPDX Version, Data License, SPDX Identifier, Document Name, SPDX Document Namespace, Creator and Created) is used for keeping the compatibility with other SPDX documents.
 
 The main part of the Package Information (those are Package Name,  Package Version, Package File Name, Package Download Location,  Package Home Page, Concluded License, Declared License, Comments on License and Copyright Text) is used for exchanging license information.
 
-In the Package Information, Package SPDX Identifier and Files Analyzed are used for keeping the compatiblity with SPDX tools. 
+In the Package Information, Package SPDX Identifier and Files Analyzed are used for keeping compatiblity with SPDX tools.
 
-File Analyzed must be set to "false", when SPDX Lite is used.
+Files Analyzed must be set to "false" when SPDX Lite is used.
 
-Package Comment can be used to describe additional explanation, such as compiling option, where a license may change with a different compiling option. 
+Package Comment can be used to describe additional details, such as compiling options, where a license may change with a different compiling option.
 
-Other information (License Identifier, Extracted Text, License Name and License Comment) is used for exchanging license information.
+The Other License information section (License Identifier, Extracted Text, License Name and License Comment) is used for exchanging license information for licenses that are not on the [SPDX License List](https://spdx.org/licenses).
 
 
 ## Table of SPDX Lite Fields
 
 | # | corresponding SPDX section no. | Field Name |
-|:-----|:----|:-----------------------|
-|L1.1  |2.1  | SPDX Version           |
-|L1.2  |2.2  | Data License           |
-|L1.3  |2.3  | SPDX Identifier        |
-|L1.4	 |2.4	 | Document Name	        | 
-|L1.5	 |2.5	 | SPDX Document Namespace| 
-|L1.6	 |2.8	 | Creator	              | 
-|L1.7  |2.9  | Created                |
-|L2.1	 |3.1	 | Package Name	          | 
-|L2.2	 |3.2	 | Package SPDX Identifier| 
-|L2.3	 |3.3	 | Package Version        | 
-|L2.4	 |3.4	 | Package File Name      | 
-|L2.5	 |3.7	 | Package Download Location | 
-|L2.6	 |3.8	 | Files Analyzed         | 
-|L2.7  |3.11 | Package Home Page      | 
-|L2.8	 |3.13 | Concluded License      | 
-|L2.9	 |3.15 | Declared License       | 
-|L2.10 |3.16 | Comments on License    | 
-|L2.11 |3.17 | Copyright Text         | 
-|L2.12 |3.20 | Package Comment        | 
-|L3.1	 |6.1	 | License Identifier     | 
-|L3.2	 |6.2	 | Extracted Text         | 
-|L3.3	 |6.3	 | License Name           | 
-|L3.4	 |6.5	 | License Comment        | 
+|:-----|:----|:--------------------------|
+|L1.1  |2.1  | SPDX Version              |
+|L1.2  |2.2  | Data License              |
+|L1.3  |2.3  | SPDX Identifier           |
+|L1.4  |2.4	 | Document Name	         |
+|L1.5  |2.5	 | SPDX Document Namespace   |
+|L1.6  |2.8	 | Creator	                 |
+|L1.7  |2.9  | Created                   |
+|L2.1  |3.1	 | Package Name	             |
+|L2.2  |3.2	 | Package SPDX Identifier   |
+|L2.3  |3.3	 | Package Version           |
+|L2.4  |3.4	 | Package File Name         |
+|L2.5  |3.7	 | Package Download Location |
+|L2.6  |3.8	 | Files Analyzed            |
+|L2.7  |3.11 | Package Home Page         |
+|L2.8  |3.13 | Concluded License         |
+|L2.9  |3.15 | Declared License          |
+|L2.10 |3.16 | Comments on License       |
+|L2.11 |3.17 | Copyright Text            |
+|L2.12 |3.20 | Package Comment           |
+|L3.1  |6.1	 | License Identifier        |
+|L3.2  |6.2	 | Extracted Text            |
+|L3.3  |6.3	 | License Name              |
+|L3.4  |6.5	 | License Comment           |


### PR DESCRIPTION
This includes a variety of cleanups for typos, incorrect use of
smart quotes, and other nitpicky things.

Very little in here should be substantive, which is why it is
prepared as a single commit rather than a bunch of separate
commits.

Signed-off-by: Steve Winslow <steve@swinslow.net>