### PR TITLE
fix typo: hyphen is missing

### DIFF
--- a/chapters/package-information.md
+++ b/chapters/package-information.md
@@ -160,7 +160,7 @@ EXAMPLE 2 RDF: Property `spdx:packageFileName` in class `spdx:Package`
 ```text
 <Package rdf:about="...">
     ...
-    <packageFileName>glibc 2.11.1.tar.gz</packageFileName>
+    <packageFileName>glibc-2.11.1.tar.gz</packageFileName>
     ...
 </Package>
 ```


### PR DESCRIPTION
In EXAMPLE 2 RDF: Property `spdx:packageFileName` in class `spdx:Package` in 7.4.3, a hyphen is missing