### PR TITLE
Populate scope[.md]

### DIFF
--- a/chapters/scope
+++ b/chapters/scope
@@ -1,1 +1,3 @@
-... rex to fill .....
+# Scope
+
+This Software Package Data Exchange (SPDX®) specification defines a standard data format for communicating the component and metadata information associated with software packages. An SPDX file can be associated with a set of software packages, set of files or snippets and contains information about the software in the SPDX format described in this specification.


### PR DESCRIPTION
@kestewart, the file "scope" was created *without* an ".md" suffix, so the md content doesn't get interpreted as such. Please rename that file with the ".md" suffix.