### PR TITLE
Improve contrast of the specification website

### DIFF
--- a/chapters/css/style.css
+++ b/chapters/css/style.css
@@ -21,7 +21,7 @@
   color: #58595b;
 }
 
-.wy-nav-side {
+.wy-nav-side, .rst-versions .rst-current-version {
   background-color: rgb(250, 250, 250);
 }
 
@@ -30,16 +30,20 @@
 }
 
 .wy-breadcrumbs li, .wy-breadcrumbs li a {
-  color: #4597cb !important;
+  color: #00416b !important;
+}
+
+.wy-menu-vertical>ul>li>a {
+  color: #515151;
 }
 
 .wy-menu-vertical li.on a:hover,.wy-menu-vertical li.current>a {
-  background: #4597cb;
+  background: #00416b;
   color: white !important;
 }
 
 .wy-menu-vertical li.on a:hover,.wy-menu-vertical li>a:hover {
-  background: #4597cb !important;
+  background: #00416b !important;
   color: white !important;
 }
 
@@ -51,24 +55,16 @@
   color: #58595b;
 }
 
-.rst-versions {
-  background: #f7f7f7;
+.rst-versions a {
+  color: #00416b !important;
 }
 
-.rst-versions .rst-current-version {
-  background: #4597cb;
-}
-
-div.section a, div.section a:visited {
-  color: #4597cb !important;
-}
-
-h1, h2, h3 {
-  color: #4597cb;
+h1, h2, h3, a {
+  color: #00416b;
 }
 
 code {
-  color: rgb(51, 51, 51);
+  color: #00416b !important;
 }
 
 code, .rst-content tt {
@@ -100,23 +96,15 @@ pre code {
 }
 
 footer {
-  font-size: .6em;
-  color: #d3d3d3;
+  font-size: 1em;
+  color: #515151;
 }
 
 footer a.btn {
   box-shadow: none;
 }
 
-footer div[role=contentinfo] p {
-   font-size: 1.2em;
-}
-
 footer .rst-footer-buttons {
   font-size: 16px;
   color: rgb(64, 64, 64);
-}
-
-footer>a, footer>a:visited {
-  color: #d3d3d3 !important;
 }


### PR DESCRIPTION
This commit improves the styling of the specification website in order to meet [Level AAA of the Web Content Accessibility Guidelines (WCAG) for contrast](https://www.w3.org/TR/WCAG21/#contrast-enhanced). To this end, this commit modifies the custom CSS file that overrides some properties of the readthedocs theme for MkDocs:

- Change light blue, orange (monospace) and grey text to the dark blue of the SPDX logo, and darken the purple text of visited links

- Increase the font size of the footer text

- Change the 'previous' and 'next' links in the section sidebar from white on light blue to dark blue on white

Note that contrast is only part of the WCAG specification; there are other improvements that could be made but these would likely requiring patching MkDocs itself.

Resolves issue #452.

Ping @goneall, @tsteenbe! :)