### PR TITLE
Remove the Relationship types NONE and NOASSERTION

### DIFF
--- a/ontology/spdx-ontology.owl.xml
+++ b/ontology/spdx-ontology.owl.xml
@@ -2996,26 +2996,6 @@ IMAGE if the file is assoicated with an picture image file (MIME type of image/*
     
 
 
-    <!-- http://spdx.org/rdf/terms#relationshipType_noAssertion -->
-
-    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_noAssertion">
-        <rdf:type rdf:resource="http://spdx.org/rdf/terms#RelationshipType"/>
-        <rdfs:comment xml:lang="en">Indicates that the author is not asserting whether there are other SPDX elements (package/file/snippet) are connected by relationships or not. ie. There could be some, but the author is not asserting one way or another.</rdfs:comment>
-        <ns:term_status xml:lang="en">stable</ns:term_status>
-    </owl:NamedIndividual>
-    
-
-
-    <!-- http://spdx.org/rdf/terms#relationshipType_none -->
-
-    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_none">
-        <rdf:type rdf:resource="http://spdx.org/rdf/terms#RelationshipType"/>
-        <rdfs:comment xml:lang="en">Indicates that an SPDX element (package/file/snippet) has no other elements connected by some relationship to it.</rdfs:comment>
-        <ns:term_status xml:lang="en">stable</ns:term_status>
-    </owl:NamedIndividual>
-    
-
-
     <!-- http://spdx.org/rdf/terms#relationshipType_optionalComponentOf -->
 
     <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_optionalComponentOf">

--- a/schemas/spdx-schema.json
+++ b/schemas/spdx-schema.json
@@ -7,6 +7,26 @@
     "Document" : {
       "type" : "object",
       "properties" : {
+        "revieweds" : {
+          "description" : "Reviewed",
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "properties" : {
+              "reviewer" : {
+                "description" : "The name and, optionally, contact information of the person who performed the review. Values of this property must conform to the agent and tool syntax.",
+                "type" : "string"
+              },
+              "comment" : {
+                "type" : "string"
+              },
+              "reviewDate" : {
+                "description" : "The date and time at which the SpdxDocument was reviewed. This value must be in UTC and have 'Z' as its timezone indicator.",
+                "type" : "string"
+              }
+            }
+          }
+        },
         "hasExtractedLicensingInfos" : {
           "description" : "Indicates that a particular ExtractedLicensingInfo was defined in the subject SpdxDocument.",
           "type" : "array",
@@ -36,26 +56,6 @@
               }
             },
             "description" : "An ExtractedLicensingInfo represents a license or licensing notice that was found in the package. Any license text that is recognized as a license may be represented as a License rather than an ExtractedLicensingInfo."
-          }
-        },
-        "revieweds" : {
-          "description" : "Reviewed",
-          "type" : "array",
-          "items" : {
-            "type" : "object",
-            "properties" : {
-              "reviewer" : {
-                "description" : "The name and, optionally, contact information of the person who performed the review. Values of this property must conform to the agent and tool syntax.",
-                "type" : "string"
-              },
-              "comment" : {
-                "type" : "string"
-              },
-              "reviewDate" : {
-                "description" : "The date and time at which the SpdxDocument was reviewed. This value must be in UTC and have 'Z' as its timezone indicator.",
-                "type" : "string"
-              }
-            }
           }
         },
         "name" : {
@@ -95,10 +95,6 @@
             "description" : "An Annotation is a comment on an SpdxItem by an agent."
           }
         },
-        "dataLicense" : {
-          "description" : "License expression for dataLicense.  Compliance with the SPDX specification includes populating the SPDX fields therein with data related to such fields (\"SPDX-Metadata\"). The SPDX specification contains numerous fields where an SPDX document creator may provide relevant explanatory text in SPDX-Metadata. Without opining on the lawfulness of \"database rights\" (in jurisdictions where applicable), such explanatory text is copyrightable subject matter in most Berne Convention countries. By using the SPDX specification, or any portion hereof, you hereby agree that any copyright rights (as determined by your jurisdiction) in any SPDX-Metadata, including without limitation explanatory text, shall be subject to the terms of the Creative Commons CC0 1.0 Universal license. For SPDX-Metadata not containing any copyright rights, you hereby agree and acknowledge that the SPDX-Metadata is provided to you \"as-is\" and without any representations or warranties of any kind concerning the SPDX-Metadata, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non-infringement, or the absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law.",
-          "type" : "string"
-        },
         "describesPackages" : {
           "description" : "The describesPackage property relates an SpdxDocument to the package which it describes.",
           "type" : "array",
@@ -106,6 +102,10 @@
             "description" : "SPDX ID for Package.  The describesPackage property relates an SpdxDocument to the package which it describes.",
             "type" : "string"
           }
+        },
+        "dataLicense" : {
+          "description" : "License expression for dataLicense.  Compliance with the SPDX specification includes populating the SPDX fields therein with data related to such fields (\"SPDX-Metadata\"). The SPDX specification contains numerous fields where an SPDX document creator may provide relevant explanatory text in SPDX-Metadata. Without opining on the lawfulness of \"database rights\" (in jurisdictions where applicable), such explanatory text is copyrightable subject matter in most Berne Convention countries. By using the SPDX specification, or any portion hereof, you hereby agree that any copyright rights (as determined by your jurisdiction) in any SPDX-Metadata, including without limitation explanatory text, shall be subject to the terms of the Creative Commons CC0 1.0 Universal license. For SPDX-Metadata not containing any copyright rights, you hereby agree and acknowledge that the SPDX-Metadata is provided to you \"as-is\" and without any representations or warranties of any kind concerning the SPDX-Metadata, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non-infringement, or the absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law.",
+          "type" : "string"
         },
         "externalDocumentRefs" : {
           "description" : "Identify any external SPDX documents referenced within this SPDX document.",
@@ -303,12 +303,12 @@
               "comment" : {
                 "type" : "string"
               },
-              "copyrightText" : {
-                "description" : "The text of copyright declarations recited in the Package or File.",
-                "type" : "string"
-              },
               "summary" : {
                 "description" : "Provides a short description of the package.",
+                "type" : "string"
+              },
+              "copyrightText" : {
+                "description" : "The text of copyright declarations recited in the Package or File.",
                 "type" : "string"
               },
               "originator" : {
@@ -319,10 +319,6 @@
                 "description" : "The base name of the package file name. For example, zlib-1.2.5.tar.gz.",
                 "type" : "string"
               },
-              "versionInfo" : {
-                "description" : "Provides an indication of the version of the package that is described by this SpdxDocument.",
-                "type" : "string"
-              },
               "licenseInfoFromFiles" : {
                 "description" : "The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.",
                 "type" : "array",
@@ -330,6 +326,10 @@
                   "description" : "License expression for licenseInfoFromFiles.  The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.",
                   "type" : "string"
                 }
+              },
+              "versionInfo" : {
+                "description" : "Provides an indication of the version of the package that is described by this SpdxDocument.",
+                "type" : "string"
               },
               "sourceInfo" : {
                 "description" : "Allows the producer(s) of the SPDX document to describe how the package was acquired and/or changed from the original source.",
@@ -427,12 +427,12 @@
                 "description" : "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
                 "type" : "string"
               },
-              "name" : {
-                "description" : "Identify name of this SpdxElement.",
-                "type" : "string"
-              },
               "fileName" : {
                 "description" : "The name of the file relative to the root of the package.",
+                "type" : "string"
+              },
+              "name" : {
+                "description" : "Identify name of this SpdxElement.",
                 "type" : "string"
               },
               "comment" : {
@@ -595,7 +595,7 @@
               "relationshipType" : {
                 "description" : "Describes the type of relationship between two SPDX elements.",
                 "type" : "string",
-                "enum" : [ "VARIANT_OF", "COPY_OF", "PATCH_FOR", "TEST_DEPENDENCY_OF", "CONTAINED_BY", "DATA_FILE_OF", "OPTIONAL_COMPONENT_OF", "NOASSERTION", "ANCESTOR_OF", "GENERATES", "CONTAINS", "OPTIONAL_DEPENDENCY_OF", "FILE_ADDED", "DEV_DEPENDENCY_OF", "DEPENDENCY_OF", "BUILD_DEPENDENCY_OF", "DESCRIBES", "PREREQUISITE_FOR", "HAS_PREREQUISITE", "PROVIDED_DEPENDENCY_OF", "NONE", "DYNAMIC_LINK", "DESCRIBED_BY", "METAFILE_OF", "DEPENDENCY_MANIFEST_OF", "PATCH_APPLIED", "RUNTIME_DEPENDENCY_OF", "TEST_OF", "TEST_TOOL_OF", "DEPENDS_ON", "FILE_MODIFIED", "DISTRIBUTION_ARTIFACT", "DOCUMENTATION_OF", "GENERATED_FROM", "STATIC_LINK", "OTHER", "BUILD_TOOL_OF", "TEST_CASE_OF", "PACKAGE_OF", "DESCENDANT_OF", "FILE_DELETED", "EXPANDED_FROM_ARCHIVE", "DEV_TOOL_OF", "EXAMPLE_OF" ]
+                "enum" : [ "VARIANT_OF", "COPY_OF", "PATCH_FOR", "TEST_DEPENDENCY_OF", "CONTAINED_BY", "DATA_FILE_OF", "OPTIONAL_COMPONENT_OF", "ANCESTOR_OF", "GENERATES", "CONTAINS", "OPTIONAL_DEPENDENCY_OF", "FILE_ADDED", "DEV_DEPENDENCY_OF", "DEPENDENCY_OF", "BUILD_DEPENDENCY_OF", "DESCRIBES", "PREREQUISITE_FOR", "HAS_PREREQUISITE", "PROVIDED_DEPENDENCY_OF", "DYNAMIC_LINK", "DESCRIBED_BY", "METAFILE_OF", "DEPENDENCY_MANIFEST_OF", "PATCH_APPLIED", "RUNTIME_DEPENDENCY_OF", "TEST_OF", "TEST_TOOL_OF", "DEPENDS_ON", "FILE_MODIFIED", "DISTRIBUTION_ARTIFACT", "DOCUMENTATION_OF", "GENERATED_FROM", "STATIC_LINK", "OTHER", "BUILD_TOOL_OF", "TEST_CASE_OF", "PACKAGE_OF", "DESCENDANT_OF", "FILE_DELETED", "EXPANDED_FROM_ARCHIVE", "DEV_TOOL_OF", "EXAMPLE_OF" ]
               },
               "relatedSpdxElement" : {
                 "description" : "SPDX ID for SpdxElement.  A related SpdxElement.",


### PR DESCRIPTION
These were introduced in error when interpreting the NONE and NOASSERTION for relationships.  The NONE and NOASSERTION applies to the SPDX element on the right hand side - not to the type.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>