### PR TITLE
Reorder review-information-deprecated

### DIFF
--- a/chapters/review-information-deprecated.md
+++ b/chapters/review-information-deprecated.md
@@ -4,17 +4,9 @@
 
 This field has been deprecated since SPDX 2.0.
 
-**Description**
+### 13.1.1 Description
 
-This field identifies the person, organization or tool that has reviewed the SPDX file. This field is optional and thus there is no requirement for any reviewer to add a set of review information to the file. This can be considered as an equivalent to “signed off” or “reviewed by.” Additional reviewers can be added after the original version of the SPDX file is created and be appended to the original file.
-
-**Intent**
-
-Here, as time progresses certain reviewers will begin to gain credibility as reliable. This field intends to make such information transparent. It may also be important for participants in the software supply chain to validate whether upstream providers have reviewed the SPDX file.
-
-**Metadata**
-
-The metadata for the reviewer field is shown in Table 76.
+This field identifies the person, organization or tool that has reviewed the SPDX file. This field is optional and thus there is no requirement for any reviewer to add a set of review information to the file. This can be considered as an equivalent to “signed off” or “reviewed by.” Additional reviewers can be added after the original version of the SPDX file is created and be appended to the original file. The metadata for the reviewer field is shown in Table 76.
 
 Table 76 — Metadata for the reviewer field
 
@@ -24,7 +16,13 @@ Table 76 — Metadata for the reviewer field
 | Cardinality | 0..1 |
 | Format | Single line of text with the following keywords.<br><pre>"Person: person name" and optional "(email)"<br>"Organization: organization" and optional "(email)"<br>"Tool: tool identifier - version"</pre> |
 
-**Examples**
+<br>
+
+### 13.1.2 Intent
+
+Here, as time progresses certain reviewers will begin to gain credibility as reliable. This field intends to make such information transparent. It may also be important for participants in the software supply chain to validate whether upstream providers have reviewed the SPDX file.
+
+### 13.1.3 Examples
 
 EXAMPLE 1 Tag: `Reviewer:`
 
@@ -44,17 +42,9 @@ EXAMPLE 2 RDF: Property `spdx:reviewer` in class `spdx:Review`
 
 This field has been deprecated since SPDX 2.0.
 
-**Description**
+### 13.2.1 Description
 
-Identify when the review was done. This shall be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.
-
-**Intent**
-
-Here, the `ReviewDate` can serve as a verification as to when the actual review was done.
-
-**Metadata**
-
-The metadata for the review date field is shown in Table 77.
+Identify when the review was done. This shall be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard. The metadata for the review date field is shown in Table 77.
 
 Table 77 — Metadata for the review date field
 
@@ -64,7 +54,13 @@ Table 77 — Metadata for the review date field
 | Cardinality | 0..1 conditional (Mandatory, one), if there is a Reviewer. |
 | Format | `YYYY-MM-DDThh:mm:ssZ`<br>where:<br><ul><li>`YYYY` is year</li><li>`MM` is month with leading zero</li><li>`DD` is day with leading zero</li><li>`T` is delimiter for time</li><li>`hh` is hours with leading zero in 24 hour time</li><li>`mm` is minutes with leading zero</li><li>`ss` is seconds with leading zero</li><li>`Z` is universal time indicator</li></ul> |
 
-**Examples**
+<br>
+
+### 13.2.2 Intent
+
+Here, the `ReviewDate` can serve as a verification as to when the actual review was done.
+
+### 13.2.3 Examples
 
 EXAMPLE 1 Tag: `ReviewDate:`
 
@@ -84,17 +80,9 @@ EXAMPLE 2 RDF: Property `spdx:reviewDate` in class `spdx:Review`
 
 This field is deprecated since SPDX 2.0.
 
-**Description**
+### 13.3.1 Description
 
-This optional free form text field permits the reviewer to provide commentary on the analysis.
-
-**Intent**
-
-This allows the reviewer to provide independent assessment and note any points where there is disagreement with the analysis.
-
-**Metadata**
-
-The metadata for the review comment field is shown in Table 78.
+This optional free form text field permits the reviewer to provide commentary on the analysis. The metadata for the review comment field is shown in Table 78.
 
 Table 78 — Metadata for the review comment field
 
@@ -104,7 +92,13 @@ Table 78 — Metadata for the review comment field
 | Cardinality | 0..1 |
 | Format | Free form text that may span multiple lines. |
 
-**Examples**
+<br>
+
+### 13.3.2 Intent
+
+This allows the reviewer to provide independent assessment and note any points where there is disagreement with the analysis.
+
+### 13.3.3 Examples
 
 EXAMPLE 1 Tag: `ReviewComment:`
 


### PR DESCRIPTION
Move Metadata sections content into the Description sections.
Convert headings to md headings.
Add additional blank line after tables to improve spacing.