### PR TITLE
Change SPDX file to SPDX Document where appropriate

### DIFF
--- a/chapters/composition-of-an-SPDX-document.md
+++ b/chapters/composition-of-an-SPDX-document.md
@@ -14,7 +14,7 @@ The data model is illustrated by [Annex C](RDF-data-model-implementation-and-ide
 
 An instance of this section provides the necessary information for forward and backward compatibility for processing tools.
 
-One instance shall be present for each SPDX file produced. 
+One instance shall be present for each SPDX document produced. 
 
 Cardinality: Mandatory, one.
 
@@ -121,7 +121,7 @@ See [Clause 12](annotations.md) for details of the fields in this kind of sectio
 
 The review information section is included for compatibility with SPDX 1.2, and is deprecated since SPDX 2.0. Any review information shall use an Annotation (as described in [Clause 12](annotations.md)) with an annotation type of `REVIEW`.
 
-Review information may be added after the initial SPDX file has been created. The set of fields are optional and multiple instances may be added. Once a Reviewer entry is added, the Review Date associated with the review is mandatory. The Created date shall not be modified as a result of the addition of information regarding the conduct of a review. A Review Comments is optional.
+Review information may be added after the initial SPDX document has been created. The set of fields are optional and multiple instances may be added. Once a Reviewer entry is added, the Review Date associated with the review is mandatory. The Created date shall not be modified as a result of the addition of information regarding the conduct of a review. A Review Comments is optional.
 
 See [Clause 13](review-information-deprecated.md) for details of the fields in this kind of section.
 
@@ -130,6 +130,6 @@ See [Clause 13](review-information-deprecated.md) for details of the fields in t
 This document does not address the following:
 
 * Information that cannot be derived from an inspection (whether manual or using automated tools) of the package to be analyzed.
-* How the data stored in an SPDX file is used by the recipient.
+* How the data stored in an SPDX document is used by the recipient.
 * Any identification of any patent(s) which may or may not relate to the package.
 * Legal interpretation of the licenses or any compliance actions that have been or may need

--- a/chapters/conformance.md
+++ b/chapters/conformance.md
@@ -28,9 +28,9 @@ The data format specification and recommendations are subject to the following:
 
 * Shall be suitable to be checked for syntactic correctness automatically, independent of how it was generated (human or tool).
 
-* The SPDX file character set shall support UTF-8 encoding.
+* The SPDX document character set shall support UTF-8 encoding.
 
-* Multiple file formats may be used to represent the information being exchanged. Current supported formats include:
+* Multiple serialization formats may be used to represent the information being exchanged. Current supported formats include:
   * **YAML 1.2** see: <https://yaml.org/spec/1.2/spec.html>
   * **JavaScript Object Notation** (JSON) see: [ECMA-404](https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf)
     * The JSON Schema for SPDX can be found in the [SPDX Spec Git Repository Schema directory](https://github.com/spdx/spdx-spec/blob/master/schemas/spdx-schema.json)

--- a/chapters/document-creation-information.md
+++ b/chapters/document-creation-information.md
@@ -58,7 +58,7 @@ Table 3 — Metadata for the data license field
 
 ### 6.2.2 Intent
 
-This is to alleviate any concern that content (the data or database) in an SPDX file is subject to any form of intellectual property right that could restrict the re-use of the information or the creation of another SPDX file for the same project(s). This approach avoids intellectual property and related restrictions over the SPDX file, however individuals can still contract with each other to restrict release of specific collections of SPDX files (which map to software bill of materials) and the identification of the supplier of SPDX files.
+This is to alleviate any concern that content (the data or database) in an SPDX document is subject to any form of intellectual property right that could restrict the re-use of the information or the creation of another SPDX document for the same project(s). This approach avoids intellectual property and related restrictions over the SPDX document, however individuals can still contract with each other to restrict release of specific collections of SPDX documents (which map to software bill of materials) and the identification of the supplier of SPDX documents.
 
 ### 6.2.3 Examples
 
@@ -268,7 +268,7 @@ NOTE In RDF, a namespace can be created for the external document reference if a
 
 ### 6.7.1 Description
 
-An optional field for creators of the SPDX file to provide the version of the SPDX License List used when the SPDX file was created. The metadata for the license list version field is shown in Table 8.
+An optional field for creators of the SPDX document to provide the version of the SPDX License List used when the SPDX document was created. The metadata for the license list version field is shown in Table 8.
 
 Table 8 — Metadata for the license list version field
 
@@ -280,7 +280,7 @@ Table 8 — Metadata for the license list version field
 
 ### 6.7.2 Intent
 
-Recognizing that licenses are added to the SPDX License List with each subsequent version, the intent is to provide recipients of the SPDX file with the version of the SPDX License List used. This anticipates that in the future, an SPDX file might have used a version of the SPDX License List that is older than the then current one.
+Recognizing that licenses are added to the SPDX License List with each subsequent version, the intent is to provide recipients of the SPDX document with the version of the SPDX License List used. This anticipates that in the future, an SPDX document might have used a version of the SPDX License List that is older than the then current one.
 
 ### 6.7.3 Examples
 
@@ -302,7 +302,7 @@ EXAMPLE 2 RDF: Property `licenseListVersion` in class `spdx:CreationInfo`
 
 ### 6.8.1 Description
 
-Identify who (or what, in the case of a tool) created the SPDX file. If the SPDX file was created by an individual, indicate the person's name. If the SPDX file was created on behalf of a company or organization, indicate the entity name. If the SPDX file was created using a software tool, indicate the name and version for that tool. If multiple participants or tools were involved, use multiple instances of this field. Person name or organization name may be designated as “anonymous” if appropriate. The metadata for the creator field is shown in Table 9.
+Identify who (or what, in the case of a tool) created the SPDX Document. If the SPDX Document was created by an individual, indicate the person's name. If the SPDX Document was created on behalf of a company or organization, indicate the entity name. If the SPDX Document was created using a software tool, indicate the name and version for that tool. If multiple participants or tools were involved, use multiple instances of this field. Person name or organization name may be designated as “anonymous” if appropriate. The metadata for the creator field is shown in Table 9.
 
 Table 9 — Metadata for the creator field
 
@@ -314,7 +314,7 @@ Table 9 — Metadata for the creator field
 
 ### 6.8.2 Intent
 
-Here, the generation method will assist the recipient of the SPDX file in assessing the general reliability/accuracy of the analysis information.
+Here, the generation method will assist the recipient of the SPDX Document in assessing the general reliability/accuracy of the analysis information.
 
 ### 6.8.3 Examples
 
@@ -340,7 +340,7 @@ EXAMPLE 2 RDF: Property `spdx:creator` in class `spdx:CreationInfo`
 
 ### 6.9.1 Description
 
-Identify when the SPDX file was originally created. The date is to be specified according to combined date and time in UTC format as specified in ISO 8601 standard. This field is distinct from the fields in Clause [12](annotations.md), which involves the addition of information during a subsequent review. The metadata for the created field is shown in Table 10.
+Identify when the SPDX Document was originally created. The date is to be specified according to combined date and time in UTC format as specified in ISO 8601 standard. This field is distinct from the fields in Clause [12](annotations.md), which involves the addition of information during a subsequent review. The metadata for the created field is shown in Table 10.
 
 Table 10 — Metadata for the created field
 
@@ -374,7 +374,7 @@ EXAMPLE 2 RDF: Property `spdx:created` in class `spdx:CreationInfo`
 
 ### 6.10.1 Description
 
-An optional field for creators of the SPDX file to provide general comments about the creation of the SPDX file or any other relevant comment not included in the other fields. The metadata for the Creator comment field is shown in Table 11.
+An optional field for creators of the SPDX Document to provide general comments about the creation of the SPDX Document or any other relevant comment not included in the other fields. The metadata for the Creator comment field is shown in Table 11.
 
 Table 11 — Metadata for the Creator comment field
 
@@ -386,14 +386,14 @@ Table 11 — Metadata for the Creator comment field
 
 ### 6.10.2 Intent
 
-Here, the intent is to provide recipients of the SPDX file with comments by the creator of the SPDX file.
+Here, the intent is to provide recipients of the SPDX Document with comments by the creator of the SPDX Document.
 
 ### 6.10.3 Examples
 
 EXAMPLE 1 Tag: `CreatorComment:`
 
 ```text
-CreatorComment: <text>This SPDX file was created by a combination of using a free tool,
+CreatorComment: <text>This SPDX Document was created by a combination of using a free tool,
 as indicated above, and manual analysis by several authors of the code.</text>
 ```
 
@@ -401,7 +401,7 @@ EXAMPLE 2 RDF: Property `rdfs:comment` in class `spdx:CreationInfo`
 
 ```text
 <CreationInfo>
-    <rdfs:comment>This SPDX file was created by a combination of 
+    <rdfs:comment>This SPDX Document was created by a combination of 
     using a free tool, as indicated above, and manual analysis 
     by several authors of the code.</rdfs:comment>
 </CreationInfo>
@@ -411,7 +411,7 @@ EXAMPLE 2 RDF: Property `rdfs:comment` in class `spdx:CreationInfo`
 
 ### 6.11.1 Description
 
-An optional field for creators of the SPDX file content to provide comments to the consumers of the SPDX document. The metadata for the document comment field is shown in Table 12.
+An optional field for creators of the SPDX Document content to provide comments to the consumers of the SPDX document. The metadata for the document comment field is shown in Table 12.
 
 Table 12 — Metadata for the document comment field
 
@@ -423,7 +423,7 @@ Table 12 — Metadata for the document comment field
 
 ### 6.11.2 Intent
 
-Here, the intent is to provide readers/reviewers with comments by the creator of the SPDX file about the SPDX document.
+Here, the intent is to provide readers/reviewers with comments by the creator of the SPDX Document about the SPDX document.
 
 ### 6.11.3 Examples
 

--- a/chapters/file-information.md
+++ b/chapters/file-information.md
@@ -212,21 +212,21 @@ EXAMPLE 2 RDF: Property `spdx:Checksum` in class `spdx:File`
 
 ### 8.5.1 Description
 
-This field contains the license the SPDX file creator has concluded as governing the file or alternative values if the governing license cannot be determined.
+This field contains the license the SPDX Document creator has concluded as governing the file or alternative values if the governing license cannot be determined.
 
 The options to populate this field are limited to:
 
 A valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions.md);
 
-`NONE`, if the SPDX file creator concludes there is no license available for this file; or
+`NONE`, if the SPDX Document creator concludes there is no license available for this file; or
 
 `NOASSERTION`, if:
 
-- the SPDX file creator has attempted to, but cannot reach a reasonable objective determination;
+- the SPDX Document creator has attempted to, but cannot reach a reasonable objective determination;
 
-- the SPDX file creator has made no attempt to determine this field; or
+- the SPDX Document creator has made no attempt to determine this field; or
 
-- the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+- the SPDX Document creator has intentionally provided no information (no meaning should be implied by doing so).
 
 If the Concluded License is not the same as the License Information in File, a written explanation should be provided in the Comments on License field ([8.7](#8.7)). With respect to `NOASSERTION`, a written explanation in the Comments on License field ([8.7](#8.7)) is preferred. The metadata for the concluded license field is shown in Table 40.
 
@@ -240,7 +240,7 @@ Table 40 — Metadata for the concluded license field
 
 ### 8.5.2 Intent
 
-Here, the intent is for the SPDX file creator to analyze the License Information in File ([8.6](#8.6)) and other objective information, e.g., “COPYING FILE,” along with the results from any scanning tools, to arrive at a reasonably objective conclusion as to what license governs the file.
+Here, the intent is for the SPDX Document creator to analyze the License Information in File ([8.6](#8.6)) and other objective information, e.g., “COPYING FILE,” along with the results from any scanning tools, to arrive at a reasonably objective conclusion as to what license governs the file.
 
 ### 8.5.3 Examples
 
@@ -289,9 +289,9 @@ A reference to the license, denoted by LicenseRef-`[idstring]`, if the license i
 
 `NOASSERTION`, if:
 
-- the SPDX file creator has made no attempt to determine this field; or
+- the SPDX Document creator has made no attempt to determine this field; or
 
-- the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+- the SPDX Document creator has intentionally provided no information (no meaning should be implied by doing so).
 
 If license information for more than one license is contained in the file or if the license information offers the package recipient a choice of licenses, then each of the choices should be listed as a separate entry. The metadata for the license information in file field is shown in Table 41.
 
@@ -330,7 +330,7 @@ EXAMPLE 2 RDF: Property `spdx:licenseInfoInFile` in class `spdx:File`
 
 ### 8.7.1 Description
 
-This field provides a place for the SPDX file creator to record any relevant background references or analysis that went in to arriving at the Concluded License for a file. If the Concluded License does not match the License Information in File, this should be explained by the SPDX file creator. It is also preferable to include an explanation here when the Concluded License is `NOASSERTION`. The metadata for the comments on license field is shown in Table 42.
+This field provides a place for the SPDX Document creator to record any relevant background references or analysis that went in to arriving at the Concluded License for a file. If the Concluded License does not match the License Information in File, this should be explained by the SPDX Document creator. It is also preferable to include an explanation here when the Concluded License is `NOASSERTION`. The metadata for the comments on license field is shown in Table 42.
 
 Table 42 — Metadata for the comments on license field
 
@@ -342,7 +342,7 @@ Table 42 — Metadata for the comments on license field
 
 ### 8.7.2 Intent
 
-Here, the intent is to provide the recipient of the SPDX file with a detailed explanation of how the Concluded License was determined if it does not match the License Information in File, is marked `NOASSERTION`, or other helpful information relevant to determining the license of the file.
+Here, the intent is to provide the recipient of the SPDX Document with a detailed explanation of how the Concluded License was determined if it does not match the License Information in File, is marked `NOASSERTION`, or other helpful information relevant to determining the license of the file.
 
 ### 8.7.3 Examples
 
@@ -436,7 +436,7 @@ Table 44 — Metadata for the artifact of project name field
 
 ### 8.9.2 Intent
 
-To make it easier for recipients of the SPDX file to determine the original source of the identified file. If the project is not described in an SPDX Document, then `ArtifactOf` can be used.
+To make it easier for recipients of the SPDX Document to determine the original source of the identified file. If the project is not described in an SPDX Document, then `ArtifactOf` can be used.
 
 If the project is described in another SPDX Document, then Relationship should be used.
 
@@ -476,7 +476,7 @@ Table 45 — Metadata for the artifact of project homepage field
 
 ### 8.10.2 Intent
 
-To make it easier for recipients of the SPDX file to determine the original source of the identified file. If the project is described in another SPDX Document, then `Relationship` should be used.
+To make it easier for recipients of the SPDX Document to determine the original source of the identified file. If the project is described in another SPDX Document, then `Relationship` should be used.
 
 ### 8.10.3 Examples
 
@@ -516,7 +516,7 @@ In `tag:value` format all optional ArtifactOf fields shall follow immediately be
 
 ### 8.11.2 Intent
 
-To make it easier for recipients of the SPDX file to determine the original source of the identified file. If the project is described in another SPDX Document, then `Relationship` should be used.
+To make it easier for recipients of the SPDX Document to determine the original source of the identified file. If the project is described in another SPDX Document, then `Relationship` should be used.
 
 ### 8.11.3 Examples
 
@@ -541,7 +541,7 @@ resource of type doap:Project -->
 
 ### 8.12.1 Description
 
-This field provides a place for the SPDX file creator to record any general comments about the file. The metadata for the file comment field is shown in Table 47.
+This field provides a place for the SPDX Document creator to record any general comments about the file. The metadata for the file comment field is shown in Table 47.
 
 Table 47 — Metadata for the file comment field
 
@@ -553,7 +553,7 @@ Table 47 — Metadata for the file comment field
 
 ### 8.12.2 Intent
 
-Here, the intent is to provide the recipient of the SPDX file with more information determined after careful analysis of a file.
+Here, the intent is to provide the recipient of the SPDX Document with more information determined after careful analysis of a file.
 
 ### 8.12.3 Examples
 
@@ -581,7 +581,7 @@ EXAMPLE 2 RDF: Property `rdfs:comments` in class `spdx:File`
 
 ### 8.13.1 Description
 
-This field provides a place for the SPDX file creator to record license notices or other such related notices found in the file. This might or might not include copyright statements. The metadata for the file notice field is shown in Table 48.
+This field provides a place for the SPDX Document creator to record license notices or other such related notices found in the file. This might or might not include copyright statements. The metadata for the file notice field is shown in Table 48.
 
 Table 48 — Metadata for the file notice field
 
@@ -593,7 +593,7 @@ Table 48 — Metadata for the file notice field
 
 ### 8.13.2 Intent
 
-Here, the intent is to provide the recipient of the SPDX file with notices that may require additional review or otherwise contribute to the determination of the Concluded License.
+Here, the intent is to provide the recipient of the SPDX Document with notices that may require additional review or otherwise contribute to the determination of the Concluded License.
 
 ### 8.13.3 Examples
 
@@ -619,7 +619,7 @@ EXAMPLE 2 RDF: Property `noticeText` in class `spdx:File`
 
 ### 8.14.1 Description
 
-This field provides a place for the SPDX file creator to record file contributors. Contributors could include names of copyright holders and/or authors who might not be copyright holders, yet contributed to the file content. The metadata for the file contributor field is shown in Table 49.
+This field provides a place for the SPDX Document creator to record file contributors. Contributors could include names of copyright holders and/or authors who might not be copyright holders, yet contributed to the file content. The metadata for the file contributor field is shown in Table 49.
 
 Table 49 — Metadata for the file contributor field
 
@@ -631,7 +631,7 @@ Table 49 — Metadata for the file contributor field
 
 ### 8.14.2 Intent
 
-Here, the intent is to provide the recipient of the SPDX file with a list of one or more contributors (credits). This is one way of providing acknowledgement to the contributors of a file. This would be useful, for example, if a recipient company wanted to contact copyright holders to inquire about alternate licensing.
+Here, the intent is to provide the recipient of the SPDX Document with a list of one or more contributors (credits). This is one way of providing acknowledgement to the contributors of a file. This would be useful, for example, if a recipient company wanted to contact copyright holders to inquire about alternate licensing.
 
 ### 8.14.3 Examples
 
@@ -673,7 +673,7 @@ Table 50 — Metadata for the file attribution text field
 
 ### 8.15.2 Intent
 
-The intent is to provide the recipient of the SPDX file with acknowledgement content at a file level, to assist redistributors of the file with reproducing those acknowledgements. This field does not necessarily indicate where, or in which contexts, the acknowledgements need to be reproduced (such as end-user documentation, advertising materials, etc.) and the SPDX data creator might or might not explain elsewhere how they intend for this field to be used.
+The intent is to provide the recipient of the SPDX Document with acknowledgement content at a file level, to assist redistributors of the file with reproducing those acknowledgements. This field does not necessarily indicate where, or in which contexts, the acknowledgements need to be reproduced (such as end-user documentation, advertising materials, etc.) and the SPDX data creator might or might not explain elsewhere how they intend for this field to be used.
 
 ### 8.15.3 Examples
 
@@ -706,7 +706,7 @@ This field is deprecated since SPDX 2.0 in favor of using Clause [11](relationsh
 
 ### 8.16.1 Description
 
-The field provides a place for the SPDX file creator to record a list of other files (referenceable within this SPDX file) which the file is a derivative of and/or depends on for the build (e.g., source file or build script for a binary program or library). The list of files might not necessarily represent the list of all file dependencies, but possibly the ones that impact the licensing and/or might be needed as part of the file distribution obligation. The metadata for the file dependencies field is shown in Table 51.
+The field provides a place for the SPDX Document creator to record a list of other files (referenceable within this SPDX Document) which the file is a derivative of and/or depends on for the build (e.g., source file or build script for a binary program or library). The list of files might not necessarily represent the list of all file dependencies, but possibly the ones that impact the licensing and/or might be needed as part of the file distribution obligation. The metadata for the file dependencies field is shown in Table 51.
 
 Table 51 — Metadata for the file dependencies field
 
@@ -718,7 +718,7 @@ Table 51 — Metadata for the file dependencies field
 
 ### 8.16.2 Intent
 
-Here, the intent is to provide the recipient of the SPDX file with file dependency information based on the build system that created the file. These other files might impact the licensing of the file and/or might be required to satisfy the distribution obligation of the file (e.g., source files subject to a copyleft license).
+Here, the intent is to provide the recipient of the SPDX Document with file dependency information based on the build system that created the file. These other files might impact the licensing of the file and/or might be required to satisfy the distribution obligation of the file (e.g., source files subject to a copyleft license).
 
 ### 8.16.3 Examples
 

--- a/chapters/license-matching-guidelines-and-templates.md
+++ b/chapters/license-matching-guidelines-and-templates.md
@@ -122,7 +122,7 @@ By having a rule regarding the use of "©", "(c)", or "copyright", we avoid the 
 
 ### B.11.1 Purpose <a name="B.11.1"></a>
 
-To avoid a license mismatch merely because the copyright notice (usually found above the actual license or exception text) is different. The copyright notice is important information to be recorded elsewhere in the SPDX file, but for the purposes of matching a license to the SPDX License List, it should be ignored because it is not part of the substantive license text.
+To avoid a license mismatch merely because the copyright notice (usually found above the actual license or exception text) is different. The copyright notice is important information to be recorded elsewhere in the SPDX Document, but for the purposes of matching a license to the SPDX License List, it should be ignored because it is not part of the substantive license text.
 
 ### B.11.2 Guideline <a name="B.11.2"></a>
 

--- a/chapters/other-licensing-information-detected.md
+++ b/chapters/other-licensing-information-detected.md
@@ -4,7 +4,7 @@
 
 ### 10.1.1 Description
 
-Provide a locally unique identifier to refer to licenses that are not found on the SPDX License List. This unique identifier can then be used in the packages and files sections of the SPDX file (Clause [7](package-information.md) and Clause [8](file-information.md), respectively). The metadata for the license identifier field is shown in Table 63.
+Provide a locally unique identifier to refer to licenses that are not found on the SPDX License List. This unique identifier can then be used in the packages and files sections of the SPDX Document (Clause [7](package-information.md) and Clause [8](file-information.md), respectively).
 
 Table 63 — Metadata for the license identifier field
 
@@ -174,7 +174,7 @@ EXAMPLE 2 RDF: Property `rdfs:seeAlso` in class `spdx:ExtractedLicensingInfo`
 
 ### 10.5.1 Description
 
-This field provides a place for the SPDX file creator to record any general comments about the license. The metadata for the license comment field is shown in Table 67.
+This field provides a place for the SPDX Document creator to record any general comments about the license. The metadata for the license comment field is shown in Table 67.
 
 Table 67 — Metadata for the license comment field
 

--- a/chapters/package-information.md
+++ b/chapters/package-information.md
@@ -179,15 +179,15 @@ Sub-directory being treated as a package:
 
 ### 7.5.1 Description
 
-Identify the actual distribution source for the package/directory identified in the SPDX file. This might or might not be different from the originating distribution source for the package. The name of the Package Supplier shall be an organization or recognized author and not a web site. For example, [SourceForge][] is a host website, not a supplier, the supplier for https://sourceforge.net/projects/bridge/ is “[The Linux Foundation][LinuxFoundation].”
+Identify the actual distribution source for the package/directory identified in the SPDX Document. This might or might not be different from the originating distribution source for the package. The name of the Package Supplier shall be an organization or recognized author and not a web site. For example, [SourceForge][] is a host website, not a supplier, the supplier for https://sourceforge.net/projects/bridge/ is “[The Linux Foundation][LinuxFoundation].”
 
 Use `NOASSERTION` if:
 
-- the SPDX file creator has attempted to but cannot reach a reasonable objective determination;
+- the SPDX Document creator has attempted to but cannot reach a reasonable objective determination;
 
-- the SPDX file creator has made no attempt to determine this field; or
+- the SPDX Document creator has made no attempt to determine this field; or
 
-- the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+- the SPDX Document creator has intentionally provided no information (no meaning should be implied by doing so).
 
 The metadata for the package supplier field is shown in Table 17.
 
@@ -201,7 +201,7 @@ Table 17 — Metadata for the package supplier field
 
 ### 7.5.2 Intent
 
-Assist with understanding the point of distribution for the code in the package. This field is vital for ensuring that downstream package recipients can address any ambiguity or concerns that might arise with the information in the SPDX file or the contents of the package it documents.
+Assist with understanding the point of distribution for the code in the package. This field is vital for ensuring that downstream package recipients can address any ambiguity or concerns that might arise with the information in the SPDX Document or the contents of the package it documents.
 
 ### 7.5.3 Examples
 
@@ -225,15 +225,15 @@ EXAMPLE 2 RDF: property `spdx:supplier` in class `spdx:Package`
 
 ### 7.6.1 Description
 
-If the package identified in the SPDX file originated from a different person or organization than identified as Package Supplier (see [7.5](#3.5) above), this field identifies from where or whom the package originally came. In some cases a package may be created and originally distributed by a different third party than the Package Supplier of the package. For example, the SPDX file identifies the package [glibc][] and [Red Hat][] as the Package Supplier, but the [Free Software Foundation][FSF] is the Package Originator.
+If the package identified in the SPDX Document originated from a different person or organization than identified as Package Supplier (see [7.5](#3.5) above), this field identifies from where or whom the package originally came. In some cases a package may be created and originally distributed by a different third party than the Package Supplier of the package. For example, the SPDX Document identifies the package [glibc][] and [Red Hat][] as the Package Supplier, but the [Free Software Foundation][FSF] is the Package Originator.
 
 Use `NOASSERTION` if:
 
-- the SPDX file creator has attempted to but cannot reach a reasonable objective determination;
+- the SPDX Document creator has attempted to but cannot reach a reasonable objective determination;
 
-- the SPDX file creator has made no attempt to determine this field; or
+- the SPDX Document creator has made no attempt to determine this field; or
 
-- the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+- the SPDX Document creator has intentionally provided no information (no meaning should be implied by doing so).
 
 The metadata for the package originator field is shown in Table 18.
 
@@ -247,7 +247,7 @@ Table 18 — Metadata for the package originator field
 
 ### 7.6.2 Intent
 
-Assist with understanding the point of origin of the code in the package. This field is vital for understanding who originally distributed a package and should help in addressing any ambiguity or concerns that might arise with the information in the SPDX file or the contents of the Package it documents.
+Assist with understanding the point of origin of the code in the package. This field is vital for understanding who originally distributed a package and should help in addressing any ambiguity or concerns that might arise with the information in the SPDX Document or the contents of the Package it documents.
 
 ### 7.6.3 Examples
 
@@ -270,18 +270,18 @@ EXAMPLE 2 RDF: property `spdx:originator` in class `spdx:Package`
 
 ### 7.7.1 Description
 
-This section identifies the download Universal Resource Locator (URL), or a specific location within a version control system (VCS) for the package at the time that the SPDX file was created.
+This section identifies the download Universal Resource Locator (URL), or a specific location within a version control system (VCS) for the package at the time that the SPDX Document was created.
 
 Use:
 
 * `NONE` if there is no download location whatsoever.
 * `NOASSERTION` if:
 
-  - the SPDX file creator has attempted to but cannot reach a reasonable objective determination;
+  - the SPDX Document creator has attempted to but cannot reach a reasonable objective determination;
 
-  - the SPDX file creator has made no attempt to determine this field; or
+  - the SPDX Document creator has made no attempt to determine this field; or
 
-  - the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+  - the SPDX Document creator has intentionally provided no information (no meaning should be implied by doing so).
 
 The metadata for the package download location field is shown in Table 19.
 
@@ -625,7 +625,7 @@ EXAMPLE 2 RDF: property `spdx:filesAnalyzed` in class `spdx:Package`
 
 ### 7.9.1 Description
 
-This field provides an independently reproducible mechanism identifying specific contents of a package based on the actual files (except the SPDX file itself, if it is included in the package) that make up each package and that correlates to the data in this SPDX file. This identifier enables a recipient to determine if any file in the original package (that the analysis was done on) has been changed and permits inclusion of an SPDX file as part of a package. The metadata for the package verification code field is shown in Table 21.
+This field provides an independently reproducible mechanism identifying specific contents of a package based on the actual files (except the SPDX Document itself, if it is included in the package) that make up each package and that correlates to the data in this SPDX Document. This identifier enables a recipient to determine if any file in the original package (that the analysis was done on) has been changed and permits inclusion of an SPDX Document as part of a package. The metadata for the package verification code field is shown in Table 21.
 
 Table 21 — Metadata for the package verification code field
 
@@ -658,7 +658,7 @@ Required sort order: '0','1','2','3','4','5','6','7','8','9','a','b','c','d','e'
 
 ### 7.9.2 Intent
 
-Provide a unique identifier based on the files inside each package, eliminating confusion over which version or modification of a specific package the SPDX file refers to. This field also permits embedding the SPDX file within the package without altering the identifier.
+Provide a unique identifier based on the files inside each package, eliminating confusion over which version or modification of a specific package the SPDX Document refers to. This field also permits embedding the SPDX Document within the package without altering the identifier.
 
 ### 7.9.3 Examples
 
@@ -691,7 +691,7 @@ EXAMPLE 2 RDF: `spdx:packageVerificationCodeValue`, `spdx:packageVerificationCod
 
 ### 7.10.1 Description
 
-Provide an independently reproducible mechanism that permits unique identification of a specific package that correlates to the data in this SPDX file. This identifier enables a recipient to determine if any file in the original package has been changed. If the SPDX file is to be included in a package, this value should not be calculated. The [SHA-1][] algorithm shall be used to provide the checksum by default. The metadata for the package checksum field is shown in Table 22.
+Provide an independently reproducible mechanism that permits unique identification of a specific package that correlates to the data in this SPDX Document. This identifier enables a recipient to determine if any file in the original package has been changed. If the SPDX Document is to be included in a package, this value should not be calculated. The [SHA-1][] algorithm shall be used to provide the checksum by default. The metadata for the package checksum field is shown in Table 22.
 
 Table 22 — Metadata for the package checksum field
 
@@ -704,7 +704,7 @@ Table 22 — Metadata for the package checksum field
 
 ### 7.10.2 Intent
 
-Eliminate confusion over which version or modification of a specific package the SPDX file references by providing a unique identifier of the package.
+Eliminate confusion over which version or modification of a specific package the SPDX Document references by providing a unique identifier of the package.
 
 ### 7.10.3 Examples
 
@@ -754,18 +754,18 @@ EXAMPLE 2 RDF: properties `spdx:algorithm`, `spdx:checksumValue` in class `spdx:
 
 ### 7.11.1 Description
 
-Provide a place for the SPDX file creator to record a web site that serves as the package's home page. This link can also be used to reference further information about the package referenced by the SPDX file creator.
+Provide a place for the SPDX Document creator to record a web site that serves as the package's home page. This link can also be used to reference further information about the package referenced by the SPDX Document creator.
 
 Use:
 
 * `NONE` if there is no package home page whatsoever.
 * `NOASSERTION` if:
 
-  - the SPDX file creator has attempted to but cannot reach a reasonable objective determination;
+  - the SPDX Document creator has attempted to but cannot reach a reasonable objective determination;
 
-  - the SPDX file creator has made no attempt to determine this field; or
+  - the SPDX Document creator has made no attempt to determine this field; or
 
-  - the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+  - the SPDX Document creator has intentionally provided no information (no meaning should be implied by doing so).
 
 The metadata for the package home page field is shown in Table 23.
 
@@ -779,7 +779,7 @@ Table 23 — Metadata for the package home page field
 
 ### 7.11.2 Intent
 
-Save the recipient of the SPDX file who is looking for more info from having to search for and verify a match between the package and the associated project homepage.
+Save the recipient of the SPDX Document who is looking for more info from having to search for and verify a match between the package and the associated project homepage.
 
 ### 7.11.3 Examples
 
@@ -806,7 +806,7 @@ http://usefulinc.com/ns/doap#
 
 ### 7.12.1 Description
 
-Provide a place for the SPDX file creator to record any relevant background information or additional comments about the origin of the package. For example, this field might include comments indicating whether the package was pulled from a source code management system or has been repackaged. The metadata for the source information field is shown in Table 24.
+Provide a place for the SPDX Document creator to record any relevant background information or additional comments about the origin of the package. For example, this field might include comments indicating whether the package was pulled from a source code management system or has been repackaged. The metadata for the source information field is shown in Table 24.
 
 Table 24 — Metadata for the source information field
 
@@ -818,7 +818,7 @@ Table 24 — Metadata for the source information field
 
 ### 7.12.2 Intent
 
-The SPDX file creator can provide additional information to describe any anomalies or discoveries in the determination of the origin of the package.
+The SPDX Document creator can provide additional information to describe any anomalies or discoveries in the determination of the origin of the package.
 
 ### 7.12.3 Examples
 
@@ -843,19 +843,19 @@ EXAMPLE 2 RDF: `spdx:sourceInfo`
 
 ### 7.13.1 Description
 
-Contain the license the SPDX file creator has concluded as governing the package or alternative values, if the governing license cannot be determined.
+Contain the license the SPDX Document creator has concluded as governing the package or alternative values, if the governing license cannot be determined.
 
 The options to populate this field are limited to:
 
 * A valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions.md);
-* `NONE`, if the SPDX file creator concludes there is no license available for this package; or
+* `NONE`, if the SPDX Document creator concludes there is no license available for this package; or
 * `NOASSERTION` if:
 
-  - the SPDX file creator has attempted to but cannot reach a reasonable objective determination;
+  - the SPDX Document creator has attempted to but cannot reach a reasonable objective determination;
 
-  - the SPDX file creator has made no attempt to determine this field; or
+  - the SPDX Document creator has made no attempt to determine this field; or
 
-  - the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+  - the SPDX Document creator has intentionally provided no information (no meaning should be implied by doing so).
 
 If the Concluded License is not the same as the Declared License ([3.15](#3.15)), a written explanation should be provided in the Comments on License field ([7.16](#7.16)). With respect to `NOASSERTION`, a written explanation in the Comments on License field ([7.16](#7.16)) is preferred.
 
@@ -871,7 +871,7 @@ Table 25 — Metadata for the concluded license field
 
 ### 7.13.2 Intent
 
-Here, the intent is for the SPDX file creator to analyze the license information in package, and other objective information, e.g., COPYING file, together with the results from any scanning tools, to arrive at a reasonably objective conclusion as to what license governs the package.
+Here, the intent is for the SPDX Document creator to analyze the license information in package, and other objective information, e.g., COPYING file, together with the results from any scanning tools, to arrive at a reasonably objective conclusion as to what license governs the package.
 
 ### 7.13.3 Examples
 
@@ -921,9 +921,9 @@ The options to populate this field are limited to:
 * `NONE`, if no license information is detected in any of the files; or
 * `NOASSERTION`, if:
 
-  - the SPDX file creator has made no attempt to determine this field; or
+  - the SPDX Document creator has made no attempt to determine this field; or
 
-  - the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+  - the SPDX Document creator has intentionally provided no information (no meaning should be implied by doing so).
 
 The metadata for the all licenses information from files field is shown in Table 26.
 
@@ -980,9 +980,9 @@ The options to populate this field are limited to:
 * `NONE`, if the package contains no license information whatsoever; or
 * `NOASSERTION` if:
 
-  - the SPDX file creator has made no attempt to determine this field; or
+  - the SPDX Document creator has made no attempt to determine this field; or
 
-  - the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+  - the SPDX Document creator has intentionally provided no information (no meaning should be implied by doing so).
 
 The metadata for the declared license field is shown in Table 27.
 
@@ -1037,7 +1037,7 @@ EXAMPLE 2 RDF: property `spdx:licenseDeclared` in class `spdx:Package`
 
 ### 7.16.1 Description
 
-This field provides a place for the SPDX file creator to record any relevant background information or analysis that went in to arriving at the Concluded License for a package. If the Concluded License does not match the Declared License or License Information from Files, this should be explained by the SPDX file creator. Its is also preferable to include an explanation here when the Concluded License is `NOASSERTION`. The metadata for the comments on license field is shown in Table 28.
+This field provides a place for the SPDX Document creator to record any relevant background information or analysis that went in to arriving at the Concluded License for a package. If the Concluded License does not match the Declared License or License Information from Files, this should be explained by the SPDX Document creator. Its is also preferable to include an explanation here when the Concluded License is `NOASSERTION`. The metadata for the comments on license field is shown in Table 28.
 
 Table 28 — Metadata for the comments on license field
 
@@ -1049,7 +1049,7 @@ Table 28 — Metadata for the comments on license field
 
 ### 7.16.2 Intent
 
-Here, the intent is to provide the recipient of the SPDX file with a detailed explanation of how the Concluded License was determined if it does not match the License Information from the files or the source code package, is marked `NOASSERTION`, or other helpful information relevant to determining the license of the package.
+Here, the intent is to provide the recipient of the SPDX Document with a detailed explanation of how the Concluded License was determined if it does not match the License Information from the files or the source code package, is marked `NOASSERTION`, or other helpful information relevant to determining the license of the package.
 
 ### 7.16.3 Examples
 
@@ -1138,7 +1138,7 @@ Table 30 — Metadata for the package summary description field
 
 ### 7.18.2 Intent
 
-Here, the intent is to allow the SPDX file creator to provide concise information about the function or use of the package without having to parse the source code of the actual package.
+Here, the intent is to allow the SPDX Document creator to provide concise information about the function or use of the package without having to parse the source code of the actual package.
 
 ### 7.18.3 Examples
 
@@ -1176,7 +1176,7 @@ Table 31 — Metadata for the package detailed description field
 
 ### 7.19.2 Intent
 
-Here, the intent is to provide recipients of the SPDX file with a detailed technical explanation of the functionality, anticipated use, and anticipated implementation of the package. This field may also include a description of improvements over prior versions of the package.
+Here, the intent is to provide recipients of the SPDX Document with a detailed technical explanation of the functionality, anticipated use, and anticipated implementation of the package. This field may also include a description of improvements over prior versions of the package.
 
 ### 7.19.3 Examples
 
@@ -1208,7 +1208,7 @@ EXAMPLE 2 RDF: property `spdx:description` in class `spdx:Package`
 
 ### 7.20.1 Description
 
-This field provides a place for the SPDX file creator to record any general comments about the package being described. The metadata for the package comment field is shown in Table 32.
+This field provides a place for the SPDX Document creator to record any general comments about the package being described. The metadata for the package comment field is shown in Table 32.
 
 Table 32 — Metadata for the package comment field
 
@@ -1385,7 +1385,7 @@ Table 35 — Metadata for the package attribution text field
 
 ### 7.23.2 Intent
 
-The intent is to provide the recipient of the SPDX file with acknowledgement content at a package level, to assist redistributors of the package with reproducing those acknowledgements. This field does not necessarily indicate where, or in which contexts, the acknowledgements need to be reproduced (such as end-user documentation, advertising materials, etc.) and the SPDX data creator might or might not explain elsewhere how they intend for this field to be used.
+The intent is to provide the recipient of the SPDX Document with acknowledgement content at a package level, to assist redistributors of the package with reproducing those acknowledgements. This field does not necessarily indicate where, or in which contexts, the acknowledgements need to be reproduced (such as end-user documentation, advertising materials, etc.) and the SPDX data creator might or might not explain elsewhere how they intend for this field to be used.
 
 ### 7.23.3 Examples
 

--- a/chapters/rationale.md
+++ b/chapters/rationale.md
@@ -9,7 +9,7 @@ To create a set of data exchange standards that enable companies and organizatio
 
 ## 1.2 Definition <a name="1.2"></a>
 
-The Software Package Data Exchange (SPDX®) specification is a standard format for communicating the component and metadata information associated with software packages. An SPDX file can be associated with a set of software packages, set of files or snippets and contains information about the software in the SPDX format described in this specification.
+The Software Package Data Exchange (SPDX®) specification is a standard format for communicating the component and metadata information associated with software packages. An SPDX Document can be associated with a set of software packages, set of files or snippets and contains information about the software in the SPDX format described in this specification.
 
 ## 1.3 Why is a common format for data exchange needed? <a name="1.3"></a>
 
@@ -17,7 +17,7 @@ Companies and organizations (collectively “Organizations”) are widely using 
 
 ## 1.4 What does this specification cover? <a name="1.4"></a>
 
-**1.4.1** SPDX Document Creation Information: Metadata to associate analysis results with a specific version of the SPDX file and license for use, and provide information on how, when, and by whom the SPDX file was created.
+**1.4.1** SPDX Document Creation Information: Metadata to associate analysis results with a specific version of the SPDX Document and license for use, and provide information on how, when, and by whom the SPDX Document was created.
 
 **1.4.2** Package Information: Facts that are common properties of an entire package.
 
@@ -29,7 +29,7 @@ Companies and organizations (collectively “Organizations”) are widely using 
 
 **1.4.6** Relationships Between SPDX Elements: Information on how Documents, Packages & Files relate to each other.
 
-**1.4.7** Annotations: Information about when and by whom the SPDX file was reviewed
+**1.4.7** Annotations: Information about when and by whom the SPDX Document was reviewed
 
 ![Overview of SPDX 2.2 document contents](img/spdx-2.2-document.png)
 
@@ -37,7 +37,7 @@ Companies and organizations (collectively “Organizations”) are widely using 
 
 **1.5.1** Information that cannot be derived from an inspection (whether manual or using automated tools) of the package to be analyzed.
 
-**1.5.2** How the data stored in an SPDX file is used by the recipient.
+**1.5.2** How the data stored in an SPDX Document is used by the recipient.
 
 **1.5.3** Any identification of any patent(s) which may or may not relate to the package.
 
@@ -70,7 +70,7 @@ In an SPDX document, Relationship elements can be used to indicate relationships
 
 **1.7.3** Must be suitable to be checked for syntactic correctness automatically, independent of how it was generated (human or tool).
 
-**1.7.4** The SPDX file character set must support UTF-8 encoding.
+**1.7.4** The SPDX Document character set must support UTF-8 encoding.
 
 **1.7.5** Multiple file formats can be used to represent the information being exchanged.   Current supported formats include:
 

--- a/chapters/relationships-between-SPDX-elements.md
+++ b/chapters/relationships-between-SPDX-elements.md
@@ -133,7 +133,7 @@ EXAMPLE 2 RDF: Property `spdx:relationship` in any `spdx:SpdxDocument`, `spdx:Pa
 
 ### 11.2.1 Description
 
-This field provides a place for the SPDX file creator to record any general comments about the relationship. The metadata for the relationship comment field is shown in Table 70.
+This field provides a place for the SPDX Document creator to record any general comments about the relationship. The metadata for the relationship comment field is shown in Table 70.
 
 Table 70 — Metadata for the relationship comment field
 

--- a/chapters/scope.md
+++ b/chapters/scope.md
@@ -1,3 +1,3 @@
 # 1 Scope
 
-This Software Package Data Exchange (SPDX®) specification defines a standard data format for communicating the component and metadata information associated with software packages. An SPDX file can be associated with a set of software packages, set of files or snippets and contains information about the software in the SPDX format described in this specification.
+This Software Package Data Exchange (SPDX®) specification defines a standard data format for communicating the component and metadata information associated with software packages. An SPDX Document can be associated with a set of software packages, set of files or snippets and contains information about the software in the SPDX format described in this specification.

--- a/chapters/snippet-information.md
+++ b/chapters/snippet-information.md
@@ -227,7 +227,7 @@ Supported classes from the pointer method vocabulary are `StartEndPointer` and `
 
 ### 9.5.1 Description
 
-This field contains the license the SPDX file creator has concluded as governing the snippet or alternative values if the governing license cannot be determined. The options to populate this field are limited to:
+This field contains the license the SPDX Document creator has concluded as governing the snippet or alternative values if the governing license cannot be determined. The options to populate this field are limited to:
 
 A valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions.md).
 
@@ -530,7 +530,7 @@ Table 62 — Metadata for the snippet attribution text field
 
 ### 9.11.2 Intent
 
-The intent is to provide the recipient of the SPDX file with acknowledgement content at a snippet level, to assist redistributors of the file with reproducing those acknowledgements. This field does not necessarily indicate where, or in which contexts, the acknowledgements need to be reproduced (such as end-user documentation, advertising materials, etc.) and the SPDX data creator might or might not explain elsewhere how they intend for this field to be used.
+The intent is to provide the recipient of the SPDX Document with acknowledgement content at a snippet level, to assist redistributors of the file with reproducing those acknowledgements. This field does not necessarily indicate where, or in which contexts, the acknowledgements need to be reproduced (such as end-user documentation, advertising materials, etc.) and the SPDX data creator might or might not explain elsewhere how they intend for this field to be used.
 
 ### 9.11.3 Examples
 


### PR DESCRIPTION
Partially resolves issue #253 by changing all occurrences of `SPDX file` to `SPDX Document`.  SPDX Document is defined to be the file containing the SPDX metadata.  SPDX file is defined to be the file metadata itself (defined in the object model as a subclass of SPDX Element).

This PR was the result of grepping for SPDX file and reviewing the 140+ occurrences for proper usage.

This PR did not update the `RDF-data-model-implementation-and-identifier-syntax.md` file since that would create a merge conflict with PR #443 .  PR #443 will be updated to include the fix.

Note that the Ontology, RDF schema, generated HTML, and RDF vocabulary documents will all need to be updated.  Once this PR is approved, I'll copy/paste and regenerate all of these artifacts.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>