### PR TITLE
Fix-up clause anchors and links

### DIFF
--- a/chapters/annotations.md
+++ b/chapters/annotations.md
@@ -1,6 +1,6 @@
 # 12 Annotations fields
 
-## 12.1 Annotator field <a name="8.1"></a>
+## 12.1 Annotator field <a name="12.1"></a>
 
 **Description**
 
@@ -38,7 +38,7 @@ EXAMPLE 2 RDF: Property `spdx:annotator` in class `spdx:Annotation`
 </Annotation>
 ```
 
-## 12.2 Annotation date field <a name="8.2"></a>
+## 12.2 Annotation date field <a name="12.2"></a>
 
 **Description**
 
@@ -76,7 +76,7 @@ EXAMPLE 2 RDF: Property `spdx:annotationDate` in class `spdx:Annotation`
 </Annotation>
 ```
 
-## 12.3 Annotation type field <a name="8.3"></a>
+## 12.3 Annotation type field <a name="12.3"></a>
 
 **Description**
 
@@ -114,7 +114,7 @@ EXAMPLE 2 RDF: property `spdx:annotationType` in class `spdx:Annotation`
 </Annotation>
 ```
 
-## 12.4 SPDX identifier reference field <a name="8.4"></a>
+## 12.4 SPDX identifier reference field <a name="12.4"></a>
 
 **Description**
 
@@ -134,7 +134,7 @@ Table 74 — Metadata for the SPDX identifier reference field
 | --------- | ----- |
 | Required | Conditional |
 | Cardinality | 0..1 conditional (Mandatory, one), if there is an Annotation. |
-| Format | `[DocumentRef-[idstring]:]SPDXID`<br>where:<br>`["DocumentRef-"[idstring]":"]` is an optional reference to an external SPDX document as described in [6.6](2-document-creation-information.md#2.6)<br>`SPDXID` is a unique string containing letters, numbers, `.` and/or `-` as described in [6.3](2-document-creation-information.md#2.3), [7.2](3-package-information.md#3.2) and [8.2](4-file-information.md#4.2). |
+| Format | `[DocumentRef-[idstring]:]SPDXID`<br>where:<br>`["DocumentRef-"[idstring]":"]` is an optional reference to an external SPDX document as described in [6.6](document-creation-information.md#6.6)<br>`SPDXID` is a unique string containing letters, numbers, `.` and/or `-` as described in [6.3](document-creation-information.md#6.3), [7.2](package-information.md#7.2) and [8.2](file-information.md#8.2). |
 
 **Examples**
 
@@ -162,7 +162,7 @@ For RDF, the annotations are a property of the SPDX Document, Package, File, or 
 </File>
 ```
 
-## 12.5 Annotation comment field <a name="8.5"></a>
+## 12.5 Annotation comment field <a name="12.5"></a>
 
 **Description**
 

--- a/chapters/composition-of-an-SPDX-document.md
+++ b/chapters/composition-of-an-SPDX-document.md
@@ -1,12 +1,12 @@
 # 5 Composition of an SPDX document
 
-## 5.1 What this specification covers
+## 5.1 What this specification covers <a name="5.1"></a>
 
 This document contains the specification for an SPDX document, which is made up of a set of **zero/one** or more sections, instances of which contain information in the form of *fields*. The following subclauses introduce the different kinds of sections allowed. The fields for each kind of section are defined in the clause corresponding to that section.
 
-## 5.2 sections
+## 5.2 Sections <a name="5.2"></a>
 
-### 5.2.1 SPDX document creation information section
+### 5.2.1 SPDX document creation information section <a name="5.2.1"></a>
 
 An instance of this kind of section provides the necessary information for forward and backward compatibility for processing tools.
 
@@ -16,7 +16,7 @@ Cardinality: Mandatory, one.
 
 See [Clause 6](2-document-creation-information.md) for details of the fields in this kind of section.
 
-### 5.2.2 Package information section
+### 5.2.2 Package information section <a name="5.2.2"></a>
 
 If SPDX information is organized by grouping into packages, then one instance of the Package Information per package being described shall exist. A package may contain sub-packages, but the information in this section is a reference to the entire contents of the package listed. Starting with SPDX 2.0, it is not necessary to have a package wrapping a set of files.
 
@@ -24,16 +24,16 @@ Cardinality: Optional, one or many.
 
 In `tag:value` format, the order in which package and files occur is syntactically significant.
 
-* A new Package Information section is denoted by the [Package Name](#3.1) field.
-* All Package Information fields shall be grouped together before the start of a [Files section](4-file-information.md), if file(s) are present.
+* A new Package Information section is denoted by the Package Name ([7.1](package-information.md#7.1)) field.
+* All Package Information fields shall be grouped together before the start of a Files section ([Clause 8](file-information.md)), if file(s) are present.
 * All files contained in a package shall immediately follow the applicable Package Information.
 * A new Package Information section (via Package Name) denotes the start of another package.
 * Sub-packages shall not be nested inside a Package Information section, but shall be separate and shall use a Relationship to clarify.
 * Annotations and Relationships for the package may appear after the Package Information before any file information.
 
-See [Clause 7](3-package-information.md) for details of the fields in this kind of section.
+See [Clause 7](package-information.md) for details of the fields in this kind of section.
 
-### 5.2.3 File information Fields
+### 5.2.3 File information Fields <a name="5.2.3"></a>
 
 One instance of the File Information shall exist for each file in the software package. It provides important meta information about a given file including licenses and copyright. Starting with SPDX 2.0, it is not necessary to have a package wrapping a set of files.
 
@@ -49,9 +49,9 @@ When implementing `tag:value` format, the positioning of File elements is syntac
 
 When implementing file information in RDF, the `spdx:hasFile` property is used to associate the package with the file.
 
-See [Clause 8](4-file-information.md) for details of the fields in this kind of section.
+See [Clause 8](file-information.md) for details of the fields in this kind of section.
 
-### 5.2.4 Snippet information section
+### 5.2.4 Snippet information section <a name="5.2.4"></a>
 
 Snippets can optionally be used when a file is known to have some content that has been included from another original source. They are useful for denoting when part of a file may have been originally created under another license.
 
@@ -64,43 +64,43 @@ When implementing `tag:value` format, the positioning of Snippet elements is syn
 * The first field to start off the description of a Snippet shall be the Snippet Identifier in `tag:value` format.
 * Annotations on the Snippet and Relationships from the Snippet may appear after the Snippet Information, before the next file or Package section.
 
-See [Clause 9](5-snippet-information.md) for details of the fields in this kind of section.
+See [Clause 9](snippet-information.md) for details of the fields in this kind of section.
 
-### 5.2.5 Other licensing information detected
+### 5.2.5 Other licensing information detected <a name="5.2.5"></a>
 
-This section is used for any detected, declared or concluded licenses that are NOT on the SPDX License List. For the most up-to-date version of the list, see [https://spdx.org/licenses/](https://spdx.org/licenses/). The SPDX License List can also be found here in [Annex A](appendix-I-SPDX-license-list.md).
+This section is used for any detected, declared or concluded licenses that are NOT on the SPDX License List. For the most up-to-date version of the list, see [https://spdx.org/licenses/](https://spdx.org/licenses/). The SPDX License List can also be found in [Annex A](SPDX-license-list.md).
 
 One instance shall be created for every unique license or licensing information reference detected in package that does not match one of the licenses on the SPDX License List. Each license instance should have the following fields.
 
-See [Clause 10](6-other-licensing-information-detected.md) for details of the fields in this kind of section.
+See [Clause 10](other-licensing-information-detected.md) for details of the fields in this kind of section.
 
-### 5.2.6 Relationships Between SPDX Elements section
+### 5.2.6 Relationships Between SPDX Elements section <a name="5.2.6"></a>
 
 > ToDo: there was no intro text in Chapter 7 to move here, but, presumably, we should say something.
 
-See [Clause 11](7-relationships-between-SPDX-elements.md) for details of the fields in this kind of section.
+See [Clause 11](relationships-between-SPDX-elements.md) for details of the fields in this kind of section.
 
-### 5.2.7 Annotations section
+### 5.2.7 Annotations section <a name="5.2.7"></a>
 
 > ToDo: there was no intro text in Chapter 8 to move here, but, presumably, we should say something.
 
-See [Clause 12](8-annotations.md) for details of the fields in this kind of section.
+See [Clause 12](annotations.md) for details of the fields in this kind of section.
 
-### 5.2.8 Review information section
+### 5.2.8 Review information section <a name="5.2.8"></a>
 
-The review information section is included for compatibility with SPDX 1.2, and is deprecated since SPDX 2.0. Any review information shall use an Annotation (as described in [Clause 12](./8-annotations.md)) with an annotation type of `REVIEW`.
+The review information section is included for compatibility with SPDX 1.2, and is deprecated since SPDX 2.0. Any review information shall use an Annotation (as described in [Clause 12](annotations.md)) with an annotation type of `REVIEW`.
 
 Review information may be added after the initial SPDX file has been created. The set of fields are optional and multiple instances may be added. Once a Reviewer entry is added, the Review Date associated with the review is mandatory. The Created date shall not be modified as a result of the addition of information regarding the conduct of a review. A Review Comments is optional.
 
-See [Clause 13](9-review-information-deprecated.md) for details of the fields in this kind of section.
+See [Clause 13](review-information-deprecated.md) for details of the fields in this kind of section.
 
-## 5.3 Section organization
+## 5.3 Section organization <a name="5.3"></a>
 
 Within an SPDX document, sections may be organized, as follows:
 
 ![Overview of SPDX document contents](img/spdx-2.2-document.png)
 
-## 5.4 What this specification does not cover
+## 5.4 What this specification does not cover <a name="5.4"></a>
 
 This document does not address the following:
 

--- a/chapters/conformance.md
+++ b/chapters/conformance.md
@@ -1,14 +1,14 @@
 # 4 Conformance
 
-## 4.1 SPDX Versions
+## 4.1 SPDX Versions <a name="4.1"></a>
 
 This edition has the version number 2.2.1 as part of its title. Although this is the first ISO edition of the SPDX Specification, earlier editions were published by the SPDX Working Group via the Linux Foundation (which also copublished this edition). [Those earlier editions are: 1.0 (August 2011), 1.1 (August 2012), 1.2 (October 2013), 2.0 (May 2015), 2.1 (November 2016), and 2.2 (May 2020).] Differences between this edition and earlier ones are reported in [Annex J](diffs-from-previous-editions.md); see also [1].
 
-## 4.2 Obsolete features
+## 4.2 Obsolete features <a name="4.2"></a>
 
 Over the life of a standard, some older approaches can become obsolete and are dropped from subsequent editions, possibly with a replacement approach being provided. Such action involves *deprecating* those out-dated features. This edition identifies all currently deprecated features.
 
-## 4.3 Alternate notation for some requirements
+## 4.3 Alternate notation for some requirements <a name="4.3"></a>
 
 This standard contains more than a few *cardinality assertions*, each of which indicates absolute, optional, or conditional requirements. Here are some examples:
 
@@ -18,7 +18,7 @@ This standard contains more than a few *cardinality assertions*, each of which i
 
 Each of these assertions can easily be understood as to whether a feature is required, and if so, how many occurrences are required; also whether a feature is permitted, and if so, in what number. As this is the format long familiar to the SPDX community, it has been preserved in this document.
 
-## 4.4 Standard data format requirements
+## 4.4 Standard data format requirements <a name="4.4"></a>
 
 The data format specification and recommendations are subject to the following:
 
@@ -58,7 +58,7 @@ In addition to the supported formats, the following format is in development wit
 
 * The convention in this specification is for the RDF examples to use `rdf:about="..."` to represent that a proper Universal Resource Indicator (URI) should be present.
 
-## 4.5 Usage
+## 4.5 Usage <a name="4.5"></a>
 
 A file may be designated an SPDX document, if it is compliant with the requirements of the SPDX Trademark License (See the SPDX Trademark Page).
 
@@ -70,6 +70,6 @@ The official copyright notice that shall be used with any non-verbatim reproduct
 
 > "This is not an official SPDX Specification. Portions herein have been reproduced from SPDX® Specification 2.2.1 found at spdx.org. These portions are Copyright © 2010-2020 Linux Foundation and its Contributors, and are licensed under the Creative Commons Attribution License 3.0 Unported by the Linux Foundation and its Contributors. All other rights are expressly reserved by Linux Foundation and its Contributors."
 
-## 4.6 The SPDX Lite profile
+## 4.6 The SPDX Lite profile <a name="4.6"></a>
 
 This profile defines a subset of the SPDX specification. SPDX Lite aims at the balance between the SPDX standard and actual workflows in some industries. See [Annex H](appendix-VIII-SPDX-Lite.md) for more information.

--- a/chapters/document-creation-information.md
+++ b/chapters/document-creation-information.md
@@ -1,6 +1,6 @@
-# Document creation information fields
+# 6 Document creation information fields
 
-## 6.1 SPDX version field <a name="2.1"></a>
+## 6.1 SPDX version field <a name="6.1"></a>
 
 **Description**
 
@@ -44,7 +44,7 @@ This specification uses the prefix `rdf:` to refer to the [RDF/XML][rdf] namespa
 http://www.w3.org/1999/02/22-rdf-syntax-ns#
 ```
 
-## 6.2 Data license field <a name="2.2"></a>
+## 6.2 Data license field <a name="6.2"></a>
 
 **Description**
 
@@ -84,11 +84,11 @@ EXAMPLE 2 RDF: `spdx:dataLicense`
 </SpdxDocument>
 ```
 
-## 6.3 SPDX identifier field <a name="2.3"></a>
+## 6.3 SPDX identifier field <a name="6.3"></a>
 
 **Description**
 
-Identify the current SPDX document which may be referenced in relationships by other files, packages internally and documents externally. To reference another SPDX document in total, this identifier should be used with the external document identifier preceding it. See [Clause R](7-relationships-between-SPDX-elements.md) for examples.
+Identify the current SPDX document which may be referenced in relationships by other files, packages internally and documents externally. To reference another SPDX document in total, this identifier should be used with the external document identifier preceding it. See [Clause 11](relationships-between-SPDX-elements.md) for examples.
 
 **Intent**
 
@@ -127,7 +127,7 @@ The URI for the document is the document namespace appended by
 </spdx:SpdxDocument>
 ```
 
-## 6.4 Document name field <a name="2.4"></a>
+## 6.4 Document name field <a name="6.4"></a>
 
 **Description**
 
@@ -175,7 +175,7 @@ EXAMPLE 2 RDF: Property `spdx:name` in class `spdx:SpdxDocument`
 </SpdxDocument>
 ```
 
-## 6.5 SPDX document namespace field <a name="2.5"></a>
+## 6.5 SPDX document namespace field <a name="6.5"></a>
 
 **Description**
 
@@ -185,11 +185,11 @@ The URI shall be unique for the SPDX document including the specific version of 
 
 **Intent**
 
-The URI provides an unambiguous mechanism for other SPDX documents to reference SPDX elements within this SPDX document. See [D.6](#2.6) for a description on how external documents are referenced. Although it is not required, the URI can be constructed in a way which provides information on how the SPDX document can be found. For example, the URI can be a URL referencing the SPDX document itself, if it is available on the internet. A best practice for creating the URI for SPDX documents available on the public internet is `http://[CreatorWebsite]/[pathToSpdx]/[DocumentName]-[UUID]` where:
+The URI provides an unambiguous mechanism for other SPDX documents to reference SPDX elements within this SPDX document. See [6.6](#6.6) for a description on how external documents are referenced. Although it is not required, the URI can be constructed in a way which provides information on how the SPDX document can be found. For example, the URI can be a URL referencing the SPDX document itself, if it is available on the internet. A best practice for creating the URI for SPDX documents available on the public internet is `http://[CreatorWebsite]/[pathToSpdx]/[DocumentName]-[UUID]` where:
 
 * `CreatorWebsite` is a website hosted by the creator of the document. (e.g. an SPDX document provided by SPDX would be spdx.org)
 * `PathToSpdx` is a path to where SPDX documents are stored on the website (e.g. /spdx/spdxdocs)
-* `DocumentName` is a name given to the SPDX Document itself, typically the (set of) package name(s) followed by the version. (See [D.4](#2.4).)
+* `DocumentName` is a name given to the SPDX Document itself, typically the (set of) package name(s) followed by the version. (See [6.4](#6.4).)
 * `UUID` is a [universally unique identifier][URI]. The UUID could be a version 4 random UUID which can be generated from the [Online UUID Generator][uuid-gen] or a version 5 UUID generated from a sha1 checksum known to be unique for this specific SPDX document version.
 * If the creator does not own their own website, a default SPDX CreatorWebsite and PathToSpdx can be used `spdx.org/spdxdocs`. Note that the SPDX documents are not currently stored or accessible on this website. The URI is only used to create a unique ID following the above conventions.
 
@@ -233,7 +233,7 @@ This specification uses the prefix `rdfs:` to refer to the [RDF Schema][rdf-sche
 http://www.w3.org/2000/01/rdf-schema#
 ```
 
-## 6.6 External document references field <a name="2.6"></a>
+## 6.6 External document references field <a name="6.6"></a>
 
 **Description**
 
@@ -253,7 +253,7 @@ Table 7 — Metadata for the external document references field
 | --------- | ----- |
 | Required | No |
 | Cardinality | 1..* |
-| Format | DocumentRef-`[idstring]` `[SPDX Document URI]` `[Checksum]`<br>where<br>`[idstring]` is a unique string containing letters, numbers, `.`, `-` and/or `+`.<br>`[SPDX Document URI]` is the unique ID for the external document as defined in [D.5](#2.5) of that referenced document,<br> `[Checksum]` is a checksum of the external document following the checksum format defined in [F.4](4-file-information#4.4). |
+| Format | DocumentRef-`[idstring]` `[SPDX Document URI]` `[Checksum]`<br>where<br>`[idstring]` is a unique string containing letters, numbers, `.`, `-` and/or `+`.<br>`[SPDX Document URI]` is the unique ID for the external document as defined in [6.5](#6.5) of that referenced document,<br> `[Checksum]` is a checksum of the external document following the checksum format defined in [8.4](file-information#8.4). |
 
 **Examples**
 
@@ -287,7 +287,7 @@ The ExternalDocumentRef contains two properties:
 
 NOTE In RDF, a namespace can be created for the external document reference if a short form name for the external reference is desired.
 
-## 6.7 License list version field <a name="2.7"></a>
+## 6.7 License list version field <a name="6.7"></a>
 
 **Description**
 
@@ -325,7 +325,7 @@ EXAMPLE 2 RDF: Property `licenseListVersion` in class `spdx:CreationInfo`
 </CreationInfo>
 ```
 
-## 6.8 Creator field <a name="2.8"></a>
+## 6.8 Creator field <a name="6.8"></a>
 
 **Description**
 
@@ -367,11 +367,11 @@ EXAMPLE 2 RDF: Property `spdx:creator` in class `spdx:CreationInfo`
 </CreationInfo>
 ```
 
-## 6.9 Created field <a name="2.9"></a>
+## 6.9 Created field <a name="6.9"></a>
 
 **Description**
 
-Identify when the SPDX file was originally created. The date is to be specified according to combined date and time in UTC format as specified in ISO 8601 standard. This field is distinct from the fields in Clause [A](8-annotations.md), which involves the addition of information during a subsequent review.
+Identify when the SPDX file was originally created. The date is to be specified according to combined date and time in UTC format as specified in ISO 8601 standard. This field is distinct from the fields in Clause [12](annotations.md), which involves the addition of information during a subsequent review.
 
 **Intent**
 
@@ -405,7 +405,7 @@ EXAMPLE 2 RDF: Property `spdx:created` in class `spdx:CreationInfo`
 </CreationInfo>
 ```
 
-## 6.10 Creator comment field <a name="2.10"></a>
+## 6.10 Creator comment field <a name="6.10"></a>
 
 **Description**
 
@@ -445,7 +445,7 @@ EXAMPLE 2 RDF: Property `rdfs:comment` in class `spdx:CreationInfo`
 </CreationInfo>
 ```
 
-## 6.11 Document comment field <a name="2.11"></a>
+## 6.11 Document comment field <a name="6.11"></a>
 
 **Description**
 

--- a/chapters/file-information.md
+++ b/chapters/file-information.md
@@ -1,6 +1,6 @@
 # 8 File information fields
 
-## 8.1 File name field <a name="4.1"></a>
+## 8.1 File name field <a name="8.1"></a>
 
 **Description**
 
@@ -39,7 +39,7 @@ EXAMPLE 2 RDF: Property `spdx:fileName` in class `spdx:File`
 </File>
 ```
 
-## 8.2 File SPDX identifier field <a name="4.2"></a>
+## 8.2 File SPDX identifier field <a name="8.2"></a>
 
 **Description**
 
@@ -89,7 +89,7 @@ Using document URI:
 </File>
 ```
 
-## 8.3 File type field <a name="4.3"></a>
+## 8.3 File type field <a name="8.3"></a>
 
 **Description**
 
@@ -162,7 +162,7 @@ Where file2 is a `README.TXT`
 </File>
 ```
 
-## 8.4 File checksum field <a name="4.4"></a>
+## 8.4 File checksum field <a name="8.4"></a>
 
 **Description**
 
@@ -218,7 +218,7 @@ EXAMPLE 2 RDF: Property `spdx:Checksum` in class `spdx:File`
 </File>
 ```
 
-## 8.5 Concluded license field <a name="4.5"></a>
+## 8.5 Concluded license field <a name="8.5"></a>
 
 **Description**
 
@@ -226,7 +226,7 @@ This field contains the license the SPDX file creator has concluded as governing
 
 The options to populate this field are limited to:
 
-A valid SPDX License Expression as defined in Annex [D](appendix-IV-SPDX-license-expressions.md);
+A valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions.md);
 
 `NONE`, if the SPDX file creator concludes there is no license available for this file; or
 
@@ -238,11 +238,11 @@ A valid SPDX License Expression as defined in Annex [D](appendix-IV-SPDX-license
 
 - the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
 
-If the Concluded License is not the same as the License Information in File, a written explanation should be provided in the Comments on License field ([8.7](#4.7)). With respect to `NOASSERTION`, a written explanation in the Comments on License field ([8.7](#4.7)) is preferred.
+If the Concluded License is not the same as the License Information in File, a written explanation should be provided in the Comments on License field ([8.7](#8.7)). With respect to `NOASSERTION`, a written explanation in the Comments on License field ([8.7](#8.7)) is preferred.
 
 **Intent**
 
-Here, the intent is for the SPDX file creator to analyze the License Information in File ([8.6](#4.6)) and other objective information, e.g., “COPYING FILE,” along with the results from any scanning tools, to arrive at a reasonably objective conclusion as to what license governs the file.
+Here, the intent is for the SPDX file creator to analyze the License Information in File ([8.6](#8.6)) and other objective information, e.g., “COPYING FILE,” along with the results from any scanning tools, to arrive at a reasonably objective conclusion as to what license governs the file.
 
 **Metadata**
 
@@ -254,7 +254,7 @@ Table 40 — Metadata for the concluded license field
 | --------- | ----- |
 | Required | Yes |
 | Cardinality | 1..1 |
-| Format | `<SPDX License Expression>` \| `NONE` \| `NOASSERTION`<br>where:<br>`<SPDX License Expression>` is a valid SPDX License Expression as defined in Annex [D](appendix-IV-SPDX-license-expressions.md). |
+| Format | `<SPDX License Expression>` \| `NONE` \| `NOASSERTION`<br>where:<br>`<SPDX License Expression>` is a valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions.md). |
 
 **Examples**
 
@@ -287,7 +287,7 @@ EXAMPLE 2 RDF: Property `spdx:licenseConcluded` in class `spdx:File`
 </File>
 ```
 
-## 8.6 License information in file field <a name="4.6"></a>
+## 8.6 License information in file field <a name="8.6"></a>
 
 **Description**
 
@@ -322,7 +322,7 @@ Table 41 — Metadata for the license information in file field
 | --------- | ----- |
 | Required | Yes |
 | Cardinality | 1..* |
-| Format | `<SPDX License Expression>` \|<br>["DocumentRef-"`[idstring]`":"]"LicenseRef-"`[idstring]` \|<br>\| `NONE` \| `NOASSERTION`<br>where:<br>`<SPDX License Expression>` is a<br>valid SPDX License Expression<br>as defined in Annex [D](appendix-IV-SPDX-license-expressions.md).<br>"DocumentRef-"`[idstring]`: is an optional reference to an external SPDX<br>document as described in [6.6](2-document-creation-information.md#2.6)<br>`[idstring]` is a unique string containing letters, numbers, `.` and/or `-` |
+| Format | `<SPDX License Expression>` \|<br>["DocumentRef-"`[idstring]`":"]"LicenseRef-"`[idstring]` \|<br>\| `NONE` \| `NOASSERTION`<br>where:<br>`<SPDX License Expression>` is a<br>valid SPDX License Expression<br>as defined in Annex [D](SPDX-license-expressions.md).<br>"DocumentRef-"`[idstring]`: is an optional reference to an external SPDX<br>document as described in [6.6](document-creation-information.md#6.6)<br>`[idstring]` is a unique string containing letters, numbers, `.` and/or `-` |
 
 **Examples**
 
@@ -342,7 +342,7 @@ EXAMPLE 2 RDF: Property `spdx:licenseInfoInFile` in class `spdx:File`
 </File>
 ```
 
-## 8.7 Comments on license field <a name="4.7"></a>
+## 8.7 Comments on license field <a name="8.7"></a>
 
 **Description**
 
@@ -387,7 +387,7 @@ EXAMPLE 2 RDF: Property `spdx:licenseComments` in class `spdx:File`
 </File>
 ```
 
-## 8.8 Copyright text field <a name="4.8"></a>
+## 8.8 Copyright text field <a name="8.8"></a>
 
 **Description**
 
@@ -441,7 +441,7 @@ EXAMPLE 2 RDF: Property `spdx:copyrightText` in class `spdx:File`
 </File>
 ```
 
-## 8.9 Artifact of project name field (deprecated) <a name="4.9"></a>
+## 8.9 Artifact of project name field (deprecated) <a name="8.9"></a>
 
 **Description**
 
@@ -485,7 +485,7 @@ EXAMPLE 2 RDF: Property `spdx:artifactOf/doap:Project/doap:name`
 </File>
 ```
 
-## 8.10 Artifact of project homepage field (deprecated) <a name="4.10"></a>
+## 8.10 Artifact of project homepage field (deprecated) <a name="8.10"></a>
 
 **Description**
 
@@ -527,7 +527,7 @@ EXAMPLE 2 RDF: `spdx:artifactOf/doap:Project/doap:homepage`
 </File>
 ```
 
-## 8.11 Artifact of project uniform resource identifier field (deprecated) <a name="4.11"></a>
+## 8.11 Artifact of project uniform resource identifier field (deprecated) <a name="8.11"></a>
 
 **Description**
 
@@ -570,7 +570,7 @@ the value "http://subversion.apache.org/" is the URI of the describes
 resource of type doap:Project -->
 ```
 
-## 8.12 File comment field <a name="4.12"></a>
+## 8.12 File comment field <a name="8.12"></a>
 
 **Description**
 
@@ -614,7 +614,7 @@ EXAMPLE 2 RDF: Property `rdfs:comments` in class `spdx:File`
 </File>
 ```
 
-## 8.13 File notice field <a name="4.13"></a>
+## 8.13 File notice field <a name="8.13"></a>
 
 **Description**
 
@@ -656,7 +656,7 @@ EXAMPLE 2 RDF: Property `noticeText` in class `spdx:File`
 </File>
 ```
 
-## 8.14 File contributor field <a name="4.14"></a>
+## 8.14 File contributor field <a name="8.14"></a>
 
 **Description**
 
@@ -700,7 +700,7 @@ EXAMPLE 2 RDF: Property `spdx:fileContributor` in class `spdx:File`
 </File>
 ```
 
-## 8.15 File attribution text field <a name="4.15"></a>
+## 8.15 File attribution text field <a name="8.15"></a>
 
 **Description**
 
@@ -746,9 +746,9 @@ EXAMPLE 2 RDF: property `spdx:attributionText` in class `spdx:File`
 </File>
 ```
 
-## 8.16 File dependencies field (deprecated) <a name="4.16"></a>
+## 8.16 File dependencies field (deprecated) <a name="8.16"></a>
 
-This field is deprecated since SPDX 2.0 in favor of using Clause [11](7-relationships-between-SPDX-elements.md) which provides more granularity about relationships.
+This field is deprecated since SPDX 2.0 in favor of using Clause [11](relationships-between-SPDX-elements.md) which provides more granularity about relationships.
 
 **Description**
 

--- a/chapters/other-licensing-information-detected.md
+++ b/chapters/other-licensing-information-detected.md
@@ -1,16 +1,10 @@
 # 10 Other licensing information detected fields
 
-This section is used for any detected, declared or concluded licenses that are NOT on the SPDX License List. For the most up-to-date version of the list see: [https://spdx.org/licenses/](https://spdx.org/licenses/). The SPDX License List can also be found here in Annex [A](appendix-I-SPDX-license-list.md).
-
-One instance should be created for every unique license or licensing information reference detected in package that does not match one of the licenses on the SPDX License List. Each license instance should have the following fields.
-
-Fields:
-
-## 10.1 License identifier field <a name="6.1"></a>
+## 10.1 License identifier field <a name="10.1"></a>
 
 **Description**
 
-Provide a locally unique identifier to refer to licenses that are not found on the SPDX License List. This unique identifier can then be used in the packages and files sections of the SPDX file (Clause [7](3-package-information.md) and Clause [8](4-file-information.md), respectively).
+Provide a locally unique identifier to refer to licenses that are not found on the SPDX License List. This unique identifier can then be used in the packages and files sections of the SPDX file (Clause [7](package-information.md) and Clause [8](file-information.md), respectively).
 
 **Intent**
 
@@ -54,7 +48,7 @@ EXAMPLE 2 RDF: Property `spdx:licenseID` in class `spdx:ExtractedLicensingInfo`
 </ExtractedLicensingInfo>
 ```
 
-## 10.2 Extracted text field <a name="6.2"></a>
+## 10.2 Extracted text field <a name="10.2"></a>
 
 **Description**
 
@@ -114,7 +108,7 @@ If indeed full text of license present in File:
 </ExtractedLicensingInfo>
 ```
 
-## 10.3 License name field <a name="6.3"></a>
+## 10.3 License name field <a name="10.3"></a>
 
 **Description**
 
@@ -154,7 +148,7 @@ EXAMPLE 2 RDF: Property `spdx:name` in class `spdx:ExtractedLicensingInfo`
 </ExtractedLicensingInfo>
 ```
 
-## 10.4 License cross reference field <a name="6.4"></a>
+## 10.4 License cross reference field <a name="10.4"></a>
 
 **Description**
 
@@ -192,7 +186,7 @@ EXAMPLE 2 RDF: Property `rdfs:seeAlso` in class `spdx:ExtractedLicensingInfo`
 </ExtractedLicensingInfo>
 ```
 
-## 10.5 License comment field <a name="6.5"></a>
+## 10.5 License comment field <a name="10.5"></a>
 
 **Description**
 

--- a/chapters/package-information.md
+++ b/chapters/package-information.md
@@ -6,8 +6,8 @@ Cardinality: Optional, one or many.
 
 In `tag:value` format, the order in which package and files occur is syntactically significant.
 
-* A new Package Information section is denoted by the [Package Name](#3.1) field.
-* All Package Information fields must be grouped together before the start of a Files section (Clause [8](4-file-information.md)), if file(s) are present.
+* A new Package Information section is denoted by the Package Name ([7.1](#7.1)) field.
+* All Package Information fields must be grouped together before the start of a Files section (Clause [8](file-information.md)), if file(s) are present.
 * All files contained in a package must immediately follow the applicable Package Information.
 * A new Package Information section (via Package Name) denotes the start of another package.
 * Sub-packages should not be nested inside a Package Information section, but should be separate and should use a Relationship to clarify.
@@ -15,11 +15,11 @@ In `tag:value` format, the order in which package and files occur is syntactical
 
 Fields:
 
-## 7.1 Package name field <a name="3.1"></a>
+## 7.1 Package name field <a name="7.1"></a>
 
 **Description**
 
-Identify the full name of the package as given by the [Package Originator](#3.6).
+Identify the full name of the package as given by the Package Originator ([7.6](#7.6)).
 
 **Intent**
 
@@ -53,7 +53,7 @@ EXAMPLE 2 RDF: property `spdx:name` in class `spdx:Package`
 </Package>
 ```
 
-## 7.2 Package SPDX identifier field <a name="3.2"></a>
+## 7.2 Package SPDX identifier field <a name="7.2"></a>
 
 **Description**
 
@@ -89,7 +89,7 @@ EXAMPLE 2 RDF: The URI for the element will follow the form:
 [SPDX DocumentNamespace]#[SPDX Identifier]
 ```
 
-See [6.5](2-document-creation-information.md#2.5) for the definition of the SPDX Document Namespace and [6.3](2-document-creation-information.md#2.3) for the definition of the SPDX Identifier
+See [6.5](document-creation-information.md#6.5) for the definition of the SPDX Document Namespace and [6.3](document-creation-information.md#6.3) for the definition of the SPDX Identifier
 
 Using `xml:base`:
 
@@ -110,7 +110,7 @@ Using document URI:
 </Package>
 ```
 
-## 7.3 Package version field <a name="3.3"></a>
+## 7.3 Package version field <a name="7.3"></a>
 
 **Description**
 
@@ -150,7 +150,7 @@ EXAMPLE 2 RDF: property `spdx:versionInfo` in class `spdx:Package`
 </Package>
 ```
 
-## 7.4 Package file name field <a name="3.4"></a>
+## 7.4 Package file name field <a name="7.4"></a>
 
 **Description**
 
@@ -206,7 +206,7 @@ Sub-directory being treated as a package:
 </Package>
 ```
 
-## 7.5 Package supplier field <a name="3.5"></a>
+## 7.5 Package supplier field <a name="7.5"></a>
 
 **Description**
 
@@ -254,7 +254,7 @@ EXAMPLE 2 RDF: property `spdx:supplier` in class `spdx:Package`
 </Package>
 ```
 
-## 7.6 Package originator field <a name="3.6"></a>
+## 7.6 Package originator field <a name="7.6"></a>
 
 **Description**
 
@@ -300,7 +300,7 @@ EXAMPLE 2 RDF: property `spdx:originator` in class `spdx:Package`
 </Package>
 ```
 
-## 7.7 Package download location field <a name="3.7"></a>
+## 7.7 Package download location field <a name="7.7"></a>
 
 **Description**
 
@@ -615,7 +615,7 @@ EXAMPLE 2 RDF: property `spdx:downloadLocation` in class `spdx:Package`
 </Package>
 ```
 
-## 7.8 Files analyzed field <a name="3.8"></a>
+## 7.8 Files analyzed field <a name="7.8"></a>
 
 **Description**
 
@@ -629,7 +629,7 @@ Some examples:
 
 1. **A bundle of external products**: Package A can be metadata about Packages and their dependencies. It may also be a loosely organized manifest of references to Packages involved in a product or project. Build or execution may transitively discover more Packages and dependencies. All of these referenced Packages can have their own SPDX Documents. In this case, Package A may be defined with its File Analyzed attribute set to `false`. Package A includes External Document References to SPDX documents containing Packages referenced in all the available relationships. The Relationships section then relates the SPDX documents and contained SPDX elements with appropriate semantics per the dependencies in the scope of Package A.
 2. **Package relation to external product**: Package A can have a STATIC_LINK relationship to Package B, but the binary representation of Package B is furnished by the build process and thus not contained in the file list of Package A. In this case, Package B needs to be defined with its Files Analyzed attribute set to false and all the other attributes subject to the subsequently defined constraints. Then, the relationship between Package A and Package B can be documented as described in Clause [11](7-relationships-between-SPDX-elements.md).
-3. **File derived from external product**: Package A contains multiple files derived from an outside project. Rather than use the `artifactOf*` attributes (F.9-4.11) to describe the relation of these files to their project, the outside project can be represented by another package, Package B, whose [`FilesAnalyzed`](#3.8) attribute is set to `false`. Each of the binary files can then have a relationship to package B (Clause 10). This allows the outside project to be represented by a single SPDX identifier (the identifier of Package B). It also allows the relationship(s) between the outside project and each of the files be represented in much more detail.
+3. **File derived from external product**: Package A contains multiple files derived from an outside project. Rather than use the `artifactOf*` attributes (F.9-4.11) to describe the relation of these files to their project, the outside project can be represented by another package, Package B, whose `FilesAnalyzed` ([7.8](#7.8)) attribute is set to `false`. Each of the binary files can then have a relationship to package B (Clause 10). This allows the outside project to be represented by a single SPDX identifier (the identifier of Package B). It also allows the relationship(s) between the outside project and each of the files be represented in much more detail.
 
 **Metadata**
 
@@ -661,7 +661,7 @@ EXAMPLE 2 RDF: property `spdx:filesAnalyzed` in class `spdx:Package`
 </Package>
 ```
 
-## 7.9 Package verification code field <a name="3.9"></a>
+## 7.9 Package verification code field <a name="7.9"></a>
 
 **Description**
 
@@ -680,7 +680,7 @@ Table 21 — Metadata for the package verification code field
 | Attribute | Value |
 | --------- | ----- |
 | Required | Yes |
-| Cardinality | 0..1 if [`FilesAnalyzed`](#3.8) is `true` or omitted, 0..0 (must be omitted) if `FilesAnalyzed` is `false`.|
+| Cardinality | 0..1 if `FilesAnalyzed` ([7.8](#7.8)) is `true` or omitted, 0..0 (must be omitted) if `FilesAnalyzed` is `false`.|
 | Algorithm | <sup>[a](#Algorithm)</sup> |
 | Format | Single line of text with 160 bit binary represented as 40 lowercase hexadecimal digits |
 
@@ -708,7 +708,7 @@ Required sort order: '0','1','2','3','4','5','6','7','8','9','a','b','c','d','e'
 
 EXAMPLE 1 Tag: `PackageVerificationCode:` (and optionally `(excludes: FileName)`)
 
-`FileName` is specified in [8.1](4-file-information.md#4.1).
+`FileName` is specified in [8.1](file-information.md#8.1).
 
 ```text
 PackageVerificationCode: d6a770ba38583ed4bb4525bd96e50461655d2758 (excludes: ./package.spdx)
@@ -731,7 +731,7 @@ EXAMPLE 2 RDF: `spdx:packageVerificationCodeValue`, `spdx:packageVerificationCod
 </Package>
 ```
 
-## 7.10 Package checksum field <a name="3.10"></a>
+## 7.10 Package checksum field <a name="7.10"></a>
 
 **Description**
 
@@ -797,7 +797,7 @@ EXAMPLE 2 RDF: properties `spdx:algorithm`, `spdx:checksumValue` in class `spdx:
 </Package>
 ```
 
-## 7.11 Package home page field <a name="3.11"></a>
+## 7.11 Package home page field <a name="7.11"></a>
 
 **Description**
 
@@ -850,7 +850,7 @@ This specification uses the prefix `doap:` to refer to the [DOAP][doap] namespac
 ```text
 http://usefulinc.com/ns/doap#
 ```
-## 7.12 Source information field <a name="3.12"></a>
+## 7.12 Source information field <a name="7.12"></a>
 
 **Description**
 
@@ -890,7 +890,7 @@ EXAMPLE 2 RDF: `spdx:sourceInfo`
 </Package>
 ```
 
-## 7.13 Concluded license field <a name="3.13"></a>
+## 7.13 Concluded license field <a name="7.13"></a>
 
 **Description**
 
@@ -898,7 +898,7 @@ Contain the license the SPDX file creator has concluded as governing the package
 
 The options to populate this field are limited to:
 
-* A valid SPDX License Expression as defined in Annex [D](appendix-IV-SPDX-license-expressions.md);
+* A valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions.md);
 * `NONE`, if the SPDX file creator concludes there is no license available for this package; or
 * `NOASSERTION` if:
 
@@ -908,7 +908,7 @@ The options to populate this field are limited to:
 
   - the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
 
-If the Concluded License is not the same as the [Declared License](#3.15), a written explanation should be provided in the Comments on License field ([7.16](#3.16)). With respect to `NOASSERTION`, a written explanation in the Comments on License field ([7.16](#3.16)) is preferred.
+If the Concluded License is not the same as the Declared License ([3.15](#3.15)), a written explanation should be provided in the Comments on License field ([7.16](#7.16)). With respect to `NOASSERTION`, a written explanation in the Comments on License field ([7.16](#7.16)) is preferred.
 
 **Intent**
 
@@ -924,7 +924,7 @@ Table 25 — Metadata for the concluded license field
 | --------- | ----- |
 | Required | Yes |
 | Cardinality | 1..1 |
-| Format | `<SPDX License Expression>` \| `NONE` \| `NOASSERTION`<br>where:<br>`<SPDX License Expression>` is a valid SPDX License Expression as defined in Annex [D](appendix-IV-SPDX-license-expressions.md). |
+| Format | `<SPDX License Expression>` \| `NONE` \| `NOASSERTION`<br>where:<br>`<SPDX License Expression>` is a valid SPDX License Expression as defined in Annex [D](IV-SPDX-license-expressions.md). |
 
 **Examples**
 
@@ -961,7 +961,7 @@ EXAMPLE 2 RDF: property `spdx:licenseConcluded` in `class spdx:Package`
 </Package>
 ```
 
-## 7.14 All licenses information from files field <a name="3.14"></a>
+## 7.14 All licenses information from files field <a name="7.14"></a>
 
 **Description**
 
@@ -991,8 +991,8 @@ Table 26 — Metadata for the all licenses information from files field
 | Attribute | Value |
 | --------- | ----- |
 | Required | Yes |
-| Cardinality | 0..* if [`FilesAnalyzed`](#3.8) is `true` or omitted, 0..0 (must be omitted) if `FilesAnalyzed` is `false`. |
-| Format | [`<shortIdentifier>`](appendix-I-SPDX-license-list.md#A.1) \| ["DocumentRef-"`[idstring]`:]"LicenseRef-"`[idstring]` \| `NONE` \| `NOASSERTION`<br>where:<br><ul><li> "DocumentRef-"`[idstring]` is an optional reference to an external SPDX document as described in [6.6](2-document-creation-information.md#2.6).</li><li>`[idstring]` is a unique string containing letters, numbers, `.`, or `-`. </li></ul> |
+| Cardinality | 0..* if `FilesAnalyzed` ([7.8](#7.8)) is `true` or omitted, 0..0 (must be omitted) if `FilesAnalyzed` is `false`. |
+| Format | `<shortIdentifier>` ([Annex A](SPDX-license-list.md#A.1)) \| ["DocumentRef-"`[idstring]`:]"LicenseRef-"`[idstring]` \| `NONE` \| `NOASSERTION`<br>where:<br><ul><li> "DocumentRef-"`[idstring]` is an optional reference to an external SPDX document as described in [6.6](document-creation-information.md#6.6).</li><li>`[idstring]` is a unique string containing letters, numbers, `.`, or `-`. </li></ul> |
 
 **Examples**
 
@@ -1022,7 +1022,7 @@ EXAMPLE 2 RDF: property `spdx:licenseInfoFromFiles` in class `spdx:Package`
 </Package>
 ```
 
-## 7.15 Declared license field <a name="3.15"></a>
+## 7.15 Declared license field <a name="7.15"></a>
 
 **Description**
 
@@ -1030,7 +1030,7 @@ List the licenses that have been declared by the authors of the package. Any lic
 
 The options to populate this field are limited to:
 
-* A valid SPDX License Expression as defined in Annex [D](appendix-IV-SPDX-license-expressions.md);
+* A valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions.md);
 * `NONE`, if the package contains no license information whatsoever; or
 * `NOASSERTION` if:
 
@@ -1040,7 +1040,7 @@ The options to populate this field are limited to:
 
 **Intent**
 
-This is simply the license identified in text in one or more files (for example COPYING file) in the source code package. This field is not intended to capture license information obtained from an external source, such as the package website. Such information can be included in Concluded License ([7.13](#3.13)). This field may have multiple Declared Licenses, if multiple licenses are declared at the package level.
+This is simply the license identified in text in one or more files (for example COPYING file) in the source code package. This field is not intended to capture license information obtained from an external source, such as the package website. Such information can be included in Concluded License ([7.13](#7.13)). This field may have multiple Declared Licenses, if multiple licenses are declared at the package level.
 
 **Metadata**
 
@@ -1052,7 +1052,7 @@ Table 27 — Metadata for the declared license field
 | --------- | ----- |
 | Required | Yes |
 | Cardinality | 1..1 |
-| Format | `<SPDX License Expression>` \| `NONE` \| `NOASSERTION`<br>where:<br><ul><li>`<SPDX License Expression>` is a valid SPDX License Expression as defined in Annex [D](appendix-IV-SPDX-license-expressions.md).</li></ul> |
+| Format | `<SPDX License Expression>` \| `NONE` \| `NOASSERTION`<br>where:<br><ul><li>`<SPDX License Expression>` is a valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions.md).</li></ul> |
 
 **Examples**
 
@@ -1089,7 +1089,7 @@ EXAMPLE 2 RDF: property `spdx:licenseDeclared` in class `spdx:Package`
 </Package>
 ```
 
-## 7.16 Comments on license field <a name="3.16"></a>
+## 7.16 Comments on license field <a name="7.16"></a>
 
 **Description**
 
@@ -1134,7 +1134,7 @@ EXAMPLE 2 RDF: property `spdx:licenseComments` in class `spdx:Package`
 </Package>
 ```
 
-## 7.17 Copyright text field <a name="3.17"></a>
+## 7.17 Copyright text field <a name="7.17"></a>
 
 **Description**
 
@@ -1184,7 +1184,7 @@ EXAMPLE 2 RDF: property `spdx:copyrightText` in class `spdx:Package`
 </Package>
 ```
 
-## 7.18 Package summary description field <a name="3.18"></a>
+## 7.18 Package summary description field <a name="7.18"></a>
 
 **Description**
 
@@ -1226,7 +1226,7 @@ EXAMPLE 2 RDF: property `spdx:summary` in class `spdx:Package`
 </Package>
 ```
 
-## 7.19 Package detailed description field <a name="3.19"></a>
+## 7.19 Package detailed description field <a name="7.19"></a>
 
 **Description**
 
@@ -1274,7 +1274,7 @@ EXAMPLE 2 RDF: property `spdx:description` in class `spdx:Package`
 </Package>
 ```
 
-## 7.20 Package comment field <a name="3.20"></a>
+## 7.20 Package comment field <a name="7.20"></a>
 
 **Description**
 
@@ -1318,7 +1318,7 @@ EXAMPLE 2 RDF: property `rdfs:comment` in class `spdx:Package`
 </Package>
 ```
 
-## 7.21 External reference field <a name="3.21"></a>
+## 7.21 External reference field <a name="7.21"></a>
 
 **Description**
 
@@ -1338,7 +1338,7 @@ Table 33 — Metadata for the external reference field
 | --------- | ----- |
 | Required | No |
 | Cardinality | 1..* |
-| Format | `<category> <type> <locator>`<br>where:<ul><li>`<category>` is `SECURITY` \| `PACKAGE-MANAGER` \| `PERSISTENT-ID` \| `OTHER`</li><li>`<type>` is one of the types listed in Annex [F](appendix-VI-external-repository-identifiers.md).</li><li>`<locator>` is the unique string with no spaces necessary to access the package-specific information, metadata, or content within the target location. The format of the locator is subject to constraints defined by the `<type>`.</li></ul> |
+| Format | `<category> <type> <locator>`<br>where:<ul><li>`<category>` is `SECURITY` \| `PACKAGE-MANAGER` \| `PERSISTENT-ID` \| `OTHER`</li><li>`<type>` is one of the types listed in Annex [F](external-repository-identifiers.md).</li><li>`<locator>` is the unique string with no spaces necessary to access the package-specific information, metadata, or content within the target location. The format of the locator is subject to constraints defined by the `<type>`.</li></ul> |
 
 **Examples**
 
@@ -1390,9 +1390,9 @@ For an unlisted location:
 </spdx:package>
 ```
 
-The referenceType value for a non-listed location consists of the SPDX document namespace (see [6.5](2-document-creation-information.md#2.5)) followed by a `#` and the category as defined in [7.21.4](#3.21).
+The referenceType value for a non-listed location consists of the SPDX document namespace (see [6.5](2-document-creation-information.md#2.5)) followed by a `#` and the category as defined in [7.21](#7.21).
 
-## 7.22 External reference comment field <a name="3.22"></a>
+## 7.22 External reference comment field <a name="7.22"></a>
 
 **Description**
 
@@ -1411,8 +1411,8 @@ Table 34 — Metadata for the external reference comment field
 | Attribute | Value |
 | --------- | ----- |
 | Required | No |
-| Cardinality | 0..1 for each [External Reference](#3.21) |
-| Format | Free form text that can span multiple lines.<br><br>In `tag:value` format this is delimited by `<text>...</text>` and is expected to follow an [External Reference](#3.21) so that the association can be made. |
+| Cardinality | 0..1 for each External Reference ([3.21](#3.21)) |
+| Format | Free form text that can span multiple lines.<br><br>In `tag:value` format this is delimited by `<text>...</text>` and is expected to follow an External Reference ([3.21](#3.21)) so that the association can be made. |
 
 **Examples**
 
@@ -1445,7 +1445,7 @@ EXAMPLE 2 RDF: Property `rdfs:comment` in class `spdx:ExternalRef`
 </spdx:package>
 ```
 
-## 7.23 Package attribution text field <a name="3.23"></a>
+## 7.23 Package attribution text field <a name="7.23"></a>
 
 **Description**
 

--- a/chapters/relationships-between-SPDX-elements.md
+++ b/chapters/relationships-between-SPDX-elements.md
@@ -1,6 +1,6 @@
 # 11 Relationships between SPDX elements fields
 
-## 11.1 Relationship field <a name="7.1"></a>
+## 11.1 Relationship field <a name="11.1"></a>
 
 **Description**
 
@@ -76,7 +76,7 @@ Table 69 — Metadata for the relationship field
 | --------- | ----- |
 | Required | No |
 | Cardinality | 0..* see `DESCRIBES` relationship for one mandatory case. |
-| Format | ["DocumentRef-"[idstring]":"]SPDXID \<relationship\> ["DocumentRef-"[idstring]":"]SPDXID \| \`NONE\` \| \`NOASSERTION\`<br>where "DocumentRef-"`[idstring]`":" is an optional reference to an external SPDX document as described in [6.6](2-document-creation-information.md#2.6)<br>where `SPDXID` is a string containing letters, numbers, `.` and/or `-`. as described in [6.3](2-document-creation-information.md#2.3), [7.2](3-package-information.md#3.2), [7.2](4-file-information.md#4.2).<br>where `<relationship>` is one of the documented relationship types in table 7.1.1.<br>where `NONE` can be used to explicitly indicate there are NO other relationships.<br>where `NOASSERTION` can be used to explicitly indicate it is not clear if there are relationships that may apply or not. |
+| Format | ["DocumentRef-"[idstring]":"]SPDXID \<relationship\> ["DocumentRef-"[idstring]":"]SPDXID \| \`NONE\` \| \`NOASSERTION\`<br>where "DocumentRef-"`[idstring]`":" is an optional reference to an external SPDX document as described in [6.6](document-creation-information.md#6.6)<br>where `SPDXID` is a string containing letters, numbers, `.` and/or `-`. as described in [6.3](document-creation-information.md#6.3), [7.2](package-information.md#7.2), [8.2](file-information.md#8.2).<br>where `<relationship>` is one of the documented relationship types in Table 68.<br>where `NONE` can be used to explicitly indicate there are NO other relationships.<br>where `NOASSERTION` can be used to explicitly indicate it is not clear if there are relationships that may apply or not. |
 
 **Examples**
 
@@ -133,7 +133,7 @@ EXAMPLE 2 RDF: Property `spdx:relationship` in any `spdx:SpdxDocument`, `spdx:Pa
 </SpdxElement>
 ```
 
-## 11.2 Relationship comment field <a name="7.2"></a>
+## 11.2 Relationship comment field <a name="11.2"></a>
 
 **Description**
 

--- a/chapters/review-information-deprecated.md
+++ b/chapters/review-information-deprecated.md
@@ -1,12 +1,6 @@
 # 13 Review information fields (deprecated)
 
-The review information section is included for compatibility with SPDX 1.2, and is deprecated since SPDX 2.0. Any review information should use an Annotation (as described in Clause [12](./8-annotations.md)) with an annotation type of `REVIEW`.
-
-Review information can be added after the initial SPDX file has been created. The set of fields are optional and multiple instances can be added. Once a Reviewer entry is added, the Review Date associated with the review is mandatory. The Created date should not be modified as a result of the addition of information regarding the conduct of a review. A Review Comments is optional.
-
-Fields:
-
-## 13.1 Reviewer field (deprecated) <a name="9.1"></a>
+## 13.1 Reviewer field (deprecated) <a name="13.1"></a>
 
 This field has been deprecated since SPDX 2.0.
 
@@ -46,7 +40,7 @@ EXAMPLE 2 RDF: Property `spdx:reviewer` in class `spdx:Review`
 </Review>
 ```
 
-## 13.2 Review date field (deprecated) <a name="9.2"></a>
+## 13.2 Review date field (deprecated) <a name="13.2"></a>
 
 This field has been deprecated since SPDX 2.0.
 
@@ -86,7 +80,7 @@ EXAMPLE 2 RDF: Property `spdx:reviewDate` in class `spdx:Review`
 </Review>
 ```
 
-## 13.3 Review comment field (deprecated) <a name="9.3"></a>
+## 13.3 Review comment field (deprecated) <a name="13.3"></a>
 
 This field is deprecated since SPDX 2.0.
 

--- a/chapters/snippet-information.md
+++ b/chapters/snippet-information.md
@@ -1,6 +1,6 @@
 # 9 Snippet information fields
 
-## 9.1 Snippet SPDX identifier field <a name="5.1"></a>
+## 9.1 Snippet SPDX identifier field <a name="9.1"></a>
 
 **Description**
 
@@ -52,7 +52,7 @@ Using document URI:
 </Snippet>
 ```
 
-## 9.2 Snippet from file SPDX identifier field <a name="5.2"></a>
+## 9.2 Snippet from file SPDX identifier field <a name="9.2"></a>
 
 **Description**
 
@@ -72,7 +72,7 @@ Table 53 — Metadata for the snippet from file SPDX identifier field
 | --------- | ----- |
 | Required | Yes |
 | Cardinality | 1..1 |
-| Format | ["DocumentRef-"[idstring]":"] SPDXID<br>where `DocumentRef-[idstring]`: is an optional reference to an external SPDX document as described in [D.6](2-document-creation-information.md#2.6)<br>where `SPDXID` is a string containing letters, numbers, `.` and/or `-`. as described in (D.3, P.2, F.2). |
+| Format | ["DocumentRef-"[idstring]":"] SPDXID<br>where `DocumentRef-[idstring]`: is an optional reference to an external SPDX document as described in [6.6](document-creation-information.md#6.6)<br>where `SPDXID` is a string containing letters, numbers, `.` and/or `-`. as described in (6.3, 7.2, 8.2). |
 
 **Examples**
 
@@ -110,11 +110,11 @@ Snippet from a File in an External SPDX Doc:
 </Snippet>
 ```
 
-## 9.3 Snippet byte range field <a name="5.3"></a>
+## 9.3 Snippet byte range field <a name="9.3"></a>
 
 **Description**
 
-This field defines the byte range in the original host file (in [9.2](#5.2)) that the snippet information applies to.
+This field defines the byte range in the original host file (in [9.2](#9.2)) that the snippet information applies to.
 
 **Intent**
 
@@ -178,11 +178,11 @@ This specification uses the prefix `ptr:` to refer to the [W3C Pointers][pointer
 xmlns:ptr=http://www.w3.org/2009/pointers#
 ```
 
-## 9.4 Snippet line range field <a name="5.4"></a>
+## 9.4 Snippet line range field <a name="9.4"></a>
 
 **Description**
 
-This optional field defines the line range in the original host file (see [9.2](#5.2)) that the snippet information applies to. If there is a disagreement between the byte range and line range, the byte range values will take precedence.
+This optional field defines the line range in the original host file (see [9.2](#9.2)) that the snippet information applies to. If there is a disagreement between the byte range and line range, the byte range values will take precedence.
 
 **Intent**
 
@@ -239,13 +239,13 @@ Supported classes from the pointer method vocabulary are `StartEndPointer` and `
 </Snippet>
 ```
 
-## 9.5 Snippet concluded license field <a name="5.5"></a>
+## 9.5 Snippet concluded license field <a name="9.5"></a>
 
 **Description**
 
 This field contains the license the SPDX file creator has concluded as governing the snippet or alternative values if the governing license cannot be determined. The options to populate this field are limited to:
 
-A valid SPDX License Expression as defined in Annex [D](appendix-IV-SPDX-license-expressions.md).
+A valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions.md).
 
 `NONE` should be used if there is no licensing information from which to conclude a license for the snippet.
 
@@ -259,7 +259,7 @@ A valid SPDX License Expression as defined in Annex [D](appendix-IV-SPDX-license
 
 - the SPDX document creator has intentionally provided no information (no meaning should be implied by doing so).
 
-If the Concluded License is not the same as the License Information in File, a written explanation should be provided in the Comments on License field (see [9.7](#5.7)). With respect to `NOASSERTION`, a written explanation in the Comments on License field (see [9.7](#5.7)) is preferred.
+If the Concluded License is not the same as the License Information in File, a written explanation should be provided in the Comments on License field (see [9.7](#9.7)). With respect to `NOASSERTION`, a written explanation in the Comments on License field (see [9.7](#9.7)) is preferred.
 
 **Intent**
 
@@ -310,7 +310,7 @@ EXAMPLE 2 RDF: Property `spdx:licenseConcluded` in class `spdx:Snippet`
 </Snippet>
 ```
 
-## 9.6 License information in snippet field <a name="5.6"></a>
+## 9.6 License information in snippet field <a name="9.6"></a>
 
 **Description**
 
@@ -345,7 +345,7 @@ Table 57 — Metadata for the license information in snippet field
 | --------- | ----- |
 | Required | No |
 | Cardinality | 0..* |
-| Format | `<SPDX License Expression>` \|<br>["DocumentRef-"`[idstring]`:"]"LicenseRef-"[idstring] \|<br>\| `NONE` \| `NOASSERTION`<br>where:<br>`<SPDX License Expression>` is a valid SPDX License Expression<br>as defined in Annex [D](appendix-IV-SPDX-license-expressions.md).<br>DocumentRef-"`[idstring]`: is an optional reference to an external SPDX<br>document as described in [6.6](2-document-creation-information.md#2.6)<br>`[idstring]` is a unique string containing letters, numbers, `.` and/or `-`. |
+| Format | `<SPDX License Expression>` \|<br>["DocumentRef-"`[idstring]`:"]"LicenseRef-"[idstring] \|<br>\| `NONE` \| `NOASSERTION`<br>where:<br>`<SPDX License Expression>` is a valid SPDX License Expression<br>as defined in Annex [D](SPDX-license-expressions.md).<br>DocumentRef-"`[idstring]`: is an optional reference to an external SPDX<br>document as described in [6.6](document-creation-information.md#6.6)<br>`[idstring]` is a unique string containing letters, numbers, `.` and/or `-`. |
 
 **Examples**
 
@@ -368,7 +368,7 @@ EXAMPLE 2 RDF: Property `spdx:licenseInfoInSnippet` in class `spdx:Snippet`
 </Snippet>
 ```
 
-## 9.7 Snippet comments on license field <a name="5.7"></a>
+## 9.7 Snippet comments on license field <a name="9.7"></a>
 
 **Description**
 
@@ -415,7 +415,7 @@ EXAMPLE 2 RDF: Property `spdx:licenseComments` in class `spdx:Snippet`
 </Snippet>
 ```
 
-## 9.8 Snippet copyright text field <a name="5.8"></a>
+## 9.8 Snippet copyright text field <a name="9.8"></a>
 
 **Description**
 
@@ -465,7 +465,7 @@ EXAMPLE 2 RDF: Property `spdx:copyrightText` in class `spdx:Snippet`
 </Snippet>
 ```
 
-## 9.9 Snippet comment field <a name="5.9"></a>
+## 9.9 Snippet comment field <a name="9.9"></a>
 
 **Description**
 
@@ -512,7 +512,7 @@ EXAMPLE 2 RDF: Property `rdfs:comment` in class `spdx:Snippet`
 </Snippet>
 ```
 
-## 9.10 Snippet name field <a name="5.10"></a>
+## 9.10 Snippet name field <a name="9.10"></a>
 
 **Description**
 
@@ -550,7 +550,7 @@ EXAMPLE 2 RDF: Property `spdx:name` in class `spdx:Snippet`
 </Snippet>
 ```
 
-## 9.11 Snippet attribution text field <a name="5.11"></a>
+## 9.11 Snippet attribution text field <a name="9.11"></a>
 
 **Description**
 


### PR DESCRIPTION
Updated the header anchors and all links to reflect the change in clause/annex renumbering, as well as the removal of numeric prefixes from all md filenames.

I also cleaned up a few others nits as I noticed them. (removed hanging paras from 2 clauses, that had already been moved to the new "Composition" clause)
