### PR TITLE
Reduce redundancy in ABNF description

### DIFF
--- a/chapters/SPDX-license-expressions.md
+++ b/chapters/SPDX-license-expressions.md
@@ -15,11 +15,11 @@ license-id = <short form license identifier in Annex A.1>
 
 license-exception-id = <short form license exception identifier in Annex A.2>
 
-license-ref = ["DocumentRef-"1\*(idstring)":"]"LicenseRef-"1*(idstring)
+license-ref = ["DocumentRef-"(idstring)":"]"LicenseRef-"(idstring)
 
 simple-expression = license-id / license-id"+" / license-ref
 
-compound-expression = 1*1(simple-expression /
+compound-expression = (simple-expression /
 
 
 simple-expression "WITH" license-exception-id /
@@ -30,7 +30,7 @@ simple-expression "WITH" license-exception-id /
 
   "(" compound-expression ")" )
 
-license-expression = 1*1(simple-expression / compound-expression)
+license-expression = (simple-expression / compound-expression)
 ```
 
 In the following sections we describe in more detail `<license-expression>` construct, a licensing expression string that enables a more accurate representation of the licensing terms of modern-day software.


### PR DESCRIPTION
"1*1" is redundant in ABNF. It just means "exactly one of", which is the same thing you get if you don't put an asterisk at all.

Due to the way idstring is defined, "1*idstring" is equivalent to "idstring".

Resolves (part of) #456 