### PR TITLE
Generate HTML documentation for JSON schema

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,8 @@ jobs:
       run: pip install -r requirements.txt
     - name: Build
       run: mkdocs build -v --clean
+    - name: Schema
+      run: generate-schema-doc schemas/spdx-schema.json site/spdx-json-schema.html
     - name: Upload
       uses: actions/upload-artifact@v1
       with:
@@ -32,6 +34,8 @@ jobs:
       run: pip install -r requirements.txt
     - name: Build
       run: mkdocs build -v --clean
+    - name: Schema
+      run: generate-schema-doc schemas/spdx-schema.json site/spdx-json-schema.html
     - name: Upload
       uses: actions/upload-artifact@v1
       with:
@@ -51,6 +55,8 @@ jobs:
       run: apt-get update && apt-get install -y graphviz
     - name: Build
       run: mkdocs build -v  --clean
+    - name: Schema
+      run: generate-schema-doc schemas/spdx-schema.json site/spdx-json-schema.html
     - name: Upload
       uses: actions/upload-artifact@v1
       with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 mkdocs==1.2.3
+json-schema-for-humans==0.39.5
+


### PR DESCRIPTION
Uses the json-schema-for-humans Python script to generate HTML
documentation from the JSON schema.  The HTML is put in the same
directory as the documentation for the spec.

Attached is the HTML and associated style sheet and javascript generated for review.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com
[spdx-json-schema.zip](https://github.com/spdx/spdx-spec/files/7833872/spdx-json-schema.zip)
>