### PR TITLE
Annex lettering fixes

### DIFF
--- a/chapters/conformance.md
+++ b/chapters/conformance.md
@@ -2,7 +2,7 @@
 
 ## 4.1 SPDX Current and Previous Versions <a name="4.1"></a>
 
-This edition has the version number 2.2.1 as part of its title. Although this is the first ISO edition of the SPDX Specification, earlier editions were published by the SPDX workgroup via the Linux Foundation. The SPDX Specification was subsequently transposed into the Joint Development Foundation. [Those earlier editions are: 1.0 (August 2011), 1.1 (August 2012), 1.2 (October 2013), 2.0 (May 2015), 2.1 (November 2016), and 2.2 (May 2020).] Differences between this edition and earlier ones are reported in [Annex J](diffs-from-previous-editions.md); see also [[1]](bibliography.md).
+This edition has the version number 2.2.1 as part of its title. Although this is the first ISO edition of the SPDX Specification, earlier editions were published by the SPDX workgroup via the Linux Foundation. The SPDX Specification was subsequently transposed into the Joint Development Foundation. [Those earlier editions are: 1.0 (August 2011), 1.1 (August 2012), 1.2 (October 2013), 2.0 (May 2015), 2.1 (November 2016), and 2.2 (May 2020).] Differences between this edition and earlier ones are reported in [Annex I](diffs-from-previous-editions.md); see also [[1]](bibliography.md).
 
 ## 4.2 Obsolete features <a name="4.2"></a>
 

--- a/chapters/creative-commons-attribution-license-3.0-unported.md
+++ b/chapters/creative-commons-attribution-license-3.0-unported.md
@@ -1,4 +1,4 @@
-# Annex G Creative Commons Attribution License 3.0 Unported (Informative)
+# Annex J Creative Commons Attribution License 3.0 Unported (Informative)
 
 **License**
 

--- a/chapters/diffs-from-previous-editions.md
+++ b/chapters/diffs-from-previous-editions.md
@@ -1,38 +1,57 @@
 # Annex I Differences from previous editions (Informative)
 
-# I.1 Differences between V2.2.1 and V2.2 <a name="I.1"></a>
 
-There were no technical differences; V2.2.1 is V2.2 reformatted for submission to ISO via the PAS process. As a result, new clauses were added causing the previous clause-numbering sequence to change. Also, Annexes went from having Roman numbers to Latin letters. Here is the translation between numbering in the current and previous editions:
+# I.1 Differences between V2.2.2 and V2.2.1 <a name="I.1"></a>
 
-**Table I.1 — SPDX Editions**
+V2.2.2 fixed annex lettering inconsistencies. It also moved CC-BY-3.0 to the end of the spec to keep annex letters more consistent in future versions. Here is the translation between lettering in V2.2.2 and the version that came before it:
 
-Current edition   | Title | V2.2
-:---------------: | ----- | :----:
-Clause 1  | Scope     | N/A
-Clause 2  | Normative references | N/A
-Clause 3  | Terms and definitions | N/A
-Clause 4  | Conformance | N/A
-Clause 5  | Composition of an SPDX document | N/A
-Clause 6  | SPDX document creation information section | Chapter 2
-Clause 7  | Package information section | Chapter 3
-Clause 8  | File information section | Chapter 4
-Clause 9  | Snippet information section | Chapter 5
-Clause 10 | Other licensing information detected section | Chapter 6
-Clause 11 | Relationships between SPDX elements section | Chapter 7
-Clause 12 | Annotations section | Chapter 8
-Clause 13 | Review information section (deprecated) | Chapter 9
-Annex A   | SPDX license list | Appendix I
-Annex B   | License matching guidelines and templates | Appendix II
-Annex C   | RDF object model and identifier syntax | Appendix III
-Annex D   | SPDX license expressions | Appendix IV
-Annex E   | Using SPDX short identifiers in source files | Appendix V
-Annex F   | External repository identifiers | Appendix VI
-[omitted] | Creative Commons Attribution License 3.0 Unported | Appendix VII
-Annex G   | SPDX Lite | Appendix VIII
-Annex H   | SPDX file tags | Appendix IX
-Annex I   | Differences from previous editions | N/A
+**Table I.1 — SPDX V2.2.2 Organizational Changes**
 
-# I.2 Differences from V2.2 and V2.1 <a name="I.2"></a>
+Title | V2.2.1 ([spdx.dev](https://spdx.dev/)) | V2.2.1 (ISO) | V2.2.2
+----- | -------------------------------------- | ------------ | ------
+SPDX Lite                                         | Annex H/G* | Annex G   | Annex G
+SPDX File Tags                                    | Annex I/H* | Annex H   | Annex H
+Differences from Earlier SPDX Versions            | Annex J/I* | Annex I   | Annex I
+Creative Commons Attribution License 3.0 Unported | Annex G    | [omitted] | Annex J [omitted in ISO version]
+
+*_This edition featured inconsistent lettering._
+
+# I.2 Differences between V2.2.1 and V2.2 <a name="I.2"></a>
+
+There were no technical differences; V2.2.1 is V2.2 reformatted for submission to ISO via the PAS process. As a result, new clauses were added causing the previous clause-numbering sequence to change. Also, Annexes went from having Roman numbers to Latin letters. Here is the translation between numbering in V2.2.1 and the version that came before it:
+
+**Table I.2 — SPDX V2.2.1 Organizational Changes**
+
+Title | V2.2      | V2.2.1 ([spdx.dev](https://spdx.dev/)) | V2.2.1 (ISO)
+----- | --------- | -------------------------------------- | ------------
+Scope                                             | N/A           | Clause 1   | Clause 1
+Normative references                              | N/A           | Clause 2   | Clause 2
+Terms and definitions                             | N/A           | Clause 3   | Clause 3
+Conformance                                       | N/A           | Clause 4   | Clause 4
+Composition of an SPDX document                   | N/A           | Clause 5   | Clause 5
+Document Creation Information                     | Chapter 2     | Clause 6   | Clause 6
+Package Information                               | Chapter 3     | Clause 7   | Clause 7
+File Information                                  | Chapter 4     | Clause 8   | Clause 8
+Snippet Information                               | Chapter 5     | Clause 9   | Clause 9
+Other Licensing Information Detected              | Chapter 6     | Clause 10  | Clause 1
+Relationship between SPDX Elements Information    | Chapter 7     | Clause 11  | Clause 1
+Annotation Information                            | Chapter 8     | Clause 12  | Clause 1
+Review Information (deprecated)                   | Chapter 9     | Clause 13  | Clause 1
+SPDX License List                                 | Appendix I    | Annex A    | Annex A
+License Matching Guidelines and Templates         | Appendix II   | Annex B    | Annex B
+RDF Object Model and Identifier Syntax            | Appendix III  | Annex C    | Annex C
+SPDX License Expressions                          | Appendix IV   | Annex D    | Annex D
+Using SPDX short identifiers in Source Files      | Appendix V    | Annex E    | Annex E
+External Repository Identifiers                   | Appendix VI   | Annex F    | Annex F
+Creative Commons Attribution License 3.0 Unported | Appendix VII  | Annex G    | [omitted]
+SPDX Lite                                         | Appendix VIII | Annex H/G* | Annex G
+SPDX File Tags                                    | Appendix IX   | Annex I/H* | Annex H
+Differences from Earlier SPDX Versions            | N/A           | Annex J/I* | Annex I
+
+
+*_This edition featured inconsistent lettering._
+
+# I.3 Differences from V2.2 and V2.1 <a name="I.3"></a>
 
 * JSON, YAML, and a development version of XML have been added as supported file formats.
 
@@ -44,7 +63,7 @@ Annex I   | Differences from previous editions | N/A
 
 * Miscellaneous bug fixes and non-breaking improvements as reported on the mailing list and reported as issues on the spdx-spec GitHub repository.
 
-# I.3 Differences between V2.1 and V2.0 <a name="I.3"></a>
+# I.4 Differences between V2.1 and V2.0 <a name="I.4"></a>
 
 * Snippets have been added to allow a portion of a file to be identified as having different properties from the file it resides in.  The use of snippets is completely optional and it is not mandatory for snippets to be identified. See section 5 Snippet Information for further details on the fields available to describe snippets.
 
@@ -59,7 +78,7 @@ more information.
 
 * Miscellaneous bug fixes.
 
-# I.4 Differences between V2.0 and V1.2 <a name="I.4"></a>
+# I.5 Differences between V2.0 and V1.2 <a name="I.5"></a>
 
 * Abstraction has been applied to the underlying model with the inclusion of SPDX elements. With SPDX 2.0, the concept of an SPDX element is introduced (see Appendix III). This includes SPDX documents, SPDX files, and SPDX packages, each of which gets associated with an SPDX identifier which is denoted by “SPDXRef-”.
 

--- a/chapters/index.md
+++ b/chapters/index.md
@@ -1,7 +1,7 @@
 # The Software Package Data Exchange® (SPDX®) Specification Version 2.2.1
 
 Copyright © 2010-2020 Linux Foundation and its Contributors.
-This work is licensed under the Creative Commons Attribution License 3.0 Unported (CC-BY-3.0) reproduced in its entirety in [Annex G](creative-commons-attribution-license-3.0-unported.md) herein. All other rights are expressly reserved.
+This work is licensed under the Creative Commons Attribution License 3.0 Unported (CC-BY-3.0) reproduced in its entirety in [Annex J](creative-commons-attribution-license-3.0-unported.md) herein. All other rights are expressly reserved.
 
 With thanks to
 Adam Cohn,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,10 +27,10 @@ nav:
 - 'Annex D: SPDX License Expressions': SPDX-license-expressions.md
 - 'Annex E: Using SPDX short identifiers in Source Files': using-SPDX-short-identifiers-in-source-files.md
 - 'Annex F: External Repository Identifiers': external-repository-identifiers.md
-- 'Annex G: Creative Commons Attribution License 3.0 Unported': creative-commons-attribution-license-3.0-unported.md
-- 'Annex H: SPDX Lite': SPDX-Lite.md
-- 'Annex I: SPDX File Tags': file-tags.md
-- 'Annex J: Differences from Earlier SPDX Versions': diffs-from-previous-editions.md
+- 'Annex G: SPDX Lite': SPDX-Lite.md
+- 'Annex H: SPDX File Tags': file-tags.md
+- 'Annex I: Differences from Earlier SPDX Versions': diffs-from-previous-editions.md
+- 'Annex J: Creative Commons Attribution License 3.0 Unported': creative-commons-attribution-license-3.0-unported.md
 - 'Bibliography': bibliography.md
 copyright: Copyright &copy; 2010 - 2020 Linux Foundation and its Contributors.
 


### PR DESCRIPTION
At the moment, the spec has two problems with annex lettering:

1. The edition on [spdx.dev](https://spdx.dev) and the ISO edition use different letters for some annexes.
2. At least in the [spdx.dev](https://spdx.dev) edition, the annex lettering is inconsistent. For example, both [Annex G](https://spdx.github.io/spdx-spec/creative-commons-attribution-license-3.0-unported/) and [Annex H](https://spdx.github.io/spdx-spec/SPDX-Lite/) call themselves “Annex G”.

This PR fixes those two issues, documents the changes in “Differences from previous editions”, and makes it less likely for these problems to crop up again in the future.