### PR TITLE
Renumber Subclauses and Change Roman-numbered Lists

### DIFF
--- a/chapters/3-package-information.md
+++ b/chapters/3-package-information.md
@@ -15,7 +15,7 @@ In `tag:value` format, the order in which package and files occur is syntactical
 
 Fields:
 
-## P.1 Package name field <a name="3.1"></a>
+## 7.1 Package name field <a name="3.1"></a>
 
 **3.1.1** Purpose: Identify the full name of the package as given by the [Package Originator](#3.6).
 
@@ -43,7 +43,7 @@ Example:
 </Package>
 ```
 
-## P.2 Package SPDX identifier field <a name="3.2"></a>
+## 7.2 Package SPDX identifier field <a name="3.2"></a>
 
 **3.2.1** Purpose: Uniquely identify any element in an SPDX document which may be referenced by other elements. These may be referenced internally and externally with the addition of the SPDX Document Identifier.
 
@@ -90,7 +90,7 @@ Example using document URI:
 </Package>
 ```
 
-## P.3 Package version field <a name="3.3"></a>
+## 7.3 Package version field <a name="3.3"></a>
 
 **3.3.1** Purpose: Identify the version of the package.
 
@@ -120,7 +120,7 @@ Example:
 </Package>
 ```
 
-## P.4 Package file name field <a name="3.4"></a>
+## 7.4 Package file name field <a name="3.4"></a>
 
 **3.4.1** Purpose: Provide the actual file name of the package, or path of the directory being treated as a package. This may include the packaging and compression methods used as part of the file name, if appropriate.
 
@@ -166,17 +166,17 @@ Example (sub-directory being treated as a package):
 </Package>
 ```
 
-## P.5 Package supplier field <a name="3.5"></a>
+## 7.5 Package supplier field <a name="3.5"></a>
 
 **3.5.1** Purpose: Identify the actual distribution source for the package/directory identified in the SPDX file. This might or might not be different from the originating distribution source for the package. The name of the Package Supplier shall be an organization or recognized author and not a web site. For example, [SourceForge][] is a host website, not a supplier, the supplier for https://sourceforge.net/projects/bridge/ is “[The Linux Foundation][LinuxFoundation].”
 
 Use `NOASSERTION` if:
 
-(i) the SPDX file creator has attempted to but cannot reach a reasonable objective determination;
+- the SPDX file creator has attempted to but cannot reach a reasonable objective determination;
 
-(ii) the SPDX file creator has made no attempt to determine this field; or
+- the SPDX file creator has made no attempt to determine this field; or
 
-(iii) the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+- the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
 
 **3.5.2** Intent: Assist with understanding the point of distribution for the code in the package. This field is vital for ensuring that downstream package recipients can address any ambiguity or concerns that might arise with the information in the SPDX file or the contents of the package it documents.
 
@@ -207,17 +207,17 @@ Example:
 </Package>
 ```
 
-## P.6 Package originator field <a name="3.6"></a>
+## 7.6 Package originator field <a name="3.6"></a>
 
 **3.6.1** Purpose: If the package identified in the SPDX file originated from a different person or organization than identified as Package Supplier (see [7.5](#3.5) above), this field identifies from where or whom the package originally came. In some cases a package may be created and originally distributed by a different third party than the Package Supplier of the package. For example, the SPDX file identifies the package [glibc][] and [Red Hat][] as the Package Supplier, but the [Free Software Foundation][FSF] is the Package Originator.
 
 Use `NOASSERTION` if:
 
-(i) the SPDX file creator has attempted to but cannot reach a reasonable objective determination;
+- the SPDX file creator has attempted to but cannot reach a reasonable objective determination;
 
-(ii) the SPDX file creator has made no attempt to determine this field; or
+- the SPDX file creator has made no attempt to determine this field; or
 
-(iii) the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+- the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
 
 **3.6.2** Intent: Assist with understanding the point of origin of the code in the package. This field is vital for understanding who originally distributed a package and should help in addressing any ambiguity or concerns that might arise with the information in the SPDX file or the contents of the Package it documents.
 
@@ -246,7 +246,7 @@ Example:
 </Package>
 ```
 
-## P.7 Package download location field <a name="3.7"></a>
+## 7.7 Package download location field <a name="3.7"></a>
 
 **3.7.1** Purpose: This section identifies the download Universal Resource Locator (URL), or a specific location within a version control system (VCS) for the package at the time that the SPDX file was created.
 
@@ -255,11 +255,11 @@ Use:
 * `NONE` if there is no download location whatsoever.
 * `NOASSERTION` if:
 
-    (i) the SPDX file creator has attempted to but cannot reach a reasonable objective determination;
+  - the SPDX file creator has attempted to but cannot reach a reasonable objective determination;
 
-    (ii) the SPDX file creator has made no attempt to determine this field; or
+  - the SPDX file creator has made no attempt to determine this field; or
 
-    (iii) the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+  - the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
 
 **3.7.2** Intent: Where and how to download the exact package being referenced is critical verification and tracking data.
 
@@ -563,7 +563,7 @@ Example:
 </Package>
 ```
 
-## P.8 Files analyzed field <a name="3.8"></a>
+## 7.8 Files analyzed field <a name="3.8"></a>
 
 **3.8.1** Purpose: Indicates whether the file content of this package has been available for or subjected to analysis when creating the SPDX document. If `false`, indicates packages that represent metadata or URI references to a project, product, artifact, distribution or a component. If `false`, the package shall not contain any files.
 
@@ -599,7 +599,7 @@ Example:
 </Package>
 ```
 
-## P.9 Package verification code field <a name="3.9"></a>
+## 7.9 Package verification code field <a name="3.9"></a>
 
 **3.9.1** Purpose: This field provides an independently reproducible mechanism identifying specific contents of a package based on the actual files (except the SPDX file itself, if it is included in the package) that make up each package and that correlates to the data in this SPDX file. This identifier enables a recipient to determine if any file in the original package (that the analysis was done on) has been changed and permits inclusion of an SPDX file as part of a package.
 
@@ -657,7 +657,7 @@ Example:
 </Package>
 ```
 
-## P.10 Package checksum field <a name="3.10"></a>
+## 7.10 Package checksum field <a name="3.10"></a>
 
 **3.10.1** Purpose: Provide an independently reproducible mechanism that permits unique identification of a specific package that correlates to the data in this SPDX file. This identifier enables a recipient to determine if any file in the original package has been changed. If the SPDX file is to be included in a package, this value should not be calculated. The [SHA-1][] algorithm shall be used to provide the checksum by default.
 
@@ -714,7 +714,7 @@ Example:
 </Package>
 ```
 
-## P.11 Package home page field <a name="3.11"></a>
+## 7.11 Package home page field <a name="3.11"></a>
 
 **3.11.1** Purpose: Provide a place for the SPDX file creator to record a web site that serves as the package's home page. This link can also be used to reference further information about the package referenced by the SPDX file creator.
 
@@ -723,11 +723,11 @@ Use:
 * `NONE` if there is no package home page whatsoever.
 * `NOASSERTION` if:
 
-    (i) the SPDX file creator has attempted to but cannot reach a reasonable objective determination;
+  - the SPDX file creator has attempted to but cannot reach a reasonable objective determination;
 
-    (ii) the SPDX file creator has made no attempt to determine this field; or
+  - the SPDX file creator has made no attempt to determine this field; or
 
-    (iii) the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+  - the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
 
 **3.11.2** Intent: Save the recipient of the SPDX file who is looking for more info from having to search for and verify a match between the package and the associated project homepage.
 
@@ -757,7 +757,7 @@ This specification uses the prefix `doap:` to refer to the [DOAP][doap] namespac
 ```text
 http://usefulinc.com/ns/doap#
 ```
-## P.12 Source information field <a name="3.12"></a>
+## 7.12 Source information field <a name="3.12"></a>
 
 **3.12.1** Purpose: Provide a place for the SPDX file creator to record any relevant background information or additional comments about the origin of the package. For example, this field might include comments indicating whether the package was pulled from a source code management system or has been repackaged.
 
@@ -789,7 +789,7 @@ Example:
 </Package>
 ```
 
-## P.13 Concluded license field <a name="3.13"></a>
+## 7.13 Concluded license field <a name="3.13"></a>
 
 **3.13.1** Purpose: Contain the license the SPDX file creator has concluded as governing the package or alternative values, if the governing license cannot be determined.
 
@@ -799,11 +799,11 @@ The options to populate this field are limited to:
 * `NONE`, if the SPDX file creator concludes there is no license available for this package; or
 * `NOASSERTION` if:
 
-    (i) the SPDX file creator has attempted to but cannot reach a reasonable objective determination;
+  - the SPDX file creator has attempted to but cannot reach a reasonable objective determination;
 
-    (ii) the SPDX file creator has made no attempt to determine this field; or
+  - the SPDX file creator has made no attempt to determine this field; or
 
-    (iii) the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+  - the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
 
 If the Concluded License is not the same as the [Declared License](#3.15), a written explanation should be provided in the Comments on License field ([7.16](#3.16)). With respect to `NOASSERTION`, a written explanation in the Comments on License field ([7.16](#3.16)) is preferred.
 
@@ -858,7 +858,7 @@ Example:
 </Package>
 ```
 
-## P.14 All licenses information from files field <a name="3.14"></a>
+## 7.14 All licenses information from files field <a name="3.14"></a>
 
 **3.14.1** Purpose: This field is to contain a list of all licenses found in the package. The relationship between licenses (i.e., conjunctive, disjunctive) is not specified in this field – it is simply a listing of all licenses found.
 
@@ -869,9 +869,9 @@ The options to populate this field are limited to:
 * `NONE`, if no license information is detected in any of the files; or
 * `NOASSERTION`, if:
 
-    (i) the SPDX file creator has made no attempt to determine this field; or
+  - the SPDX file creator has made no attempt to determine this field; or
 
-    (ii) the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+  - the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
 
 **3.14.2** Intent: Here, the intention is to capture all license information detected in the actual files.
 
@@ -916,7 +916,7 @@ Example:
 </Package>
 ```
 
-## P.15 Declared license field <a name="3.15"></a>
+## 7.15 Declared license field <a name="3.15"></a>
 
 **3.15.1** Purpose: List the licenses that have been declared by the authors of the package. Any license information that does not originate from the package authors, e.g. license information from a third party repository, should not be included in this field.
 
@@ -926,9 +926,9 @@ The options to populate this field are limited to:
 * `NONE`, if the package contains no license information whatsoever; or
 * `NOASSERTION` if:
 
-    (i) the SPDX file creator has made no attempt to determine this field; or
+  - the SPDX file creator has made no attempt to determine this field; or
 
-    (ii) the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+  - the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
 
 **3.15.2** Intent: This is simply the license identified in text in one or more files (for example COPYING file) in the source code package. This field is not intended to capture license information obtained from an external source, such as the package website. Such information can be included in Concluded License ([7.13](#3.13)). This field may have multiple Declared Licenses, if multiple licenses are declared at the package level.
 
@@ -981,7 +981,7 @@ Example:
 </Package>
 ```
 
-## P.16 Comments on license field <a name="3.16"></a>
+## 7.16 Comments on license field <a name="3.16"></a>
 
 **3.16.1** Purpose: This field provides a place for the SPDX file creator to record any relevant background information or analysis that went in to arriving at the Concluded License for a package. If the Concluded License does not match the Declared License or License Information from Files, this should be explained by the SPDX file creator. Its is also preferable to include an explanation here when the Concluded License is `NOASSERTION`.
 
@@ -1018,7 +1018,7 @@ Example:
 </Package>
 ```
 
-## P.17 Copyright text field <a name="3.17"></a>
+## 7.17 Copyright text field <a name="3.17"></a>
 
 **3.17.1** Purpose: Identify the copyright holders of the package, as well as any dates present. This will be a free form text field extracted from package information files. The options to populate this field are limited to:
 
@@ -1026,9 +1026,9 @@ Example:
 * `NONE` if the package contains no copyright information whatsoever; or
 * `NOASSERTION`, if
 
-    (i) the SPDX document creator has made no attempt to determine this field; or
+  - the SPDX document creator has made no attempt to determine this field; or
 
-    (ii) the SPDX document creator has intentionally provided no information (no meaning should be implied by doing so).
+  - the SPDX document creator has intentionally provided no information (no meaning should be implied by doing so).
 
 **3.17.2** Intent: Record any copyright notices for the package.
 
@@ -1058,7 +1058,7 @@ Example:
 </Package>
 ```
 
-## P.18 Package summary description field <a name="3.18"></a>
+## 7.18 Package summary description field <a name="3.18"></a>
 
 **3.18.1** Purpose: This field is a short description of the package.
 
@@ -1090,7 +1090,7 @@ Example:
 </Package>
 ```
 
-## P.19 Package detailed description field <a name="3.19"></a>
+## 7.19 Package detailed description field <a name="3.19"></a>
 
 **3.19.1** Purpose: This field is a more detailed description of the package. It may also be extracted from the packages itself.
 
@@ -1128,7 +1128,7 @@ Example:
 </Package>
 ```
 
-## P.20 Package comment field <a name="3.20"></a>
+## 7.20 Package comment field <a name="3.20"></a>
 
 **3.20.1** Purpose: This field provides a place for the SPDX file creator to record any general comments about the package being described.
 
@@ -1162,7 +1162,7 @@ Example:
 </Package>
 ```
 
-## P.21 External reference field <a name="3.21"></a>
+## 7.21 External reference field <a name="3.21"></a>
 
 **3.21.1** Purpose: An External Reference allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package.
 
@@ -1231,7 +1231,7 @@ Example (for an unlisted location):
 
 The referenceType value for a non-listed location consists of the SPDX document namespace (see [6.5](2-document-creation-information.md#2.5)) followed by a `#` and the category as defined in [7.21.4](#3.21).
 
-## P.22 External reference comment field <a name="3.22"></a>
+## 7.22 External reference comment field <a name="3.22"></a>
 
 **3.22.1** Purpose: To provide human-readable information about the purpose and target of the reference.
 
@@ -1274,7 +1274,7 @@ acmecorp:acmenator:6.6.6.</text>
 </spdx:package>
 ```
 
-## P.23 Package attribution text field <a name="3.23"></a>
+## 7.23 Package attribution text field <a name="3.23"></a>
 
 **3.23.1** Purpose: This field provides a place for the SPDX data creator to record, at the package level, acknowledgements that might be required to be communicated in some contexts. This is not meant to include the package's actual complete license text (see `PackageLicenseConcluded`, `PackageLicenseDeclared` and `PackageLicenseInfoFromFiles`), and might or might not include copyright notices (see also `PackageCopyrightText`). The SPDX data creator might use this field to record other acknowledgements, such as particular clauses from license texts, which might be necessary or desirable to reproduce.
 

--- a/chapters/4-file-information.md
+++ b/chapters/4-file-information.md
@@ -1,6 +1,6 @@
 # 8 File information fields
 
-## F.1 File name field <a name="4.1"></a>
+## 8.1 File name field <a name="4.1"></a>
 
 **4.1.1** Purpose: Identify the full path and filename that corresponds to the file information in this section.
 
@@ -31,7 +31,7 @@ Example:
 </File>
 ```
 
-## F.2 File SPDX identifier field <a name="4.2"></a>
+## 8.2 File SPDX identifier field <a name="4.2"></a>
 
 **4.2.1** Purpose: Uniquely identify any element in an SPDX document which might be referenced by other elements. These might be referenced internally and externally with the addition of the SPDX Document Identifier.
 
@@ -71,7 +71,7 @@ Example using document URI:
 </File>
 ```
 
-## F.3 File type field <a name="4.3"></a>
+## 8.3 File type field <a name="4.3"></a>
 
 **4.3.1** Purpose: This field provides information about the type of file identified. File Type is intrinsic to the file, independent of how the file is being used. A file may have more than one file type assigned to it, however the options to populate this field are limited to:
 
@@ -134,7 +134,7 @@ Example: (where file2 is a `README.TXT`)
 </File>
 ```
 
-## F.4 File checksum field <a name="4.4"></a>
+## 8.4 File checksum field <a name="4.4"></a>
 
 **4.4.1** Purpose: Provide a unique identifier to match analysis information on each specific file in a package.
 
@@ -181,7 +181,7 @@ Example:
 </File>
 ```
 
-## F.5 Concluded license field <a name="4.5"></a>
+## 8.5 Concluded license field <a name="4.5"></a>
 
 **4.5.1** Purpose: This field contains the license the SPDX file creator has concluded as governing the file or alternative values if the governing license cannot be determined.
 
@@ -193,11 +193,11 @@ A valid SPDX License Expression as defined in Annex [D](appendix-IV-SPDX-license
 
 `NOASSERTION`, if:
 
-(i) the SPDX file creator has attempted to, but cannot reach a reasonable objective determination;
+- the SPDX file creator has attempted to, but cannot reach a reasonable objective determination;
 
-(ii) the SPDX file creator has made no attempt to determine this field; or
+- the SPDX file creator has made no attempt to determine this field; or
 
-(iii) the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+- the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
 
 If the Concluded License is not the same as the License Information in File, a written explanation should be provided in the Comments on License field ([8.7](#4.7)). With respect to `NOASSERTION`, a written explanation in the Comments on License field ([8.7](#4.7)) is preferred.
 
@@ -248,7 +248,7 @@ Example:
 </File>
 ```
 
-## F.6 License information in file field <a name="4.6"></a>
+## 8.6 License information in file field <a name="4.6"></a>
 
 **4.6.1** Purpose: This field contains the license information actually found in the file, if any. This information is most commonly found in the header of the file, although it might be in other areas of the actual file. Any license information not actually in the file, e.g., “COPYING.txt” file in a top level directory, should not be reflected in this field.
 
@@ -261,9 +261,9 @@ A reference to the license, denoted by LicenseRef-`[idstring]`, if the license i
 
 `NOASSERTION`, if:
 
-(i) the SPDX file creator has made no attempt to determine this field; or
+- the SPDX file creator has made no attempt to determine this field; or
 
-(ii) the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+- the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
 
 If license information for more than one license is contained in the file or if the license information offers the package recipient a choice of licenses, then each of the choices should be listed as a separate entry.
 
@@ -309,7 +309,7 @@ Example:
 </File>
 ```
 
-## F.7 Comments on license field <a name="4.7"></a>
+## 8.7 Comments on license field <a name="4.7"></a>
 
 **4.7.1** Purpose: This field provides a place for the SPDX file creator to record any relevant background references or analysis that went in to arriving at the Concluded License for a file. If the Concluded License does not match the License Information in File, this should be explained by the SPDX file creator. It is also preferable to include an explanation here when the Concluded License is `NOASSERTION`.
 
@@ -344,7 +344,7 @@ Example:
 </File>
 ```
 
-## F.8 Copyright text field <a name="4.8"></a>
+## 8.8 Copyright text field <a name="4.8"></a>
 
 **4.8.1** Purpose: Identify the copyright holder of the file, as well as any dates present. This shall be a free-form text field extracted from the actual file.
 
@@ -356,9 +356,9 @@ Any text relating to a copyright notice, even if not complete;
 
 `NOASSERTION`, if
 
-(i) the SPDX document creator has made no attempt to determine this field; or
+- the SPDX document creator has made no attempt to determine this field; or
 
-(ii) the SPDX document creator has intentionally provided no information (no meaning should be implied from the absence of an assertion).
+- the SPDX document creator has intentionally provided no information (no meaning should be implied from the absence of an assertion).
 
 **4.8.2** Intent: Record any copyright notice for the file.
 
@@ -388,7 +388,7 @@ Example:
 </File>
 ```
 
-## F.9 Artifact of project name field (deprecated) <a name="4.9"></a>
+## 8.9 Artifact of project name field (deprecated) <a name="4.9"></a>
 
 **4.9.1** Purpose: To indicate that a file has been derived from a specific project.
 
@@ -422,7 +422,7 @@ Example:
 </File>
 ```
 
-## F.10 Artifact of project homepage field (deprecated) <a name="4.10"></a>
+## 8.10 Artifact of project homepage field (deprecated) <a name="4.10"></a>
 
 **4.10.1** Purpose: To indicate the location of the project from which the file has been derived.
 
@@ -456,7 +456,7 @@ Example:
 </File>
 ```
 
-## F.11 Artifact of project uniform resource identifier field (deprecated) <a name="4.11"></a>
+## 8.11 Artifact of project uniform resource identifier field (deprecated) <a name="4.11"></a>
 
 **4.11.1** Purpose: To provide a linkage to the project resource in the DOAP document and permit interoperability between the different formats supported.
 
@@ -489,7 +489,7 @@ the value "http://subversion.apache.org/" is the URI of the describes
 resource of type doap:Project -->
 ```
 
-## F.12 File comment field <a name="4.12"></a>
+## 8.12 File comment field <a name="4.12"></a>
 
 **4.12.1** Purpose: This field provides a place for the SPDX file creator to record any general comments about the file.
 
@@ -523,7 +523,7 @@ Example:
 </File>
 ```
 
-## F.13 File notice field <a name="4.13"></a>
+## 8.13 File notice field <a name="4.13"></a>
 
 **4.13.1** Purpose: This field provides a place for the SPDX file creator to record license notices or other such related notices found in the file. This might or might not include copyright statements.
 
@@ -555,7 +555,7 @@ Example:
 </File>
 ```
 
-## F.14 File contributor field <a name="4.14"></a>
+## 8.14 File contributor field <a name="4.14"></a>
 
 **4.14.1** Purpose: This field provides a place for the SPDX file creator to record file contributors. Contributors could include names of copyright holders and/or authors who might not be copyright holders, yet contributed to the file content.
 
@@ -589,7 +589,7 @@ Example:
 </File>
 ```
 
-## F.15 File attribution text field <a name="4.15"></a>
+## 8.15 File attribution text field <a name="4.15"></a>
 
 **4.15.1** Purpose: This field provides a place for the SPDX data creator to record, at the file level, acknowledgements that might be required to be communicated in some contexts. This is not meant to include the file's actual complete license text (see `LicenseConcluded` and `LicenseInfoInFile`), and might or might not include copyright notices (see also `FileCopyrightText`). The SPDX data creator might use this field to record other acknowledgements, such as particular clauses from license texts, which might be necessary or desirable to reproduce.
 
@@ -625,7 +625,7 @@ Example:
 </File>
 ```
 
-## F.16 File dependencies field (deprecated) <a name="4.16"></a>
+## 8.16 File dependencies field (deprecated) <a name="4.16"></a>
 
 This field is deprecated since SPDX 2.0 in favor of using Clause [11](7-relationships-between-SPDX-elements.md) which provides more granularity about relationships.
 

--- a/chapters/5-snippet-information.md
+++ b/chapters/5-snippet-information.md
@@ -1,6 +1,6 @@
 # 9 Snippet information fields
 
-## S.1 Snippet SPDX identifier field <a name="5.1"></a>
+## 9.1 Snippet SPDX identifier field <a name="5.1"></a>
 
 **5.1.1** Purpose: Uniquely identify any element in an SPDX document which may be referenced by other elements. These may be referenced internally and externally with the addition of the SPDX Document Identifier.
 
@@ -40,7 +40,7 @@ Example using document URI:
 </Snippet>
 ```
 
-## S.2 Snippet from file SPDX identifier field <a name="5.2"></a>
+## 9.2 Snippet from file SPDX identifier field <a name="5.2"></a>
 
 **5.2.1** Purpose: Uniquely identify the file in an SPDX document which this snippet is associated with.
 
@@ -88,7 +88,7 @@ Example (snippet from a File in an External SPDX Doc):
 </Snippet>
 ```
 
-## S.3 Snippet byte range field <a name="5.3"></a>
+## 9.3 Snippet byte range field <a name="5.3"></a>
 
 **5.3.1** Purpose: This field defines the byte range in the original host file (in [9.2](#5.2)) that the snippet information applies to.
 
@@ -150,7 +150,7 @@ This specification uses the prefix `ptr:` to refer to the [W3C Pointers][pointer
 xmlns:ptr=http://www.w3.org/2009/pointers#
 ```
 
-## S.4 Snippet line range field <a name="5.4"></a>
+## 9.4 Snippet line range field <a name="5.4"></a>
 
 **5.4.1** Purpose: This optional field defines the line range in the original host file (see [9.2](#5.2)) that the snippet information applies to. If there is a disagreement between the byte range and line range, the byte range values will take precedence.
 
@@ -204,7 +204,7 @@ Example:
 </Snippet>
 ```
 
-## S.5 Snippet concluded license field <a name="5.5"></a>
+## 9.5 Snippet concluded license field <a name="5.5"></a>
 
 **5.5.1** Purpose: This field contains the license the SPDX file creator has concluded as governing the snippet or alternative values if the governing license cannot be determined. The options to populate this field are limited to:
 
@@ -214,13 +214,13 @@ A valid SPDX License Expression as defined in Annex [D](appendix-IV-SPDX-license
 
 `NOASSERTION` should be used if for the snippet:
 
-(i) the SPDX document creator has attempted to, but cannot reach a reasonable objective determination of the Concluded License;
+- the SPDX document creator has attempted to, but cannot reach a reasonable objective determination of the Concluded License;
 
-(ii) the SPDX document creator is uncomfortable concluding a license, despite some license information being available;
+- the SPDX document creator is uncomfortable concluding a license, despite some license information being available;
 
-(iii) the SPDX document creator has made no attempt to determine a Concluded License;
+- the SPDX document creator has made no attempt to determine a Concluded License;
 
-(iv) the SPDX document creator has intentionally provided no information (no meaning should be implied by doing so).
+- the SPDX document creator has intentionally provided no information (no meaning should be implied by doing so).
 
 If the Concluded License is not the same as the License Information in File, a written explanation should be provided in the Comments on License field (see [9.7](#5.7)). With respect to `NOASSERTION`, a written explanation in the Comments on License field (see [9.7](#5.7)) is preferred.
 
@@ -273,7 +273,7 @@ Example:
 </Snippet>
 ```
 
-## S.6 License information in snippet field <a name="5.6"></a>
+## 9.6 License information in snippet field <a name="5.6"></a>
 
 **5.6.1** Purpose: This field contains the license information actually found in the snippet, if any. Any license information not actually in the snippet itself, e.g., header of the file the snippet belongs in, “COPYING.txt” file in a top level directory, should not be reflected in this field.
 
@@ -286,9 +286,9 @@ A reference to the license, denoted by LicenseRef-`[idstring]`, if the license i
 
 `NOASSERTION`, if:
 
-(i) the SPDX snippet creator has made no attempt to determine this field; or
+- the SPDX snippet creator has made no attempt to determine this field; or
 
-(ii) the SPDX snippet creator has intentionally provided no information (no meaning should be implied by doing so).
+- the SPDX snippet creator has intentionally provided no information (no meaning should be implied by doing so).
 
 If license information for more than one license is contained in the snippet or if the license information offers a choice of licenses, then each of the choices should be listed as a separate entry.
 
@@ -337,7 +337,7 @@ Example:
 </Snippet>
 ```
 
-## S.7 Snippet comments on license field <a name="5.7"></a>
+## 9.7 Snippet comments on license field <a name="5.7"></a>
 
 **5.7.1** Purpose: This field provides a place for the SPDX document creator to record any relevant background references or analysis that went in to arriving at the Concluded License for a snippet.
 
@@ -374,7 +374,7 @@ Example:
 </Snippet>
 ```
 
-## S.8 Snippet copyright text field <a name="5.8"></a>
+## 9.8 Snippet copyright text field <a name="5.8"></a>
 
 **5.8.1** Purpose: Identify the copyright holder of the snippet, as well as any dates present. This shall be a free form text field, ideally extracted from the actual snippet.  The options to populate this field are limited to:
 
@@ -414,7 +414,7 @@ Example:
 </Snippet>
 ```
 
-## S.9 Snippet comment field <a name="5.9"></a>
+## 9.9 Snippet comment field <a name="5.9"></a>
 
 **5.9.1** Purpose: This field provides a place for the SPDX document creator to record any general comments about the snippet.
 
@@ -451,7 +451,7 @@ Example:
 </Snippet>
 ```
 
-## S.10 Snippet name field <a name="5.10"></a>
+## 9.10 Snippet name field <a name="5.10"></a>
 
 **5.10.1** Purpose: Identify a specific snippet in a human convenient manner.
 
@@ -479,7 +479,7 @@ Example:
 </Snippet>
 ```
 
-## S.11 Snippet attribution text field <a name="5.11"></a>
+## 9.11 Snippet attribution text field <a name="5.11"></a>
 
 **5.11.1** Purpose: This field provides a place for the SPDX data creator to record, at the snippet level, acknowledgements that may be required to be communicated in some contexts. This is not meant to include the snippet's actual complete license text (see `SnippetLicenseConcluded` and `LicenseInfoInSnippet`), and might or might not include copyright notices (see also `SnippetCopyrightText`). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which might be necessary or desirable to reproduce.
 

--- a/chapters/6-other-licensing-information-detected.md
+++ b/chapters/6-other-licensing-information-detected.md
@@ -6,7 +6,7 @@ One instance should be created for every unique license or licensing information
 
 Fields:
 
-## L.1 License identifier field <a name="6.1"></a>
+## 10.1 License identifier field <a name="6.1"></a>
 
 **6.1.1** Purpose: Provide a locally unique identifier to refer to licenses that are not found on the SPDX License List. This unique identifier can then be used in the packages and files sections of the SPDX file (Clause [7](3-package-information.md) and Clause [8](4-file-information.md), respectively).
 
@@ -48,7 +48,7 @@ Examples:
 </ExtractedLicensingInfo>
 ```
 
-## L.2 Extracted text field <a name="6.2"></a>
+## 10.2 Extracted text field <a name="6.2"></a>
 
 **6.2.1** Purpose: Provide a copy of the actual text of the license reference extracted from the package or file that is associated with the License Identifier to aid in future analysis.
 
@@ -94,7 +94,7 @@ Example 2 (if indeed full text of license present in File):
 </ExtractedLicensingInfo>
 ```
 
-## L.3 License name field <a name="6.3"></a>
+## 10.3 License name field <a name="6.3"></a>
 
 **6.3.1** Purpose: Provide a common name of the license that is not on the SPDX list.
 
@@ -124,7 +124,7 @@ Example:
 </ExtractedLicensingInfo>
 ```
 
-## L.4 License cross reference field <a name="6.4"></a>
+## 10.4 License cross reference field <a name="6.4"></a>
 
 **6.4.1** Purpose: Provide a pointer to the official source of a license that is not included in the SPDX License List, that is referenced by the License Identifier.
 
@@ -152,7 +152,7 @@ Example:
 </ExtractedLicensingInfo>
 ```
 
-## L.5 License comment field <a name="6.5"></a>
+## 10.5 License comment field <a name="6.5"></a>
 
 **6.5.1** Purpose: This field provides a place for the SPDX file creator to record any general comments about the license.
 

--- a/chapters/7-relationships-between-SPDX-elements.md
+++ b/chapters/7-relationships-between-SPDX-elements.md
@@ -1,6 +1,6 @@
 # 11 Relationships between SPDX elements fields
 
-## R.1 Relationship field <a name="7.1"></a>
+## 11.1 Relationship field <a name="7.1"></a>
 
 **7.1.1** Purpose: This field provides information about the relationship between two SPDX elements. For example, you can represent a relationship between two different Files, between a Package and a File, between two Packages, or between one SPDXDocument and another SPDXDocument. 
 
@@ -137,7 +137,7 @@ Examples:
 </SpdxElement>
 ```
 
-## R.2 Relationship comment field <a name="7.2"></a>
+## 11.2 Relationship comment field <a name="7.2"></a>
 
 **7.2.1** Purpose: This field provides a place for the SPDX file creator to record any general comments about the relationship.
 

--- a/chapters/8-annotations.md
+++ b/chapters/8-annotations.md
@@ -1,6 +1,6 @@
 # 12 Annotations fields
 
-## A.1 Annotator field <a name="8.1"></a>
+## 12.1 Annotator field <a name="8.1"></a>
 
 **8.1.1** Purpose: This field identifies the person, organization or tool that has commented on a file, package, or the entire document.
 
@@ -34,7 +34,7 @@ Example:
 </Annotation>
 ```
 
-## A.2 Annotation date field <a name="8.2"></a>
+## 12.2 Annotation date field <a name="8.2"></a>
 
 **8.2.1** Purpose: Identify when the comment was made. This shall be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.
 
@@ -73,7 +73,7 @@ Example:
 </Annotation>
 ```
 
-## A.3 Annotation type field <a name="8.3"></a>
+## 12.3 Annotation type field <a name="8.3"></a>
 
 **8.3.1** Purpose: This field describes the type of annotation. Annotations are usually created when someone reviews the file, and if this is the case the annotation type should be `REVIEW`. If the author wants to store extra information about one of the elements during creation, it is recommended to use the type of `OTHER`.
 
@@ -101,7 +101,7 @@ Example:
 </Annotation>
 ```
 
-## A.4 SPDX identifier reference field <a name="8.4"></a>
+## 12.4 SPDX identifier reference field <a name="8.4"></a>
 
 **8.4.1** Purpose: Uniquely identify the element in an SPDX document which is being referenced. These may be referenced internally and externally with the addition of the SPDX Document Identifier.
 
@@ -144,7 +144,7 @@ For RDF, the annotations are a property of the SPDX Document, Package, File, or 
 </File>
 ```
 
-## A.5 Annotation comment field <a name="8.5"></a>
+## 12.5 Annotation comment field <a name="8.5"></a>
 
 **8.5.1** Purpose: This required free form text field permits the annotator to provide commentary on the analysis.
 

--- a/chapters/9-review-information-deprecated.md
+++ b/chapters/9-review-information-deprecated.md
@@ -6,7 +6,7 @@ Review information can be added after the initial SPDX file has been created. Th
 
 Fields:
 
-## I.1 Reviewer field (deprecated) <a name="9.1"></a>
+## 13.1 Reviewer field (deprecated) <a name="9.1"></a>
 
 This field has been deprecated since SPDX 2.0.
 
@@ -42,7 +42,7 @@ Example:
 </Review>
 ```
 
-## I.2 Review date field (deprecated) <a name="9.2"></a>
+## 13.2 Review date field (deprecated) <a name="9.2"></a>
 
 This field has been deprecated since SPDX 2.0.
 
@@ -83,7 +83,7 @@ Example:
 </Review>
 ```
 
-## I.3 Review comment field (deprecated) <a name="9.3"></a>
+## 13.3 Review comment field (deprecated) <a name="9.3"></a>
 
 This field is deprecated since SPDX 2.0.
 


### PR DESCRIPTION
- Now that we've changed from lettered-clause IDs to numbered ones, I updated all level-2 subclauses to reflect this, *except* for Clause 6, which John is handling.
- In all clauses, changed all Roman-numbered pseudo-lists to md bullet lists
