### PR TITLE
WIP: Easier handling of snippets in source code files

### DIFF
--- a/chapters/using-SPDX-short-identifiers-in-source-files.md
+++ b/chapters/using-SPDX-short-identifiers-in-source-files.md
@@ -69,3 +69,23 @@ SPDX-License-Identifier: LicenseRef-my-special-license
 ```
 
 The `LicenseRef-` format is defined in Annex [D](SPDX-license-expressions.md). When using a custom `LicenseRef-` identifier, you will also need to provide a way for others to determine what license text corresponds to it. [Version 3.0 of the REUSE Software Specification](https://reuse.software/spec/) provides a standardized format that can optionally be used for providing the corresponding license text for these identifiers.
+
+## E.5 Representing licenses of a third-party snippet <a name="E.5"></a>
+
+When re-using a third-party snippet, e.g. from another software project or person on a help forum, you may have to attribute the copyright holder and license. In SPDX, you can do this like the following in your source code file:
+
+```text
+[ your own code ]
+
+SPDX-SnippetBegin
+SPDX-License-Identifier: CC-BY-SA-4.0
+SPDX-SnippetCopyrightText: © 2020 Jane Doe <https://stackoverflow/users/...>
+
+[ snippet code by Jane Doe here ]
+
+SPDX-SnippetEnd
+
+[ your own code continues ]
+```
+
+Please note that the `SPDX-License-Identifier` in this case is enclosed by `SPDX-SnippetBegin` and `SPDX-SnippetEnd`, and therefore only relates to the content of this very snippet. More information on snippets in SPDX can be found in the [snippet information fields](snippet-information.md).


### PR DESCRIPTION
This PR relates to a [discussion on spdx-legal](https://lists.spdx.org/g/Spdx-legal/topic/correct_handling_of_snippets/74693470) about snippet handling in SPDX. It is supposed to go hand in hand with a specification update of [REUSE](https://reuse.software) for which we seek to [make marking licensing and copyright of snippets in source code files easier](https://github.com/fsfe/reuse-docs/issues/34#issuecomment-661130117).

The format we would aim for is the following, e.g. for a shell file:

```sh
# /bin/sh

# SPDX-License-Identifier: GPL-3.0-or-later
# SPDX-FileCopyrightText: 2020 John Doe

echo "This is John's script"

# SPDX-SnippetBegin
# SPDX-License-Identifier: CC-BY-SA-4.0
# SPDX-SnippetCopyrightText: 2020 Max Mehl <https://stackoverflow.com/users/4273755/mxmehl>
# Copyright © 2016 Original author of code Max developed further <contact@example.com>

echo "Here's Max' great addition to this script" > /dev/null

# SPDX-SnippetEnd

echo "John's script continues"
```

Note on `SnippetCopyrightText` and `Copyright`: per REUSE's specification, both is perfectly fine, so both should also be supported in snippets.

Following @goneall's request, I've added this to Annex E. However, I am wondering whether [snippet-information.md](https://github.com/spdx/spdx-spec/blob/development/v2.2.1/chapters/snippet-information.md) also needs some update, e.g. to make clear that nesting is not allowed (see ML thread). 

To be honest, I am bit lost here how SPDX specifies things, and whether they are different for SPDX documents than in source code files. Help and guidance is most welcome!

## Variants

There are some variants we could discuss:

* `SPDX-License-Identifier` is a beautiful, well-known tag which I would prefer to also be valid for snippets. However, since we already have `SnippetCopyrightText`, one could think about `SPDX-Snippet-License-Identifier`. But I would see a big problem caused by the missing/additional dash in the tag name, something that is already quite confusing.
* I am impartial about `SnippetBegin` or `Snippet-Begin`. AFAIU, camel-case is preferred in SPDX, so I took that.
* To make it brutally simple for users, we could also replace `SnippetCopyrightText` by `FileCopyrightText`, but it's quite obvious that the scope would be wrong. As said above, it's always possible to use the traditional Copyright lines, and tools would just have to interpret it correctly, knowing that it related to the full file or just a snippet.