### PR TITLE
Reformat 6-other-licensing-information-detected

### DIFF
--- a/chapters/6-other-licensing-information-detected.md
+++ b/chapters/6-other-licensing-information-detected.md
@@ -8,21 +8,29 @@ Fields:
 
 ## 10.1 License identifier field <a name="6.1"></a>
 
-**6.1.1** Purpose: Provide a locally unique identifier to refer to licenses that are not found on the SPDX License List. This unique identifier can then be used in the packages and files sections of the SPDX file (Clause [7](3-package-information.md) and Clause [8](4-file-information.md), respectively).
+**Description**
 
-**6.1.2** Intent: Create a human readable short form license identifier for a license not on the SPDX License List. This identifier shall be unique within the SPDX file. In previous versions of SPDX, the references were required to be sequential numbers, but as of version 1.2, creators may specify references that are easier for humans to remember and mentally map.
+Provide a locally unique identifier to refer to licenses that are not found on the SPDX License List. This unique identifier can then be used in the packages and files sections of the SPDX file (Clause [7](3-package-information.md) and Clause [8](4-file-information.md), respectively).
 
-**6.1.3** Cardinality: Conditional (mandatory, one) if license is not on SPDX License List.
+**Intent**
 
-**6.1.4** Data Format: "LicenseRef-"`[idstring]`
+Create a human readable short form license identifier for a license not on the SPDX License List. This identifier shall be unique within the SPDX file. In previous versions of SPDX, the references were required to be sequential numbers, but as of version 1.2, creators may specify references that are easier for humans to remember and mentally map.
 
-where
+**Metadata**
 
-`[idstring]` is a unique string containing letters, numbers, `.` and/or `-`.
+The metadata for the license identifier field is shown in Table 63.
 
-**6.1.5** Tag: `LicenseID:`
+Table 63 — Metadata for the license identifier field
 
-Examples:
+| Attribute | Value |
+| --------- | ----- |
+| Required | Conditional |
+| Cardinality | 0..1 conditional (mandatory, one) if license is not on SPDX License List. |
+| Format | "LicenseRef-"`[idstring]`<br>where<br>`[idstring]` is a unique string containing letters, numbers, `.` and/or `-`. |
+
+**Examples**
+
+EXAMPLE 1 Tag: `LicenseID:`
 
 ```text
 LicenseID: LicenseRef-1
@@ -32,9 +40,7 @@ LicenseID: LicenseRef-1
 LicenseID: LicenseRef-Beerware-4.2
 ```
 
-**6.1.6** RDF: Property `spdx:licenseID` in class `spdx:ExtractedLicensingInfo`
-
-Examples:
+EXAMPLE 2 RDF: Property `spdx:licenseID` in class `spdx:ExtractedLicensingInfo`
 
 ```text
 <ExtractedLicensingInfo rdf:about="licenseRef-1">
@@ -50,33 +56,47 @@ Examples:
 
 ## 10.2 Extracted text field <a name="6.2"></a>
 
-**6.2.1** Purpose: Provide a copy of the actual text of the license reference extracted from the package or file that is associated with the License Identifier to aid in future analysis.
+**Description**
 
-**6.2.2** Intent: Provide the actual text as found in the package or file for a license that is not on the SPDX License List.
+Provide a copy of the actual text of the license reference extracted from the package or file that is associated with the License Identifier to aid in future analysis.
 
-**6.2.3** Cardinality: Conditional (Mandatory, one) if there is a License Identifier assigned.
+**Intent**
 
-**6.2.4** Data Format: Free form text field that may span multiple lines.
+Provide the actual text as found in the package or file for a license that is not on the SPDX License List.
 
-**6.2.5** Tag: `ExtractedText:`
+**Metadata**
+
+The metadata for the extracted text field is shown in Table 64.
+
+Table 64 — Metadata for the extracted text field
+
+| Attribute | Value |
+| --------- | ----- |
+| Required | Conditional |
+| Cardinality | 0..1 conditional (Mandatory, one) if there is a License Identifier assigned. |
+| Format | Free form text field that may span multiple lines. |
+
+**Examples**
+
+EXAMPLE 1 Tag: `ExtractedText:`
 
 In `tag:value` format multiple lines are delimited by `<text> .. </text>`.
 
-Example 1 (if only short reference to license present in File):
+If only short reference to license present in File:
 
 ```text
 ExtractedText: <text>This software is licensed under the Beer License.</text>
 ```
 
-Example 2 (if indeed full text of license present in File):
+If indeed full text of license present in File:
 
 ```text
 ExtractedText: <text>"THE WHISKEY-WARE LICENSE": whiskeyfan@example.com wrote this file. As long as you retain this notice you can do whatever you want with this stuff. If we meet some day, and you think this stuff is worth it, you can buy me a bottle of whiskey in return </text>
 ```
 
-**6.2.6** RDF: Property `spdx:extractedText` in class `spdx:ExtractedLicensingInfo`
+EXAMPLE 2 RDF: Property `spdx:extractedText` in class `spdx:ExtractedLicensingInfo`
 
-Example 1 (if only short reference to license present in File):
+If only short reference to license present in File:
 
 ```text
 <ExtractedLicensingInfo rdf:about="licenseRef-Whiskeyware">
@@ -85,7 +105,7 @@ Example 1 (if only short reference to license present in File):
 </ExtractedLicensingInfo>
 ```
 
-Example 2 (if indeed full text of license present in File):
+If indeed full text of license present in File:
 
 ```text
 <ExtractedLicensingInfo rdf:about="licenseRef-Whiskeyware">
@@ -96,27 +116,37 @@ Example 2 (if indeed full text of license present in File):
 
 ## 10.3 License name field <a name="6.3"></a>
 
-**6.3.1** Purpose: Provide a common name of the license that is not on the SPDX list.
+**Description**
+
+Provide a common name of the license that is not on the SPDX list.
 
 Use `NOASSERTION` If there is no common name or it is not known.
 
-**6.3.2** Intent: Provides a human readable name suitable for use as a title or label of the license when showing compact lists of licenses from the SPDX data to humans.
+**Intent**
 
-**6.3.3** Cardinality: Conditional (mandatory, one) if license is not on SPDX License List.
+Provides a human readable name suitable for use as a title or label of the license when showing compact lists of licenses from the SPDX data to humans.
 
-**6.3.4** Data Format: Single line of text | `NOASSERTION`.
+**Metadata**
 
-**6.3.5** Tag: `LicenseName:`
+The metadata for the license name field is shown in Table 65.
 
-Example:
+Table 65 — Metadata for the license name field
+
+| Attribute | Value |
+| --------- | ----- |
+| Required | Conditional |
+| Cardinality | 0..1 conditional (mandatory, one) if license is not on SPDX License List. |
+| Format | Single line of text | `NOASSERTION` |
+
+**Examples**
+
+EXAMPLE 1 Tag: `LicenseName:`
 
 ```text
 LicenseName: Whiskey-Ware License
 ```
 
-**6.3.6** RDF: Property `spdx:name` in class `spdx:ExtractedLicensingInfo`
-
-Example:
+EXAMPLE 2 RDF: Property `spdx:name` in class `spdx:ExtractedLicensingInfo`
 
 ```text
 <ExtractedLicensingInfo rdf:about="licenseRef-Whiskey-Ware">
@@ -126,25 +156,35 @@ Example:
 
 ## 10.4 License cross reference field <a name="6.4"></a>
 
-**6.4.1** Purpose: Provide a pointer to the official source of a license that is not included in the SPDX License List, that is referenced by the License Identifier.
+**Description**
 
-**6.4.2** Intent: Canonical source for a license currently not on the SPDX License List.
+Provide a pointer to the official source of a license that is not included in the SPDX License List, that is referenced by the License Identifier.
 
-**6.4.3** Cardinality: Conditional (optional, one or more) if license is not on SPDX License List.
+**Intent**
 
-**6.4.4** Data Format: Uniform Resource Locator
+Canonical source for a license currently not on the SPDX License List.
 
-**6.4.5** Tag: `LicenseCrossReference:`
+**Metadata**
 
-Example:
+The metadata for the license cross reference field is shown in Table 66.
+
+Table 66 — Metadata for the license cross reference field
+
+| Attribute | Value |
+| --------- | ----- |
+| Required | Conditional |
+| Cardinality | 0..* conditional (optional, one or more) if license is not on SPDX License List. |
+| Format | Uniform Resource Locator |
+
+**Examples**
+
+EXAMPLE 1 Tag: `LicenseCrossReference:`
 
 ```text
 LicenseCrossReference: http://people.freebsd.org/~phk/
 ```
 
-**6.4.6** RDF: Property `rdfs:seeAlso` in class `spdx:ExtractedLicensingInfo`
-
-Example:
+EXAMPLE 2 RDF: Property `rdfs:seeAlso` in class `spdx:ExtractedLicensingInfo`
 
 ```text
 <ExtractedLicensingInfo rdf:about="licenseRef-1">
@@ -154,27 +194,37 @@ Example:
 
 ## 10.5 License comment field <a name="6.5"></a>
 
-**6.5.1** Purpose: This field provides a place for the SPDX file creator to record any general comments about the license.
+**Description**
 
-**6.5.2** Intent: Here, the intent is to provide the recipient of the SPDX file with more information determined after careful analysis of a license, or addition cross references.
+This field provides a place for the SPDX file creator to record any general comments about the license.
 
-**6.5.3** Cardinality: Optional, one.
+**Intent**
 
-**6.5.4** Data Format: Free form text that can span multiple lines
+Here, the intent is to provide the recipient of the SPDX file with more information determined after careful analysis of a license, or addition cross references.
 
-**6.5.5** Tag: `LicenseComment:`
+**Metadata**
+
+The metadata for the license comment field is shown in Table 67.
+
+Table 67 — Metadata for the license comment field
+
+| Attribute | Value |
+| --------- | ----- |
+| Required | No |
+| Cardinality | 0..1 |
+| Format | Free form text that can span multiple lines |
+
+**Examples**
+
+EXAMPLE 1 Tag: `LicenseComment:`
 
 In `tag:value` format multiple lines are delimited by `<text> .. </text>`.
-
-Example:
 
 ```text
 LicenseComment: <text>The Whiskey-Ware License has a couple of other standard variants.</text>
 ```
 
-**6.5.6** RDF: Property `rdfs:comment` in class `spdx:ExtractedLicensingInfo`
-
-Example:
+EXAMPLE 2 RDF: Property `rdfs:comment` in class `spdx:ExtractedLicensingInfo`
 
 ```text
 <ExtractedLicensingInfo rdf:about="licenseRef-1">


### PR DESCRIPTION
Rename Purpose headings to Description
Convert metadata to tabular format
Remove pseudo-subsection numbers