### PR TITLE
Reorder annotations

### DIFF
--- a/chapters/annotations.md
+++ b/chapters/annotations.md
@@ -2,17 +2,9 @@
 
 ## 12.1 Annotator field <a name="12.1"></a>
 
-**Description**
+### 12.1.1 Description
 
-This field identifies the person, organization or tool that has commented on a file, package, or the entire document.
-
-**Intent**
-
-It may also be important for participants in the software supply chain to validate and add information on ambiguous files, and packages.
-
-**Metadata**
-
-The metadata for the annotator field is shown in Table 71.
+This field identifies the person, organization or tool that has commented on a file, package, or the entire document. The metadata for the annotator field is shown in Table 71.
 
 Table 71 — Metadata for the annotator field
 
@@ -22,7 +14,13 @@ Table 71 — Metadata for the annotator field
 | Cardinality | 0..1 conditional (Mandatory, one), if there is an Annotation. |
 | Format | Single line of text with the following keywords.<br><pre>"Person: person name" and optional  "(email)"<br>"Organization: organization" and optional "(email)"<br>"Tool: tool identifier - version"</pre> |
 
-**Examples**
+<br>
+
+### 12.1.2 Intent
+
+It may also be important for participants in the software supply chain to validate and add information on ambiguous files, and packages.
+
+### 12.1.3 Examples
 
 EXAMPLE 1 Tag: `Annotator:`
 
@@ -40,17 +38,9 @@ EXAMPLE 2 RDF: Property `spdx:annotator` in class `spdx:Annotation`
 
 ## 12.2 Annotation date field <a name="12.2"></a>
 
-**Description**
+### 12.2.1 Description
 
-Identify when the comment was made. This shall be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.
-
-**Intent**
-
-Here, the Annotation Date can serve as a verification as to when the actual review was done.
-
-**Metadata**
-
-The metadata for the annotation date field is shown in Table 72.
+Identify when the comment was made. This shall be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard. The metadata for the annotation date field is shown in Table 72.
 
 Table 72 — Metadata for the annotation date field
 
@@ -60,7 +50,13 @@ Table 72 — Metadata for the annotation date field
 | Cardinality | 0..1 conditional (Mandatory, one), if there is an Annotation. |
 | Format | `YYYY-MM-DDThh:mm:ssZ`<br>where:<br><ul><li>`YYYY` is year</li><li>`MM` is month with leading zero</li><li>`DD` is day with leading zero</li><li>`T` is delimiter for time</li><li>`hh` is hours with leading zero in 24 hour time</li><li>`mm` is minutes with leading zero</li><li>`ss` is seconds with leading zero</li><li>`Z` is universal time indicator</li></ul> |
 
-**Examples**
+<br>
+
+### 12.2.2 Intent
+
+Here, the Annotation Date can serve as a verification as to when the actual review was done.
+
+### 12.2.3 Examples
 
 EXAMPLE 1 Tag: `AnnotationDate:`
 
@@ -78,17 +74,9 @@ EXAMPLE 2 RDF: Property `spdx:annotationDate` in class `spdx:Annotation`
 
 ## 12.3 Annotation type field <a name="12.3"></a>
 
-**Description**
+### 12.3.1 Description
 
-This field describes the type of annotation. Annotations are usually created when someone reviews the file, and if this is the case the annotation type should be `REVIEW`. If the author wants to store extra information about one of the elements during creation, it is recommended to use the type of `OTHER`.
-
-**Intent**
-
-This allows the type of annotation to be recorded.
-
-**Metadata**
-
-The metadata for the annotation type field is shown in Table 73.
+This field describes the type of annotation. Annotations are usually created when someone reviews the file, and if this is the case the annotation type should be `REVIEW`. If the author wants to store extra information about one of the elements during creation, it is recommended to use the type of `OTHER`. The metadata for the annotation type field is shown in Table 73.
 
 Table 73 — Metadata for the annotation type field
 
@@ -98,7 +86,13 @@ Table 73 — Metadata for the annotation type field
 | Cardinality | 0..1 conditional (Mandatory, one), if there is an Annotation. |
 | Format | `REVIEW` \| `OTHER` |
 
-**Examples**
+<br>
+
+### 12.3.2 Intent
+
+This allows the type of annotation to be recorded.
+
+### 12.3.3 Examples
 
 EXAMPLE 1 Tag: `AnnotationType:`
 
@@ -117,17 +111,9 @@ EXAMPLE 2 RDF: property `spdx:annotationType` in class `spdx:Annotation`
 
 ## 12.4 SPDX identifier reference field <a name="12.4"></a>
 
-**Description**
+### 12.4.1 Description
 
-Uniquely identify the element in an SPDX document which is being referenced. These may be referenced internally and externally with the addition of the SPDX Document Identifier.
-
-**Intent**
-
-There may be several versions of the same package or file within an SPDX document. Each element needs to be able to be referred to uniquely so that relationships between elements can be clearly articulated.
-
-**Metadata**
-
-The metadata for the SPDX identifier reference field is shown in Table 74.
+Uniquely identify the element in an SPDX document which is being referenced. These may be referenced internally and externally with the addition of the SPDX Document Identifier. The metadata for the SPDX identifier reference field is shown in Table 74.
 
 Table 74 — Metadata for the SPDX identifier reference field
 
@@ -137,7 +123,13 @@ Table 74 — Metadata for the SPDX identifier reference field
 | Cardinality | 0..1 conditional (Mandatory, one), if there is an Annotation. |
 | Format | `[DocumentRef-[idstring]:]SPDXID`<br>where:<br>`["DocumentRef-"[idstring]":"]` is an optional reference to an external SPDX document as described in [6.6](document-creation-information.md#6.6)<br>`SPDXID` is a unique string containing letters, numbers, `.` and/or `-` as described in [6.3](document-creation-information.md#6.3), [7.2](package-information.md#7.2) and [8.2](file-information.md#8.2). |
 
-**Examples**
+<br>
+
+### 12.4.2 Intent
+
+There may be several versions of the same package or file within an SPDX document. Each element needs to be able to be referred to uniquely so that relationships between elements can be clearly articulated.
+
+### 12.4.3 Examples
 
 EXAMPLE 1 Tag: `SPDXREF:`
 
@@ -165,17 +157,9 @@ For RDF, the annotations are a property of the SPDX Document, Package, File, or 
 
 ## 12.5 Annotation comment field <a name="12.5"></a>
 
-**Description**
+### 12.5.1 Description
 
-This required free form text field permits the annotator to provide commentary on the analysis.
-
-**Intent**
-
-This allows the annotator to provide independent assessment and note any points where there is disagreement with the analysis.
-
-**Metadata**
-
-The metadata for the annotation comment field is shown in Table 75.
+This required free form text field permits the annotator to provide commentary on the analysis. The metadata for the annotation comment field is shown in Table 75.
 
 Table 75 — Metadata for the annotation comment field
 
@@ -185,7 +169,13 @@ Table 75 — Metadata for the annotation comment field
 | Cardinality | 0..1 conditional (Mandatory, one), if there is an Annotation. |
 | Format | Free form text that may span multiple lines. |
 
-**Examples**
+<br>
+
+### 12.5.2 Intent
+
+This allows the annotator to provide independent assessment and note any points where there is disagreement with the analysis.
+
+### 12.5.3 Examples
 
 EXAMPLE 1 Tag: `AnnotationComment:`
 


### PR DESCRIPTION
Move Metadata sections content into the Description sections.
Convert headings to md headings.
Add additional blank line after tables to improve spacing.