### PR TITLE
Fix link to Annex D

### DIFF
--- a/chapters/package-information.md
+++ b/chapters/package-information.md
@@ -867,7 +867,7 @@ The metadata for the concluded license field is shown in Table 25.
 | --------- | ----- |
 | Required | Yes |
 | Cardinality | 1..1 |
-| Format | `<SPDX License Expression>` \| `NONE` \| `NOASSERTION`<br>where:<br>`<SPDX License Expression>` is a valid SPDX License Expression as defined in Annex [D](IV-SPDX-license-expressions.md). |
+| Format | `<SPDX License Expression>` \| `NONE` \| `NOASSERTION`<br>where:<br>`<SPDX License Expression>` is a valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions.md). |
 
 ### 7.13.2 Intent
 


### PR DESCRIPTION
The link was pointing to the file’s old name from when annexes were
assigned numbers instead of letters.

Signed-off-by: Jason Yundt <swagfortress@gmail.com>