### PR TITLE
Create and populate normative-references.md

### DIFF
--- a/chapters/normative-references.md
+++ b/chapters/normative-references.md
@@ -1,0 +1,35 @@
+# Normative references
+
+The following documents are referred to in the text in such a way that some or all of their content constitutes requirements of this document. For dated references, only the edition cited applies. For undated references, the latest edition of the referenced document (including any amendments) applies.
+
+*Apache Maven*, Apache Software Foundation, https://maven.apache.org/
+
+*Bower API*, https://bower.io/docs/api/#install
+
+*Common Platform Enumeration (CPE) – Specification*, The MITRE Corporation, https://cpe.mitre.org/files/cpe-specification_2.2.pdf
+
+*Creative Commons Attribution License 3.0 Unported*, Creative Commons, http://creativecommons.org/licenses/by/3.0/
+
+NISTIR 7695, *Common Platform Enumeration: Naming Specification Version 2.3*, NIST, https://csrc.nist.gov/publications/detail/nistir/7695/final
+
+*npm-package.json*, npn Inc., https://docs.npmjs.com/files/package.json
+
+*NuGet documentation*, Microsoft, https://docs.microsoft.com/en-us/nuget/
+
+POSIX.1-2017 *The Open Group Base Specifications Issue 7*, 2018 edition, IEEE/Open Group, https://pubs.opengroup.org/onlinepubs/9699919799/
+
+*Resource Description Framework (RDF)*, 2014-02-25, W3C, http://www.w3.org/standards/techs/rdf
+
+RFC-1321, *The MD5 Message-Digest Algorithm*, The Internet Society Network Working Group, https://tools.ietf.org/html/rfc1321
+
+RFC-3174, *US Secure Hash Algorithm 1 (SHA1)*, The Internet Society Network Working Group, https://tools.ietf.org/html/rfc3174
+
+RFC-3986, *Uniform Resource Identifier (URI): Generic Syntax*, The Internet Society Network Working Group, https://tools.ietf.org/html/rfc3986
+
+RFC-5234, *Augmented BNF for Syntax Specifications: ABNF*, The Internet Society Network Working Group, https://tools.ietf.org/html/rfc5234
+
+RFC-6234, *US Secure Hash Algorithms (SHA and SHA-based HMAC and HKDF)*, The Internet Society Network Working Group, https://tools.ietf.org/html/rfc6234
+
+*SPDX License list*, Linux Foundation, https://spdx.org/licenses/
+
+*SPDX License Exceptions list*, Linux Foundation, https://spdx.org/licenses/exceptions-index.html


### PR DESCRIPTION
Kate, I left all the URLs as raw text, as in "https://maven.apache.org/", which renders correctly in GitHub. If you need me to convert them to the md form, as in

> `[https://maven.apache.org/](https://maven.apache.org/)`

let me know and I'll make another Commit before you merge this PR; however, this verbose approach seems redundant. That said, if we will use a conversion tool to produce the final Word document, it might be useful to be consistent in having all links have the same format in md.