### PR TITLE
Remove redefinitions of external ontology elements

### DIFF
--- a/ontology/spdx-ontology.owl.xml
+++ b/ontology/spdx-ontology.owl.xml
@@ -19,8 +19,6 @@ Known issues:</rdfs:comment>
         <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">2.2</owl:versionInfo>
     </owl:Ontology>
     
-
-
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
@@ -30,42 +28,6 @@ Known issues:</rdfs:comment>
      -->
 
     
-
-
-    <!-- http://www.w3.org/2000/01/rdf-schema#comment -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#comment">
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://www.w3.org/2002/07/owl#deprecatedClass -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/2002/07/owl#deprecatedClass"/>
-    
-
-
-    <!-- http://www.w3.org/2002/07/owl#deprecatedProperty -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/2002/07/owl#deprecatedProperty"/>
-    
-
-
-    <!-- http://www.w3.org/2002/07/owl#qualifiedCardinality -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/2002/07/owl#qualifiedCardinality"/>
-    
-
-
-    <!-- http://www.w3.org/2003/06/sw-vocab-status/ns#term_status -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/2003/06/sw-vocab-status/ns#term_status">
-        <rdfs:isDefinedBy>http://spdx.org/rdf/terms#</rdfs:isDefinedBy>
-        <ns:term_status>stable</ns:term_status>
-    </owl:AnnotationProperty>
-    
-
 
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
@@ -147,8 +109,9 @@ Known issues:</rdfs:comment>
         <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#SpdxElement"/>
         <rdfs:range rdf:resource="http://usefulinc.com/ns/doap#Project"/>
         <rdfs:comment xml:lang="en">Indicates the project in which the SpdxElement originated. Tools must preserve doap:homepage and doap:name properties and the URI (if one is known) of doap:Project resources that are values of this property. All other properties of doap:Projects are not directly supported by SPDX and may be dropped when translating to or from some SPDX formats.</rdfs:comment>
-        <owl:deprecatedProperty xml:lang="en">Deprecated as of version 2.1</owl:deprecatedProperty>
-        <ns:term_status>stable</ns:term_status>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:comment xml:lang="en">Deprecated as of version 2.1</rdfs:comment>
+        <ns:term_status xml:lang="en">deprecated</ns:term_status>
     </owl:ObjectProperty>
     
 
@@ -205,8 +168,8 @@ Known issues:</rdfs:comment>
         <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#SpdxDocument"/>
         <rdfs:range rdf:resource="http://spdx.org/rdf/terms#Package"/>
         <rdfs:comment xml:lang="en">The describesPackage property relates an SpdxDocument to the package which it describes.</rdfs:comment>
-        <owl:deprecatedProperty></owl:deprecatedProperty>
-        <ns:term_status xml:lang="en">stable</ns:term_status>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <ns:term_status xml:lang="en">deprecated</ns:term_status>
     </owl:ObjectProperty>
     
 
@@ -237,7 +200,9 @@ Known issues:</rdfs:comment>
     <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#fileDependency">
         <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#File"/>
         <rdfs:range rdf:resource="http://spdx.org/rdf/terms#File"/>
-        <owl:deprecated xml:lang="en">This field is deprecated since SPDX 2.0 in favor of using Section 7 which provides more granularity about relationships.</owl:deprecated>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:comment xml:lang="en">This field is deprecated since SPDX 2.0 in favor of using Section 7 which provides more granularity about relationships.</rdfs:comment>
+        <ns:term_status xml:lang="en">deprecated</ns:term_status>
     </owl:ObjectProperty>
     
 
@@ -390,7 +355,8 @@ Known issues:</rdfs:comment>
             </owl:Class>
         </rdfs:range>
         <rdfs:comment xml:lang="en">Licensing information that was discovered directly in the subject file. This is also considered a declared license for the file.</rdfs:comment>
-        <ns:term_status>deprecated</ns:term_status>
+        <ns:term_status xml:lang="en">deprecated</ns:term_status>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -507,7 +473,8 @@ Known issues:</rdfs:comment>
         <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#SpdxDocument"/>
         <rdfs:range rdf:resource="http://spdx.org/rdf/terms#File"/>
         <rdfs:comment xml:lang="en">Indicates that a particular file belongs as part of the set of analyzed files in the SpdxDocument.</rdfs:comment>
-        <owl:deprecatedProperty xml:lang="en">This property has been replaced by a relationship between the SPDX document and file with a &quot;contains&quot; relationship type.</owl:deprecatedProperty>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:comment xml:lang="en">This property has been replaced by a relationship between the SPDX document and file with a &quot;contains&quot; relationship type.</rdfs:comment>
         <ns:term_status xml:lang="en">deprecated</ns:term_status>
     </owl:ObjectProperty>
     
@@ -705,40 +672,6 @@ Known issues:</rdfs:comment>
     </owl:ObjectProperty>
     
 
-
-    <!-- http://www.w3.org/2000/01/rdf-schema#member -->
-
-    <owl:ObjectProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#member"/>
-    
-
-
-    <!-- http://www.w3.org/2009/pointers#endPointer -->
-
-    <owl:ObjectProperty rdf:about="http://www.w3.org/2009/pointers#endPointer">
-        <rdfs:domain rdf:resource="http://www.w3.org/2009/pointers#CompoundPointer"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2009/pointers#SinglePointer"/>
-        <ns:term_status xml:lang="en">stable</ns:term_status>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.w3.org/2009/pointers#reference -->
-
-    <owl:ObjectProperty rdf:about="http://www.w3.org/2009/pointers#reference">
-        <rdfs:domain rdf:resource="http://www.w3.org/2009/pointers#SinglePointer"/>
-        <ns:term_status xml:lang="en">stable</ns:term_status>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.w3.org/2009/pointers#startPointer -->
-
-    <owl:ObjectProperty rdf:about="http://www.w3.org/2009/pointers#startPointer">
-        <rdfs:domain rdf:resource="http://www.w3.org/2009/pointers#CompoundPointer"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2009/pointers#SinglePointer"/>
-        <ns:term_status xml:lang="en">stable</ns:term_status>
-    </owl:ObjectProperty>
-    
 
 
     <!-- 
@@ -1155,7 +1088,8 @@ Known issues:</rdfs:comment>
         <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Review"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
         <rdfs:comment xml:lang="en">The date and time at which the SpdxDocument was reviewed. This value must be in UTC and have &apos;Z&apos; as its timezone indicator.</rdfs:comment>
-        <owl:deprecatedProperty xml:lang="en">Deprecated in favor of Annotation with an annotationType_review.</owl:deprecatedProperty>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:comment xml:lang="en">Deprecated in favor of Annotation with an annotationType_review.</rdfs:comment>
         <ns:term_status xml:lang="en">deprecated</ns:term_status>
     </owl:DatatypeProperty>
     
@@ -1167,8 +1101,9 @@ Known issues:</rdfs:comment>
         <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Review"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">The name and, optionally, contact information of the person who performed the review. Values of this property must conform to the agent and tool syntax.</rdfs:comment>
-        <owl:deprecatedProperty xml:lang="en">The reviewer property is deprecated in favor of Annotation with an annotationType review.</owl:deprecatedProperty>
-        <ns:term_status xml:lang="en">depcrecated</ns:term_status>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:comment xml:lang="en">The reviewer property is deprecated in favor of Annotation with an annotationType review.</rdfs:comment>
+        <ns:term_status xml:lang="en">deprecated</ns:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1282,38 +1217,6 @@ Known issues:</rdfs:comment>
     
 
 
-    <!-- http://www.w3.org/2000/01/rdf-schema#comment -->
-
-    <owl:DatatypeProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#comment"/>
-    
-
-
-    <!-- http://www.w3.org/2000/01/rdf-schema#seeAlso -->
-
-    <owl:DatatypeProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#seeAlso"/>
-    
-
-
-    <!-- http://www.w3.org/2009/pointers#lineNumber -->
-
-    <owl:DatatypeProperty rdf:about="http://www.w3.org/2009/pointers#lineNumber">
-        <rdfs:domain rdf:resource="http://www.w3.org/2009/pointers#LineCharPointer"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#positiveInteger"/>
-        <ns:term_status xml:lang="en">stable</ns:term_status>
-    </owl:DatatypeProperty>
-    
-
-
-    <!-- http://www.w3.org/2009/pointers#offset -->
-
-    <owl:DatatypeProperty rdf:about="http://www.w3.org/2009/pointers#offset">
-        <rdfs:domain rdf:resource="http://www.w3.org/2009/pointers#OffsetPointer"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#positiveInteger"/>
-        <ns:term_status xml:lang="en">stable</ns:term_status>
-    </owl:DatatypeProperty>
-    
-
-
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
@@ -1345,13 +1248,6 @@ Known issues:</rdfs:comment>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#annotator"/>
-                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
-                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
                 <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
                 <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
             </owl:Restriction>
@@ -1455,13 +1351,6 @@ Known issues:</rdfs:comment>
                 <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
-                <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
-                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">One instance is required for each SPDX file produced. It provides the necessary information for forward and backward compatibility for processing tools.</rdfs:comment>
         <ns:term_status xml:lang="en">stable</ns:term_status>
     </owl:Class>
@@ -1538,13 +1427,6 @@ Known issues:</rdfs:comment>
                 <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#referenceLocator"/>
                 <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
                 <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
-                <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
-                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">An External Reference allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package.</rdfs:comment>
@@ -1710,13 +1592,6 @@ Known issues:</rdfs:comment>
     <owl:Class rdf:about="http://spdx.org/rdf/terms#LicenseException">
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#seeAlso"/>
-                <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">0</owl:minQualifiedCardinality>
-                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
                 <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#licenseExceptionId"/>
                 <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
                 <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
@@ -1732,13 +1607,6 @@ Known issues:</rdfs:comment>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#name"/>
-                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
-                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
                 <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
                 <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
             </owl:Restriction>
@@ -1996,13 +1864,6 @@ Known issues:</rdfs:comment>
                 <owl:onClass rdf:resource="http://spdx.org/rdf/terms#RelationshipType"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
-                <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
-                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A Relationship represents a relationship between two SpdxElements.</rdfs:comment>
         <ns:term_status xml:lang="en">stable</ns:term_status>
     </owl:Class>
@@ -2035,14 +1896,8 @@ Known issues:</rdfs:comment>
                 <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
-                <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
-                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <owl:deprecatedClass xml:lang="en">This class has been deprecated in favor of an Annotation with an Annotation type of review.</owl:deprecatedClass>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:comment xml:lang="en">This class has been deprecated in favor of an Annotation with an Annotation type of review.</rdfs:comment>
         <ns:term_status xml:lang="en">deprecated</ns:term_status>
     </owl:Class>
     
@@ -2054,13 +1909,6 @@ Known issues:</rdfs:comment>
         <rdfs:subClassOf rdf:resource="http://spdx.org/rdf/terms#AnyLicenseInfo"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#seeAlso"/>
-                <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">0</owl:minQualifiedCardinality>
-                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
                 <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#licenseId"/>
                 <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
                 <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
@@ -2070,13 +1918,6 @@ Known issues:</rdfs:comment>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#name"/>
                 <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
-                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
-                <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
                 <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
             </owl:Restriction>
         </rdfs:subClassOf>
@@ -2206,13 +2047,6 @@ Known issues:</rdfs:comment>
                 <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
-                <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
-                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">An SpdxElement is any thing described in SPDX, either a document or an SpdxItem. SpdxElements can be related to other SpdxElements.</rdfs:comment>
         <ns:term_status>stable</ns:term_status>
     </owl:Class>
@@ -2300,114 +2134,6 @@ Known issues:</rdfs:comment>
     
 
 
-    <!-- http://usefulinc.com/ns/doap#Project -->
-
-    <owl:Class rdf:about="http://usefulinc.com/ns/doap#Project"/>
-    
-
-
-    <!-- http://www.w3.org/2000/01/rdf-schema#Container -->
-
-    <owl:Class rdf:about="http://www.w3.org/2000/01/rdf-schema#Container"/>
-    
-
-
-    <!-- http://www.w3.org/2009/pointers#ByteOffsetPointer -->
-
-    <owl:Class rdf:about="http://www.w3.org/2009/pointers#ByteOffsetPointer">
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/2009/pointers#OffsetPointer"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.w3.org/2009/pointers#offset"/>
-                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
-                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#positiveInteger"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <ns:term_status>stable</ns:term_status>
-    </owl:Class>
-    
-
-
-    <!-- http://www.w3.org/2009/pointers#CompoundPointer -->
-
-    <owl:Class rdf:about="http://www.w3.org/2009/pointers#CompoundPointer">
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/2009/pointers#Pointer"/>
-        <ns:term_status>stable</ns:term_status>
-    </owl:Class>
-    
-
-
-    <!-- http://www.w3.org/2009/pointers#LineCharPointer -->
-
-    <owl:Class rdf:about="http://www.w3.org/2009/pointers#LineCharPointer">
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/2009/pointers#OffsetPointer"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.w3.org/2009/pointers#lineNumber"/>
-                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
-                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#positiveInteger"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <ns:term_status>stable</ns:term_status>
-    </owl:Class>
-    
-
-
-    <!-- http://www.w3.org/2009/pointers#OffsetPointer -->
-
-    <owl:Class rdf:about="http://www.w3.org/2009/pointers#OffsetPointer">
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/2009/pointers#SinglePointer"/>
-        <ns:term_status>stable</ns:term_status>
-    </owl:Class>
-    
-
-
-    <!-- http://www.w3.org/2009/pointers#Pointer -->
-
-    <owl:Class rdf:about="http://www.w3.org/2009/pointers#Pointer">
-        <ns:term_status>stable</ns:term_status>
-    </owl:Class>
-    
-
-
-    <!-- http://www.w3.org/2009/pointers#SinglePointer -->
-
-    <owl:Class rdf:about="http://www.w3.org/2009/pointers#SinglePointer">
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/2009/pointers#Pointer"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.w3.org/2009/pointers#reference"/>
-                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
-                <owl:onClass rdf:resource="http://spdx.org/rdf/terms#File"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <ns:term_status>stable</ns:term_status>
-    </owl:Class>
-    
-
-
-    <!-- http://www.w3.org/2009/pointers#StartEndPointer -->
-
-    <owl:Class rdf:about="http://www.w3.org/2009/pointers#StartEndPointer">
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/2009/pointers#CompoundPointer"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.w3.org/2009/pointers#endPointer"/>
-                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
-                <owl:onClass rdf:resource="http://www.w3.org/2009/pointers#SinglePointer"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.w3.org/2009/pointers#startPointer"/>
-                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
-                <owl:onClass rdf:resource="http://www.w3.org/2009/pointers#SinglePointer"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <ns:term_status>stable</ns:term_status>
-    </owl:Class>
-    
-
 
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
@@ -2443,12 +2169,6 @@ Known issues:</rdfs:comment>
         <rdfs:comment xml:lang="en">A Review represents an audit and signoff by an individual, organization or tool on the information for an SpdxElement.</rdfs:comment>
         <ns:term_status xml:lang="en">stable</ns:term_status>
     </owl:NamedIndividual>
-    
-
-
-    <!-- http://spdx.org/rdf/terms#annotator -->
-
-    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#annotator"/>
     
 
 
@@ -2656,7 +2376,7 @@ IMAGE if the file is assoicated with an picture image file (MIME type of image/*
     <!-- http://spdx.org/rdf/terms#noassertion -->
 
     <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#noassertion">
-        <rdfs:comment>Individual to indiate the creator of the SPDX document does not assert any value for the object.</rdfs:comment>
+        <rdfs:comment>Individual to indicate the creator of the SPDX document does not assert any value for the object.</rdfs:comment>
     </owl:NamedIndividual>
     
 
@@ -2781,6 +2501,7 @@ IMAGE if the file is assoicated with an picture image file (MIME type of image/*
     <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#relationshipType_dataFile">
         <rdf:type rdf:resource="http://spdx.org/rdf/terms#RelationshipType"/>
         <rdfs:comment xml:lang="en">Is to be used when SPDXRef-A is a data file used in SPDXRef-B.  Replaced by relationshipType_dataFileOf</rdfs:comment>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
         <ns:term_status xml:lang="en">deprecated</ns:term_status>
     </owl:NamedIndividual>
     
@@ -3146,15 +2867,6 @@ IMAGE if the file is assoicated with an picture image file (MIME type of image/*
     
 
 
-    <!-- http://spdx.org/rdf/terms#reviewed -->
-
-    <owl:NamedIndividual rdf:about="http://spdx.org/rdf/terms#reviewed"/>
-    <rdf:Description>
-        <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
-    </rdf:Description>
-    
-
-
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
@@ -3167,10 +2879,12 @@ IMAGE if the file is assoicated with an picture image file (MIME type of image/*
         <rdfs:comment>This field identifies the person, organization or tool that has commented on a file, package, or the entire document.</rdfs:comment>
         <ns:term_status xml:lang="en">stable</ns:term_status>
     </rdf:Description>
+
     <rdf:Description rdf:about="http://spdx.org/rdf/terms#reviewed">
         <rdfs:comment>Reviewed</rdfs:comment>
         <ns:term_status xml:lang="en">deprecated</ns:term_status>
-        <owl:deprecatedProperty xml:lang="en">This property has been deprecated since SPDX version 2.0.  It has been replaced by an Annotation with an annotation type review.</owl:deprecatedProperty>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:comment xml:lang="en">This property has been deprecated since SPDX version 2.0.  It has been replaced by an Annotation with an annotation type review.</rdfs:comment>
     </rdf:Description>
     
 


### PR DESCRIPTION
Fixes #539 and fixes #540
Remove local definitions of elements from external ontologies rdfs: and pointers: 
Remove restrictions on  rdfs:comment and rdfs:seeAlso which, as annotation properties, are not subject to reasoning
Use owl:deprecated instead of non-existent owl:deprecatedClass/Property and set to be consistent with term_status
Use rdfs:comment for deprecation reason previously the value of owl:deprecatedClass/Property