### PR TITLE
Reorder document-creation-information

### DIFF
--- a/chapters/document-creation-information.md
+++ b/chapters/document-creation-information.md
@@ -2,17 +2,9 @@
 
 ## 6.1 SPDX version field <a name="6.1"></a>
 
-**Description**
+### 6.1.1 Description
 
-Provide a reference number that can be used to understand how to parse and interpret the rest of the file. It will enable both future changes to the specification and to support backward compatibility. The version number consists of a major and minor version indicator. The major field shall be incremented when incompatible changes between versions are made (one or more sections are created, modified or deleted). The minor field shall be incremented when backwards compatible changes are made.
-
-**Intent**
-
-Here, parties exchanging information in accordance with the SPDX specification need to provide 100% transparency as to which SPDX specification version such information is conforming to.
-
-**Metadata**
-
-The metadata for the SPDX version field is shown in Table 2.
+Provide a reference number that can be used to understand how to parse and interpret the rest of the file. It will enable both future changes to the specification and to support backward compatibility. The version number consists of a major and minor version indicator. The major field shall be incremented when incompatible changes between versions are made (one or more sections are created, modified or deleted). The minor field shall be incremented when backwards compatible changes are made. The metadata for the SPDX version field is shown in Table 2.
 
 Table 2 — Metadata for the SPDX version field
 
@@ -20,9 +12,15 @@ Table 2 — Metadata for the SPDX version field
 | --------- | ----- |
 | Required | Yes |
 | Cardinality | 1..1 |
-| Format | `SPDX-M.N` where:<br>* `M` is major version number<br>* `N` is minor version number. |
+| Format | `SPDX-M.N` where:<br><ul><li>`M` is major version number</li><li>N` is minor version number.</li></ul> |
 
-**Examples**
+<br>
+
+### 6.1.2 Intent
+
+Here, parties exchanging information in accordance with the SPDX specification need to provide 100% transparency as to which SPDX specification version such information is conforming to.
+
+### 6.1.3 Examples
 
 EXAMPLE 1 Tag: `SPDXVersion:`
 
@@ -46,19 +44,11 @@ http://www.w3.org/1999/02/22-rdf-syntax-ns#
 
 ## 6.2 Data license field <a name="6.2"></a>
 
-**Description**
+### 6.2.1 Description
 
 Compliance with this document includes populating the SPDX fields therein with data related to such fields ("SPDX-Metadata"). This document contains numerous fields where an SPDX document creator may provide relevant explanatory text in SPDX-Metadata.
 Without opining on the lawfulness of "database rights" (in jurisdictions where applicable), such explanatory text is copyrightable subject matter in most Berne Convention countries.
-By using this document, or any portion hereof, you hereby agree that any copyright rights (as determined by your jurisdiction) in any SPDX-Metadata, including without limitation explanatory text, shall be subject to the terms of the Creative Commons CC0 1.0 Universal license.  For SPDX-Metadata not containing any copyright rights, you hereby agree and acknowledge that the SPDX-Metadata is provided to you "as-is" and without any representations or warranties of any kind concerning the SPDX-Metadata, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non-infringement, or the absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law.
-
-**Intent**
-
-This is to alleviate any concern that content (the data or database) in an SPDX file is subject to any form of intellectual property right that could restrict the re-use of the information or the creation of another SPDX file for the same project(s). This approach avoids intellectual property and related restrictions over the SPDX file, however individuals can still contract with each other to restrict release of specific collections of SPDX files (which map to software bill of materials) and the identification of the supplier of SPDX files.
-
-**Metadata**
-
-The metadata for the data license field is shown in Table 3.
+By using this document, or any portion hereof, you hereby agree that any copyright rights (as determined by your jurisdiction) in any SPDX-Metadata, including without limitation explanatory text, shall be subject to the terms of the Creative Commons CC0 1.0 Universal license.  For SPDX-Metadata not containing any copyright rights, you hereby agree and acknowledge that the SPDX-Metadata is provided to you "as-is" and without any representations or warranties of any kind concerning the SPDX-Metadata, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non-infringement, or the absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law. The metadata for the data license field is shown in Table 3.
 
 Table 3 — Metadata for the data license field
 
@@ -68,7 +58,13 @@ Table 3 — Metadata for the data license field
 | Cardinality | 1..1 |
 | Format | `CC0-1.0` |
 
-**Examples**
+<br>
+
+### 6.2.2 Intent
+
+This is to alleviate any concern that content (the data or database) in an SPDX file is subject to any form of intellectual property right that could restrict the re-use of the information or the creation of another SPDX file for the same project(s). This approach avoids intellectual property and related restrictions over the SPDX file, however individuals can still contract with each other to restrict release of specific collections of SPDX files (which map to software bill of materials) and the identification of the supplier of SPDX files.
+
+### 6.2.3 Examples
 
 EXAMPLE 1 Tag: `DataLicense:`
 
@@ -86,17 +82,9 @@ EXAMPLE 2 RDF: `spdx:dataLicense`
 
 ## 6.3 SPDX identifier field <a name="6.3"></a>
 
-**Description**
+### 6.3.1 Description
 
-Identify the current SPDX document which may be referenced in relationships by other files, packages internally and documents externally. To reference another SPDX document in total, this identifier should be used with the external document identifier preceding it. See [Clause 11](relationships-between-SPDX-elements.md) for examples.
-
-**Intent**
-
-Provide a way for the document to refer to itself in relationship to other elements.
-
-**Metadata**
-
-The metadata for the SPDX identifier field is shown in Table 4.
+Identify the current SPDX document which may be referenced in relationships by other files, packages internally and documents externally. To reference another SPDX document in total, this identifier should be used with the external document identifier preceding it. See [Clause 11](relationships-between-SPDX-elements.md) for examples. The metadata for the SPDX identifier field is shown in Table 4.
 
 Table 4 — Metadata for SPDX identifier field
 
@@ -106,7 +94,13 @@ Table 4 — Metadata for SPDX identifier field
 | Cardinality | 1..1 |
 | Format | `SPDXRef-DOCUMENT` |
 
-**Examples**
+<br>
+
+### 6.3.2 Intent
+
+Provide a way for the document to refer to itself in relationship to other elements.
+
+### 6.3.3 Examples
 
 EXAMPLE 1 Tag: `SPDXID:`
 
@@ -129,17 +123,9 @@ The URI for the document is the document namespace appended by
 
 ## 6.4 Document name field <a name="6.4"></a>
 
-**Description**
+### 6.4.1 Description
 
-Identify name of this document as designated by creator.
-
-**Intent**
-
-Here, the name of each document is an important convention and easier to refer to than the URI.
-
-**Metadata**
-
-The metadata for the document name field is shown in Table 5.
+Identify name of this document as designated by creator. The metadata for the document name field is shown in Table 5.
 
 Table 5 — Metadata for the document name field
 
@@ -149,7 +135,13 @@ Table 5 — Metadata for the document name field
 | Cardinality | 1..1 |
 | Format | Single line of text. |
 
-**Examples**
+<br>
+
+### 6.4.2 Intent
+
+Here, the name of each document is an important convention and easier to refer to than the URI.
+
+### 6.4.3 Examples
 
 EXAMPLE 1 Tag: `DocumentName:`
 
@@ -177,13 +169,23 @@ EXAMPLE 2 RDF: Property `spdx:name` in class `spdx:SpdxDocument`
 
 ## 6.5 SPDX document namespace field <a name="6.5"></a>
 
-**Description**
+### 6.5.1 Description
 
 Provide an SPDX document-specific namespace as a unique absolute [Uniform Resource Identifier][URI] (URI) as specified in [RFC-3986][rfc3986], with the exception of the ‘#’ delimiter. The SPDX Document URI shall not contain a URI "part" (e.g. the "#" character), since the ‘#’ is used in SPDX element URIs (packages, files, snippets, etc) to separate the document namespace from the element’s SPDX identifier. Additionally, a scheme (e.g. “https:”) is required.
 
-The URI shall be unique for the SPDX document including the specific version of the SPDX document. If the SPDX document is updated, thereby creating a new version, a new URI for the updated document shall be used. There may only be one URI for an SPDX document and only one SPDX document for a given URI.
+The URI shall be unique for the SPDX document including the specific version of the SPDX document. If the SPDX document is updated, thereby creating a new version, a new URI for the updated document shall be used. There may only be one URI for an SPDX document and only one SPDX document for a given URI. The metadata for the SPDX document namespace field is shown in Table 6.
 
-**Intent**
+Table 6 — Metadata for the SPDX document namespace field
+
+| Attribute | Value |
+| --------- | ----- |
+| Required | Yes |
+| Cardinality | 1..1 |
+| Format | Unique absolute Uniform Resource Identifier (URI) as specified in [RFC-3986](https://tools.ietf.org/html/rfc3986), with the following exceptions:<br><br>The SPDX Document URI cannot contain a URI "part" (e.g. the `#` delimiter), since the `#` is used to uniquely identify SPDX element identifiers. The URI must contain a scheme (e.g. `https:`).<br><br>The URI must be unique for the SPDX document including the specific version of the SPDX document. If the SPDX document is updated, thereby creating a new version, a new URI for the updated document must be used. There can only be one URI for an SPDX document and only one SPDX document for a given URI. |
+
+<br>
+
+### 6.5.2 Intent
 
 The URI provides an unambiguous mechanism for other SPDX documents to reference SPDX elements within this SPDX document. See [6.6](#6.6) for a description on how external documents are referenced. Although it is not required, the URI can be constructed in a way which provides information on how the SPDX document can be found. For example, the URI can be a URL referencing the SPDX document itself, if it is available on the internet. A best practice for creating the URI for SPDX documents available on the public internet is `http://[CreatorWebsite]/[pathToSpdx]/[DocumentName]-[UUID]` where:
 
@@ -199,19 +201,7 @@ NOTE The URI does not have to be accessible. It is only intended to provide a un
 [rfc3986]: https://tools.ietf.org/html/rfc3986
 [uuid-gen]: https://www.uuidgenerator.net/
 
-**Metadata**
-
-The metadata for the SPDX document namespace field is shown in Table 6.
-
-Table 6 — Metadata for the SPDX document namespace field
-
-| Attribute | Value |
-| --------- | ----- |
-| Required | Yes |
-| Cardinality | 1..1 |
-| Format | Unique absolute Uniform Resource Identifier (URI) as specified in [RFC-3986](https://tools.ietf.org/html/rfc3986), with the following exceptions:<br><br>The SPDX Document URI cannot contain a URI "part" (e.g. the `#` delimiter), since the `#` is used to uniquely identify SPDX element identifiers. The URI must contain a scheme (e.g. `https:`).<br><br>The URI must be unique for the SPDX document including the specific version of the SPDX document. If the SPDX document is updated, thereby creating a new version, a new URI for the updated document must be used. There can only be one URI for an SPDX document and only one SPDX document for a given URI. |
-
-**Examples**
+### 6.5.3 Examples
 
 EXAMPLE 1 Tag: `DocumentNamespace:`
 
@@ -235,17 +225,9 @@ http://www.w3.org/2000/01/rdf-schema#
 
 ## 6.6 External document references field <a name="6.6"></a>
 
-**Description**
+### 6.6.1 Description
 
-Identify any external SPDX documents referenced within this SPDX document.
-
-**Intent**
-
-SPDX elements within this document may be related to other SPDX elements referenced from external SPDX documents. An SPDX element could be a snippet, file, package, license reference or SPDX document.
-
-**Metadata**
-
-The metadata for the external document references field is shown in Table 7.
+Identify any external SPDX documents referenced within this SPDX document. The metadata for the external document references field is shown in Table 7.
 
 Table 7 — Metadata for the external document references field
 
@@ -255,7 +237,13 @@ Table 7 — Metadata for the external document references field
 | Cardinality | 1..* |
 | Format | DocumentRef-`[idstring]` `[SPDX Document URI]` `[Checksum]`<br>where<br>`[idstring]` is a unique string containing letters, numbers, `.`, `-` and/or `+`.<br>`[SPDX Document URI]` is the unique ID for the external document as defined in [6.5](#6.5) of that referenced document,<br> `[Checksum]` is a checksum of the external document following the checksum format defined in [8.4](file-information#8.4). |
 
-**Examples**
+<br>
+
+### 6.6.2 Intent
+
+SPDX elements within this document may be related to other SPDX elements referenced from external SPDX documents. An SPDX element could be a snippet, file, package, license reference or SPDX document.
+
+###6.6.3 Examples
 
 EXAMPLE 1 Tag: `ExternalDocumentRef:`
 
@@ -289,17 +277,9 @@ NOTE In RDF, a namespace can be created for the external document reference if a
 
 ## 6.7 License list version field <a name="6.7"></a>
 
-**Description**
+### 6.7.1 Description
 
-An optional field for creators of the SPDX file to provide the version of the SPDX License List used when the SPDX file was created.
-
-**Intent**
-
-Recognizing that licenses are added to the SPDX License List with each subsequent version, the intent is to provide recipients of the SPDX file with the version of the SPDX License List used. This anticipates that in the future, an SPDX file might have used a version of the SPDX License List that is older than the then current one.
-
-**Metadata**
-
-The metadata for the license list version field is shown in Table 8.
+An optional field for creators of the SPDX file to provide the version of the SPDX License List used when the SPDX file was created. The metadata for the license list version field is shown in Table 8.
 
 Table 8 — Metadata for the license list version field
 
@@ -309,7 +289,13 @@ Table 8 — Metadata for the license list version field
 | Cardinality | 1..1 |
 | Format | `M.N`<br>where:<br>`M` is major version number<br>`N` is minor version number. |
 
-**Examples**
+<br>
+
+### 6.7.2 Intent
+
+Recognizing that licenses are added to the SPDX License List with each subsequent version, the intent is to provide recipients of the SPDX file with the version of the SPDX License List used. This anticipates that in the future, an SPDX file might have used a version of the SPDX License List that is older than the then current one.
+
+### 6.7.3 Examples
 
 EXAMPLE 1 Tag: `LicenseListVersion:`
 
@@ -327,17 +313,9 @@ EXAMPLE 2 RDF: Property `licenseListVersion` in class `spdx:CreationInfo`
 
 ## 6.8 Creator field <a name="6.8"></a>
 
-**Description**
+### 6.8.1 Description
 
-Identify who (or what, in the case of a tool) created the SPDX file. If the SPDX file was created by an individual, indicate the person's name. If the SPDX file was created on behalf of a company or organization, indicate the entity name. If the SPDX file was created using a software tool, indicate the name and version for that tool. If multiple participants or tools were involved, use multiple instances of this field. Person name or organization name may be designated as “anonymous” if appropriate.
-
-**Intent**
-
-Here, the generation method will assist the recipient of the SPDX file in assessing the general reliability/accuracy of the analysis information.
-
-**Metadata**
-
-The metadata for the creator field is shown in Table 9.
+Identify who (or what, in the case of a tool) created the SPDX file. If the SPDX file was created by an individual, indicate the person's name. If the SPDX file was created on behalf of a company or organization, indicate the entity name. If the SPDX file was created using a software tool, indicate the name and version for that tool. If multiple participants or tools were involved, use multiple instances of this field. Person name or organization name may be designated as “anonymous” if appropriate. The metadata for the creator field is shown in Table 9.
 
 Table 9 — Metadata for the creator field
 
@@ -347,7 +325,13 @@ Table 9 — Metadata for the creator field
 | Cardinality | 1..* |
 | Format | Single line of text with the following keywords:<br>`"Person: person name" and optional "(email)"`<br>`"Organization: organization" and optional "(email)"`<br>`"Tool: toolidentifier-version"` |
 
-**Examples**
+<br>
+
+### 6.8.2 Intent
+
+Here, the generation method will assist the recipient of the SPDX file in assessing the general reliability/accuracy of the analysis information.
+
+### 6.8.3 Examples
 
 EXAMPLE 1 Tag: `Creator:`
 
@@ -369,17 +353,9 @@ EXAMPLE 2 RDF: Property `spdx:creator` in class `spdx:CreationInfo`
 
 ## 6.9 Created field <a name="6.9"></a>
 
-**Description**
+### 6.9.1 Description
 
-Identify when the SPDX file was originally created. The date is to be specified according to combined date and time in UTC format as specified in ISO 8601 standard. This field is distinct from the fields in Clause [12](annotations.md), which involves the addition of information during a subsequent review.
-
-**Intent**
-
-Here, the time stamp can serve as an indication as to whether the analysis needs to be updated.
-
-**Metadata**
-
-The metadata for the created field is shown in Table 10.
+Identify when the SPDX file was originally created. The date is to be specified according to combined date and time in UTC format as specified in ISO 8601 standard. This field is distinct from the fields in Clause [12](annotations.md), which involves the addition of information during a subsequent review. The metadata for the created field is shown in Table 10.
 
 Table 10 — Metadata for the created field
 
@@ -387,9 +363,15 @@ Table 10 — Metadata for the created field
 | --------- | ----- |
 | Required | Yes |
 | Cardinality | 1..1 |
-| Format | `YYYY-MM-DDThh:mm:ssZ`<br>where:<br>* `YYYY` is year<br>* `MM` is month with leading zero<br>* `DD` is day with leading zero<br>* `T` is delimiter for time<br>* `hh` is hours with leading zero in 24 hour time<br>* `mm` is minutes with leading zero<br>* `ss` is seconds with leading zero<br>* `Z` is universal time indicator |
+| Format | `YYYY-MM-DDThh:mm:ssZ`<br>where:<br><ul><li>`YYYY` is year</li><li>`MM` is month with leading zero</li><li>`DD` is day with leading zero</li><li>`T` is delimiter for time</li><li>`hh` is hours with leading zero in 24 hour time</li><li>`mm` is minutes with leading zero</li><li>`ss` is seconds with leading zero</li><li>`Z` is universal time indicator</li></ul> |
 
-**Examples**
+<br>
+
+### 6.9.2 Intent
+
+Here, the time stamp can serve as an indication as to whether the analysis needs to be updated.
+
+### 6.9.3 Examples
 
 EXAMPLE 1 Tag: `Created:`
 
@@ -407,17 +389,9 @@ EXAMPLE 2 RDF: Property `spdx:created` in class `spdx:CreationInfo`
 
 ## 6.10 Creator comment field <a name="6.10"></a>
 
-**Description**
+### 6.10.1 Description
 
-An optional field for creators of the SPDX file to provide general comments about the creation of the SPDX file or any other relevant comment not included in the other fields.
-
-**Intent**
-
-Here, the intent is to provide recipients of the SPDX file with comments by the creator of the SPDX file.
-
-**Metadata**
-
-The metadata for the Creator comment field is shown in Table 11.
+An optional field for creators of the SPDX file to provide general comments about the creation of the SPDX file or any other relevant comment not included in the other fields. The metadata for the Creator comment field is shown in Table 11.
 
 Table 11 — Metadata for the Creator comment field
 
@@ -427,7 +401,13 @@ Table 11 — Metadata for the Creator comment field
 | Cardinality | 1..1 |
 | Format | Free form text that can span multiple lines.<br>In `tag:value` format this is delimited by `<text> .. </text>`, in RDF, it is delimited by `<rdfs:comment>`. |
 
-**Examples**
+<br>
+
+### 6.10.2 Intent
+
+Here, the intent is to provide recipients of the SPDX file with comments by the creator of the SPDX file.
+
+### 6.10.3 Examples
 
 EXAMPLE 1 Tag: `CreatorComment:`
 
@@ -447,17 +427,9 @@ EXAMPLE 2 RDF: Property `rdfs:comment` in class `spdx:CreationInfo`
 
 ## 6.11 Document comment field <a name="6.11"></a>
 
-**Description**
+### 6.11.1 Description
 
-An optional field for creators of the SPDX file content to provide comments to the consumers of the SPDX document.
-
-**Intent**
-
-Here, the intent is to provide readers/reviewers with comments by the creator of the SPDX file about the SPDX document.
-
-**Metadata**
-
-The metadata for the document comment field is shown in Table 12.
+An optional field for creators of the SPDX file content to provide comments to the consumers of the SPDX document. The metadata for the document comment field is shown in Table 12.
 
 Table 12 — Metadata for the document comment field
 
@@ -467,7 +439,13 @@ Table 12 — Metadata for the document comment field
 | Cardinality | 1..1 |
 | Format | Free form text that can span multiple lines. In `tag:value` format this is delimited by `<text> .. </text>`, in RDF, it is delimited by `<rdfs:comment>`. |
 
-**Examples**
+<br>
+
+### 6.11.2 Intent
+
+Here, the intent is to provide readers/reviewers with comments by the creator of the SPDX file about the SPDX document.
+
+### 6.11.3 Examples
 
 EXAMPLE 1 Tag: `DocumentComment:`
 

--- a/chapters/document-creation-information.md
+++ b/chapters/document-creation-information.md
@@ -12,7 +12,7 @@ Table 2 — Metadata for the SPDX version field
 | --------- | ----- |
 | Required | Yes |
 | Cardinality | 1..1 |
-| Format | `SPDX-M.N` where:<br><ul><li>`M` is major version number</li><li>N` is minor version number.</li></ul> |
+| Format | `SPDX-M.N` where:<br><ul><li>`M` is major version number</li><li>`N` is minor version number.</li></ul> |
 
 <br>
 
@@ -235,7 +235,7 @@ Table 7 — Metadata for the external document references field
 | --------- | ----- |
 | Required | No |
 | Cardinality | 1..* |
-| Format | DocumentRef-`[idstring]` `[SPDX Document URI]` `[Checksum]`<br>where<br>`[idstring]` is a unique string containing letters, numbers, `.`, `-` and/or `+`.<br>`[SPDX Document URI]` is the unique ID for the external document as defined in [6.5](#6.5) of that referenced document,<br> `[Checksum]` is a checksum of the external document following the checksum format defined in [8.4](file-information#8.4). |
+| Format | DocumentRef-`[idstring]` `[SPDX Document URI]` `[Checksum]`<br>where<br>`[idstring]` is a unique string containing letters, numbers, `.`, `-` and/or `+`.<br>`[SPDX Document URI]` is the unique ID for the external document as defined in [6.5](#6.5) of that referenced document,<br>`[Checksum]` is a checksum of the external document following the checksum format defined in [8.4](file-information#8.4). |
 
 <br>
 


### PR DESCRIPTION
Move Metadata sections content into the Description sections.
Convert headings to md headings.
Add additional blank line after tables to improve spacing.