### PR TITLE
ISO-required wrap example code

### DIFF
--- a/chapters/SPDX-license-expressions.md
+++ b/chapters/SPDX-license-expressions.md
@@ -163,11 +163,14 @@ A conjunctive license can be expressed in RDF via a `<spdx:ConjunctiveLicenseSet
 ```text
 <spdx:ConjunctiveLicenseSet>
     <spdx:member rdf:resource="http://spdx.org/licenses/GPL-2.0-only"/>
-    <spdx:ExtractedLicensingInfo rdf:about="http://example.org#LicenseRef-EternalSurrender">
+    <spdx:ExtractedLicensingInfo rdf:about
+      ="http://example.org#LicenseRef-EternalSurrender">
         <spdx:extractedText>
-            In exchange for using this software, you agree to give its author all your worldly possessions.
-            You will not hold the author liable for all the damage this software will inevitably cause not only
-            to your person and property, but to the entire fabric of the cosmos.
+            In exchange for using this software, you agree to give
+            its author all your worldly possessions. You will not
+            hold the author liable for all the damage this software
+            will inevitably cause not only to your person and
+            property, but to the entire fabric of the cosmos.
         </spdx:extractedText>
         <spdx:licenseId>LicenseRef-EternalSurrender</spdx:licenseId>
     </spdx:ExtractedLicensingInfo>
@@ -180,11 +183,15 @@ A disjunctive license can be expressed in RDF via a `<spdx:DisjunctiveLicenseSet
 <spdx:DisjunctiveLicenseSet>
     <spdx:member rdf:resource="http://spdx.org/licenses/GPL-2.0-only"/>
     <spdx:member>
-        <spdx:ExtractedLicensingInfo rdf:about="http://example.org#LicenseRef-EternalSurrender">
+        <spdx:ExtractedLicensingInfo rdf:about
+          ="http://example.org#LicenseRef-EternalSurrender">
             <spdx:extractedText>
-                In exchange for using this software, you agree to give its author all your worldly possessions.
-                You will not hold the author liable for all the damage this software will inevitably cause
-                not only to your person and property, but to the entire fabric of the cosmos.
+                In exchange for using this software, you agree to
+                give its author all your worldly possessions. You
+                will not hold the author liable for all the damage
+                this software will inevitably cause not only to
+                your person and property, but to the entire fabric
+                of the cosmos.
             </spdx:extractedText>
             <spdx:licenseId>LicenseRef-EternalSurrender</spdx:licenseId>
         </spdx:ExtractedLicensingInfo>
@@ -202,16 +209,21 @@ A License Exception can be expressed in RDF via a `<spdx:LicenseException>` elem
 * `licenseExceptionText` - Full text of the license exception.
 
 ```text
-<rdf:Description rdf:about="http://example.org#SPDXRef-ButIdDontWantToException">
-    <rdfs:comment>This exception may be invalid in some jurisdictions.</rdfs:comment>
+<rdf:Description rdf:about
+  ="http://example.org#SPDXRef-ButIdDontWantToException">
+    <rdfs:comment>This exception may be invalid in some
+      jurisdictions.</rdfs:comment>
     <rdfs:seeAlso>http://dilbert.com/strip/1997-01-15</rdfs:seeAlso>
-    <spdx:example>So this one time, I had a license exception…</spdx:example>
+    <spdx:example>So this one time, I had a license exception
+      …</spdx:example>
     <spdx:licenseExceptionText>
-        A user of this software may decline to follow any subset of the terms of this license upon
-        finding any or all such terms unfavorable.
+        A user of this software may decline to follow any subset of
+        the terms of this license upon finding any or all such terms
+        unfavorable.
     </spdx:licenseExceptionText>
     <spdx:name>&quot;But I Don&apos;t Want To&quot; Exception</spdx:name>
     <spdx:licenseExceptionId>SPDXRef-ButIdDontWantToException</spdx:licenseExceptionId>
-    <rdf:type rdf:resource="http://spdx.org/rdf/terms#LicenseException"/>
+    <rdf:type rdf:resource
+      ="http://spdx.org/rdf/terms#LicenseException"/>
 </rdf:Description>
 ```

--- a/chapters/annotations.md
+++ b/chapters/annotations.md
@@ -172,9 +172,11 @@ EXAMPLE 1 Tag: `AnnotationComment:`
 In `tag:value` format multiple lines are delimited by `<text> .. </text>`.
 
 ```text
-AnnotationComment: <text>All of the licenses seen in the file, are matching what was seen during manual inspection.
-There are some terms that can influence the concluded license, and some alternatives may be possible,
-but the concluded license is one of the options.</text>
+AnnotationComment: <text>All of the licenses seen in the file, are
+matching what was seen during manual inspection. There are some
+terms that can influence the concluded license, and some
+alternatives may be possible, but the concluded license is one of
+the options.</text>
 ```
 
 EXAMPLE 2 RDF: Property `rdfs:comment` in class `spdx:Annotation`

--- a/chapters/document-creation-information.md
+++ b/chapters/document-creation-information.md
@@ -396,8 +396,9 @@ Here, the intent is to provide recipients of the SPDX document with comments by 
 EXAMPLE 1 Tag: `CreatorComment:`
 
 ```text
-CreatorComment: <text>This SPDX document was created by a combination of using a free tool,
-as indicated above, and manual analysis by several authors of the code.</text>
+CreatorComment: <text>This SPDX document was created by a combination of
+using a free tool, as indicated above, and manual analysis by several
+authors of the code.</text>
 ```
 
 EXAMPLE 2 RDF: Property `rdfs:comment` in class `spdx:CreationInfo`
@@ -434,7 +435,8 @@ EXAMPLE 1 Tag: `DocumentComment:`
 
 ```text
 DocumentComment: <text>This document was created using SPDX 2.0,
-version 2.3 of the SPDX License List and refering to licenses in file MyCompany.Approved.Licenses.spdx.</text>
+version 2.3 of the SPDX License List and refering to licenses
+in file MyCompany.Approved.Licenses.spdx.</text>
 ```
 
 EXAMPLE 2 RDF: Property `rdfs:comment` in class `SpdxDocument`

--- a/chapters/file-information.md
+++ b/chapters/file-information.md
@@ -351,8 +351,9 @@ EXAMPLE 1 Tag: `LicenseComments:`
 In `tag:value` format multiple lines are delimited by `<text> .. </text>`.
 
 ```text
-LicenseComments: <text>The concluded license was taken from the package level that the file was included in.
-This information was found in the COPYING.txt file in the xyz directory.</text>
+LicenseComments: <text>The concluded license was taken from the package
+level that the file was included in. This information was found in the
+COPYING.txt file in the xyz directory.</text>
 ```
 
 EXAMPLE 2 RDF: Property `spdx:licenseComments` in class `spdx:File`
@@ -689,8 +690,9 @@ In `tag:value` format multiple lines are delimited by `<text> .. </text>`.
 
 ```text
 FileAttributionText: <text>
-All advertising materials mentioning features or use of this software must display the
-following acknowledgement:  This product includes software developed by the AT&T.
+All advertising materials mentioning features or use of this software
+must display the following acknowledgement:  This product includes
+software developed by the AT&T.
 </text>
 ```
 

--- a/chapters/other-licensing-information-detected.md
+++ b/chapters/other-licensing-information-detected.md
@@ -77,7 +77,10 @@ ExtractedText: <text>This software is licensed under the Beer License.</text>
 If indeed full text of license present in File:
 
 ```text
-ExtractedText: <text>"THE WHISKEY-WARE LICENSE": whiskeyfan@example.com wrote this file. As long as you retain this notice you can do whatever you want with this stuff. If we meet some day, and you think this stuff is worth it, you can buy me a bottle of whiskey in return </text>
+ExtractedText: <text>"THE WHISKEY-WARE LICENSE": whiskeyfan@example.com
+wrote this file. As long as you retain this notice you can do whatever
+you want with this stuff. If we meet some day, and you think this stuff
+is worth it, you can buy me a bottle of whiskey in return </text>
 ```
 
 EXAMPLE 2 RDF: Property `spdx:extractedText` in class `spdx:ExtractedLicensingInfo`
@@ -96,7 +99,11 @@ If indeed full text of license present in File:
 ```text
 <ExtractedLicensingInfo rdf:about="licenseRef-Whiskeyware">
     <licenseId>LicenseRef-Whiskeyware</licenseId>
-    <extractedText>"THE WHISKEY-WARE LICENSE": whiskeyfan@example.com wrote this file. As long as you retain this notice you can do whatever you want with this stuff. If we meet some day, and you think this stuff is worth it, you can buy me a bottle of whiskey in return.</extractedText>
+    <extractedText>"THE WHISKEY-WARE LICENSE": whiskeyfan@example.com
+    wrote this file. As long as you retain this notice you can do
+    whatever you want with this stuff. If we meet some day, and you
+    think this stuff is worth it, you can buy me a bottle of whiskey
+    in return.</extractedText>
 </ExtractedLicensingInfo>
 ```
 
@@ -195,7 +202,8 @@ EXAMPLE 1 Tag: `LicenseComment:`
 In `tag:value` format multiple lines are delimited by `<text> .. </text>`.
 
 ```text
-LicenseComment: <text>The Whiskey-Ware License has a couple of other standard variants.</text>
+LicenseComment: <text>The Whiskey-Ware License has a couple
+of other standard variants.</text>
 ```
 
 EXAMPLE 2 RDF: Property `rdfs:comment` in class `spdx:ExtractedLicensingInfo`

--- a/chapters/package-information.md
+++ b/chapters/package-information.md
@@ -1056,8 +1056,9 @@ Here, the intent is to provide the recipient of the SPDX document with a detaile
 EXAMPLE 1 Tag: `PackageLicenseComments:`
 
 ```text
-PackageLicenseComments: <text>The license for this project changed with the release of version 1.4.
-The version of the project included here post-dates the license change.</text>
+PackageLicenseComments: <text>The license for this project changed with
+the release of version 1.4. The version of the project included here
+post-dates the license change.</text>
 ```
 
 EXAMPLE 2 RDF: Property `spdx:licenseComments` in class `spdx:Package`
@@ -1185,8 +1186,9 @@ EXAMPLE 1 Tag: `PackageDescription:`
 In `tag:value` format multiple lines are delimited by `<text>...</text>`.
 
 ```text
-PackageDescription: <text>The GNU C Library defines functions that are specified by the ISO C standard,
-as well as additional features specific to POSIX and other derivatives of the Unix operating system,
+PackageDescription: <text>The GNU C Library defines functions that are
+specified by the ISO C standard, as well as additional features
+specific to POSIX and other derivatives of the Unix operating system,
 and extensions specific to GNU systems.</text>
 ```
 
@@ -1197,8 +1199,9 @@ EXAMPLE 2 RDF: Property `spdx:description` in class `spdx:Package`
   ...
   <description>
     The GNU C Library defines functions that are specified by the
-    ISO C standard, as well as additional features specific to POSIX and other
-    derivatives of the Unix operating system, and extensions specific to GNU systems.
+    ISO C standard, as well as additional features specific to POSIX and
+    other derivatives of the Unix operating system, and extensions
+    specific to GNU systems.
   </description>
     ...
 </Package>
@@ -1229,7 +1232,8 @@ EXAMPLE 1 Tag: `PackageComment:`
 In `tag:value` format multiple lines are delimited by `<text>...</text>`.
 
 ```text
-PackageComment: <text>The package includes several sub-packages; see Relationship information.</text>
+PackageComment: <text>The package includes several sub-packages; see Relationship
+information.</text>
 ```
 
 EXAMPLE 2 RDF: Property `rdfs:comment` in class `spdx:Package`
@@ -1340,9 +1344,9 @@ To inform a human consumer why the reference exists, what kind of information, c
 EXAMPLE 1 Tag: `ExternalRefComment:`
 
 ```text
-ExternalRefComment: <text>NIST National Vulnerability Database (NVD) describes
-security vulnerabilities (CVEs) which affect Vendor Product Version
-acmecorp:acmenator:6.6.6.</text>
+ExternalRefComment: <text>NIST National Vulnerability Database (NVD)
+describes security vulnerabilities (CVEs) which affect Vendor Product
+Version acmecorp:acmenator:6.6.6.</text>
 ```
 
 EXAMPLE 2 RDF: Property `rdfs:comment` in class `spdx:ExternalRef`
@@ -1395,8 +1399,9 @@ In `tag:value` format multiple lines are delimited by `<text> .. </text>`.
 
 ```text
 PackageAttributionText: <text>
-All advertising materials mentioning features or use of this software must display the
-following acknowledgement:  This product includes software developed by the AT&T.
+All advertising materials mentioning features or use of this software
+must display the following acknowledgement:  This product includes
+software developed by the AT&T.
 </text>
 ```
 

--- a/chapters/review-information-deprecated.md
+++ b/chapters/review-information-deprecated.md
@@ -99,8 +99,9 @@ EXAMPLE 1 Tag: `ReviewComment:`
 In `tag:value` format multiple lines are delimited by `<text> .. </text>`.
 
 ```text
-ReviewComment: <text>All of the licenses seen in the file, are matching what was seen during manual inspection.
-There are some terms that can influence the concluded license, and some alternatives may be possible,
+ReviewComment: <text>All of the licenses seen in the file, are matching
+what was seen during manual inspection. There are some terms that can
+influence the concluded license, and some alternatives may be possible,
 but the concluded license is one of the options.</text>
 ```
 

--- a/chapters/snippet-information.md
+++ b/chapters/snippet-information.md
@@ -283,7 +283,8 @@ EXAMPLE 2 RDF: Property `spdx:licenseConcluded` in class `spdx:Snippet`
 <Snippet rdf:about="...">
     <licenseConcluded>
         <DisjunctiveLicenseSet>
-            <member rdf:resource="http://spdx.org/licenses/LGPL-2.0-only"/>
+            <member rdf:resource
+              ="http://spdx.org/licenses/LGPL-2.0-only"/>
             <member rdf:resource="#LicenseRef-2"/>
         </DisjunctiveLicenseSet>
     </licenseConcluded>
@@ -380,9 +381,9 @@ EXAMPLE 2 RDF: Property `spdx:licenseComments` in class `spdx:Snippet`
 <Snippet rdf:about="...">
     ...
     <licenseComments>
-        The concluded license was taken from package xyz, from which the snippet
-        was copied into the current file. The concluded license information was found
-        in the COPYING.txt file in package xyz.
+        The concluded license was taken from package xyz, from which the
+        snippet was copied into the current file. The concluded license
+        information was found in the COPYING.txt file in package xyz.
     </licenseComments>
     ...
 </Snippet>
@@ -461,8 +462,10 @@ EXAMPLE 1 Tag: `SnippetComment:`
 In `tag:value` format multiple lines are delimited by `<text> .. </text>`.
 
 ```text
-SnippetComment: <text>This snippet was identified as significant and highlighted in this Apache-2.0 file,
-when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0.</text>
+SnippetComment: <text>This snippet was identified as significant and
+highlighted in this Apache-2.0 file, when a commercial scanner
+identified it as being derived from file foo.c in package xyz which
+is licensed under GPL-2.0.</text>
 ```
 
 EXAMPLE 2 RDF: Property `rdfs:comment` in class `spdx:Snippet`
@@ -540,8 +543,9 @@ In `tag:value` format multiple lines are delimited by `<text> .. </text>`.
 
 ```text
 SnippetAttributionText: <text>
-All advertising materials mentioning features or use of this software must display the
-following acknowledgement:  This product includes software developed by the AT&T.
+All advertising materials mentioning features or use of this software
+must display the following acknowledgement:  This product includes
+software developed by the AT&T.
 </text>
 ```
 


### PR DESCRIPTION
ISO requires constant-width lines to be set in Courier New, which is a wide font. As such, more than a few example lines got wrapped by Word, in the middle of words/tokens. In the ISO spec, some still have "bad line breaks," but when I pushed this family of fixes back into the md, I *only* broke lines at spaces, so things look better. However, this *does* not exactly match the ISO spec, but the content is the same. I *don't* see that being a problem.