### PR TITLE
Update field names and descriptions in externalDocumentRefs object of…

### DIFF
--- a/schemas/spdx-schema.json
+++ b/schemas/spdx-schema.json
@@ -155,8 +155,8 @@
       "items" : {
         "type" : "object",
         "properties" : {
-          "externalDocumentId" : {
-            "description" : "externalDocumentId is a string containing letters, numbers, ., - and/or + which uniquely identifies an external document within this document.",
+          "SPDXID" : {
+            "description" : "A string with the format DocumentRef-[idstring] where [idstring] is a unique string containing letters, numbers, ., - and/or + which uniquely identifies an external document within this document.",
             "type" : "string"
           },
           "checksum" : {
@@ -175,12 +175,12 @@
             "required" : [ "algorithm", "checksumValue" ],
             "description" : "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
           },
-          "spdxDocument" : {
-            "description" : "SPDX ID for SpdxDocument.  A propoerty containing an SPDX document.",
+          "documentNamespace" : {
+            "description" : "This is the Namespace of the external document, as defined in section 2.5 of the specification.",
             "type" : "string"
           }
         },
-        "required" : [ "externalDocumentId", "checksum", "spdxDocument" ],
+        "required" : [ "SPDXID", "checksum", "documentNamespace" ],
         "description" : "Information about an external SPDX document reference including the checksum. This allows for verification of the external references."
       }
     },


### PR DESCRIPTION
externalDocumentRefs has three properties.  The property "checksum" is clear enough and matches up with the specification (section 2.6). But I get very confused trying to line up with other two properties "spdxDocument" and "externalDocumentId" with the corresponding properties in the specification ("DocumentRef-[idstring]" and [SPDX Document URI])

I would propose renaming "externalDocumentId" to just "SPDXID".  This makes it consistent with how IDs are named for packages, files and the whole document. 

I would propose renaming "spdxDocument" to "documentNamespace".  This makes it consistent with how the Namespace is named for the whole document

This makes it much clearer to a user trying to fill in the fields to understand what each one does, and to tie them back to the specification.