### PR TITLE
Update JSON Schema PERSISTENT-ID to PERSISTENT_ID

### DIFF
--- a/schemas/spdx-schema.json
+++ b/schemas/spdx-schema.json
@@ -8,112 +8,6 @@
       "type" : "string",
       "description" : "Uniquely identify any element in an SPDX document which may be referenced by other elements."
     },
-    "revieweds" : {
-      "description" : "Reviewed",
-      "type" : "array",
-      "items" : {
-        "type" : "object",
-        "properties" : {
-          "reviewer" : {
-            "description" : "The name and, optionally, contact information of the person who performed the review. Values of this property must conform to the agent and tool syntax.",
-            "type" : "string"
-          },
-          "comment" : {
-            "type" : "string"
-          },
-          "reviewDate" : {
-            "description" : "The date and time at which the SpdxDocument was reviewed. This value must be in UTC and have 'Z' as its timezone indicator.",
-            "type" : "string"
-          }
-        },
-        "required" : [ "reviewDate" ],
-        "additionalProperties" : false
-      }
-    },
-    "hasExtractedLicensingInfos" : {
-      "description" : "Indicates that a particular ExtractedLicensingInfo was defined in the subject SpdxDocument.",
-      "type" : "array",
-      "items" : {
-        "type" : "object",
-        "properties" : {
-          "seeAlsos" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          },
-          "name" : {
-            "description" : "Identify name of this SpdxElement.",
-            "type" : "string"
-          },
-          "comment" : {
-            "type" : "string"
-          },
-          "crossRefs" : {
-            "description" : "Cross Reference Detail for a license SeeAlso URL",
-            "type" : "array",
-            "items" : {
-              "type" : "object",
-              "properties" : {
-                "isWayBackLink" : {
-                  "description" : "True if the License SeeAlso URL points to a Wayback archive",
-                  "type" : "boolean"
-                },
-                "match" : {
-                  "description" : "Status of a License List SeeAlso URL reference if it refers to a website that matches the license text.",
-                  "type" : "string"
-                },
-                "timestamp" : {
-                  "description" : "Timestamp",
-                  "type" : "string"
-                },
-                "order" : {
-                  "description" : "The ordinal order of this element within a list",
-                  "type" : "integer"
-                },
-                "url" : {
-                  "description" : "URL Reference",
-                  "type" : "string"
-                },
-                "isLive" : {
-                  "description" : "Indicate a URL is still a live accessible location on the public internet",
-                  "type" : "boolean"
-                },
-                "isValid" : {
-                  "description" : "True if the URL is a valid well formed URL",
-                  "type" : "boolean"
-                }
-              },
-              "required" : [ "url" ],
-              "additionalProperties" : false,
-              "description" : "Cross reference details for the a URL reference"
-            }
-          },
-          "licenseId" : {
-            "description" : "A human readable short form license identifier for a license. The license ID is iether on the standard license oist or the form \"LicenseRef-\"[idString] where [idString] is a unique string containing letters, numbers, \".\", \"-\" or \"+\".",
-            "type" : "string"
-          },
-          "extractedText" : {
-            "description" : "Verbatim license or licensing notice text that was discovered.",
-            "type" : "string"
-          }
-        },
-        "required" : [ "licenseId", "extractedText" ],
-        "additionalProperties" : false,
-        "description" : "An ExtractedLicensingInfo represents a license or licensing notice that was found in the package. Any license text that is recognized as a license may be represented as a License rather than an ExtractedLicensingInfo."
-      }
-    },
-    "name" : {
-      "description" : "Identify name of this SpdxElement.",
-      "type" : "string"
-    },
-    "comment" : {
-      "type" : "string"
-    },
-    "spdxVersion" : {
-      "description" : "Provide a reference number that can be used to understand how to parse and interpret the rest of the file. It will enable both future changes to the specification and to support backward compatibility. The version number consists of a major and minor version indicator. The major field will be incremented when incompatible changes between versions are made (one or more sections are created, modified or deleted). The minor field will be incremented when backwards compatible changes are made.",
-      "type" : "string"
-    },
     "annotations" : {
       "description" : "Provide additional information about an SpdxElement.",
       "type" : "array",
@@ -124,64 +18,26 @@
             "description" : "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
             "type" : "string"
           },
-          "comment" : {
-            "type" : "string"
+          "annotationType" : {
+            "description" : "Type of the annotation.",
+            "type" : "string",
+            "enum" : [ "OTHER", "REVIEW" ]
           },
           "annotator" : {
             "description" : "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
             "type" : "string"
           },
-          "annotationType" : {
-            "description" : "Type of the annotation.",
-            "type" : "string",
-            "enum" : [ "OTHER", "REVIEW" ]
+          "comment" : {
+            "type" : "string"
           }
         },
-        "required" : [ "annotationDate", "comment", "annotator", "annotationType" ],
+        "required" : [ "annotationDate", "annotationType", "annotator", "comment" ],
         "additionalProperties" : false,
         "description" : "An Annotation is a comment on an SpdxItem by an agent."
       }
     },
-    "dataLicense" : {
-      "description" : "License expression for dataLicense.  Compliance with the SPDX specification includes populating the SPDX fields therein with data related to such fields (\"SPDX-Metadata\"). The SPDX specification contains numerous fields where an SPDX document creator may provide relevant explanatory text in SPDX-Metadata. Without opining on the lawfulness of \"database rights\" (in jurisdictions where applicable), such explanatory text is copyrightable subject matter in most Berne Convention countries. By using the SPDX specification, or any portion hereof, you hereby agree that any copyright rights (as determined by your jurisdiction) in any SPDX-Metadata, including without limitation explanatory text, shall be subject to the terms of the Creative Commons CC0 1.0 Universal license. For SPDX-Metadata not containing any copyright rights, you hereby agree and acknowledge that the SPDX-Metadata is provided to you \"as-is\" and without any representations or warranties of any kind concerning the SPDX-Metadata, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non-infringement, or the absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law.",
+    "comment" : {
       "type" : "string"
-    },
-    "externalDocumentRefs" : {
-      "description" : "Identify any external SPDX documents referenced within this SPDX document.",
-      "type" : "array",
-      "items" : {
-        "type" : "object",
-        "properties" : {
-          "externalDocumentId" : {
-            "description" : "externalDocumentId is a string containing letters, numbers, ., - and/or + which uniquely identifies an external document within this document.",
-            "type" : "string"
-          },
-          "checksum" : {
-            "type" : "object",
-            "properties" : {
-              "algorithm" : {
-                "description" : "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
-                "type" : "string",
-                "enum" : [ "SHA256", "SHA1", "SHA384", "MD2", "MD4", "SHA512", "MD6", "MD5", "SHA224" ]
-              },
-              "checksumValue" : {
-                "description" : "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
-                "type" : "string"
-              }
-            },
-            "required" : [ "algorithm", "checksumValue" ],
-            "additionalProperties" : false,
-            "description" : "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
-          },
-          "spdxDocument" : {
-            "description" : "SPDX ID for SpdxDocument.  A propoerty containing an SPDX document.",
-            "type" : "string"
-          }
-        },
-        "required" : [ "externalDocumentId", "checksum", "spdxDocument" ],
-        "additionalProperties" : false,
-        "description" : "Information about an external SPDX document reference including the checksum. This allows for verification of the external references."
-      }
     },
     "creationInfo" : {
       "type" : "object",
@@ -211,6 +67,150 @@
       "additionalProperties" : false,
       "description" : "One instance is required for each SPDX file produced. It provides the necessary information for forward and backward compatibility for processing tools."
     },
+    "dataLicense" : {
+      "description" : "License expression for dataLicense.  Compliance with the SPDX specification includes populating the SPDX fields therein with data related to such fields (\"SPDX-Metadata\"). The SPDX specification contains numerous fields where an SPDX document creator may provide relevant explanatory text in SPDX-Metadata. Without opining on the lawfulness of \"database rights\" (in jurisdictions where applicable), such explanatory text is copyrightable subject matter in most Berne Convention countries. By using the SPDX specification, or any portion hereof, you hereby agree that any copyright rights (as determined by your jurisdiction) in any SPDX-Metadata, including without limitation explanatory text, shall be subject to the terms of the Creative Commons CC0 1.0 Universal license. For SPDX-Metadata not containing any copyright rights, you hereby agree and acknowledge that the SPDX-Metadata is provided to you \"as-is\" and without any representations or warranties of any kind concerning the SPDX-Metadata, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non-infringement, or the absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law.",
+      "type" : "string"
+    },
+    "externalDocumentRefs" : {
+      "description" : "Identify any external SPDX documents referenced within this SPDX document.",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "checksum" : {
+            "type" : "object",
+            "properties" : {
+              "algorithm" : {
+                "description" : "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
+                "type" : "string",
+                "enum" : [ "SHA256", "SHA1", "SHA384", "MD2", "MD4", "SHA512", "MD6", "MD5", "SHA224" ]
+              },
+              "checksumValue" : {
+                "description" : "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
+                "type" : "string"
+              }
+            },
+            "required" : [ "algorithm", "checksumValue" ],
+            "additionalProperties" : false,
+            "description" : "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
+          },
+          "externalDocumentId" : {
+            "description" : "externalDocumentId is a string containing letters, numbers, ., - and/or + which uniquely identifies an external document within this document.",
+            "type" : "string"
+          },
+          "spdxDocument" : {
+            "description" : "SPDX ID for SpdxDocument.  A propoerty containing an SPDX document.",
+            "type" : "string"
+          }
+        },
+        "required" : [ "checksum", "externalDocumentId", "spdxDocument" ],
+        "additionalProperties" : false,
+        "description" : "Information about an external SPDX document reference including the checksum. This allows for verification of the external references."
+      }
+    },
+    "hasExtractedLicensingInfos" : {
+      "description" : "Indicates that a particular ExtractedLicensingInfo was defined in the subject SpdxDocument.",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "comment" : {
+            "type" : "string"
+          },
+          "crossRefs" : {
+            "description" : "Cross Reference Detail for a license SeeAlso URL",
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "isLive" : {
+                  "description" : "Indicate a URL is still a live accessible location on the public internet",
+                  "type" : "boolean"
+                },
+                "isValid" : {
+                  "description" : "True if the URL is a valid well formed URL",
+                  "type" : "boolean"
+                },
+                "isWayBackLink" : {
+                  "description" : "True if the License SeeAlso URL points to a Wayback archive",
+                  "type" : "boolean"
+                },
+                "match" : {
+                  "description" : "Status of a License List SeeAlso URL reference if it refers to a website that matches the license text.",
+                  "type" : "string"
+                },
+                "order" : {
+                  "description" : "The ordinal order of this element within a list",
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "description" : "Timestamp",
+                  "type" : "string"
+                },
+                "url" : {
+                  "description" : "URL Reference",
+                  "type" : "string"
+                }
+              },
+              "required" : [ "url" ],
+              "additionalProperties" : false,
+              "description" : "Cross reference details for the a URL reference"
+            }
+          },
+          "extractedText" : {
+            "description" : "Verbatim license or licensing notice text that was discovered.",
+            "type" : "string"
+          },
+          "licenseId" : {
+            "description" : "A human readable short form license identifier for a license. The license ID is iether on the standard license oist or the form \"LicenseRef-\"[idString] where [idString] is a unique string containing letters, numbers, \".\", \"-\" or \"+\".",
+            "type" : "string"
+          },
+          "name" : {
+            "description" : "Identify name of this SpdxElement.",
+            "type" : "string"
+          },
+          "seeAlsos" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        },
+        "required" : [ "extractedText", "licenseId" ],
+        "additionalProperties" : false,
+        "description" : "An ExtractedLicensingInfo represents a license or licensing notice that was found in the package. Any license text that is recognized as a license may be represented as a License rather than an ExtractedLicensingInfo."
+      }
+    },
+    "name" : {
+      "description" : "Identify name of this SpdxElement.",
+      "type" : "string"
+    },
+    "revieweds" : {
+      "description" : "Reviewed",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "comment" : {
+            "type" : "string"
+          },
+          "reviewDate" : {
+            "description" : "The date and time at which the SpdxDocument was reviewed. This value must be in UTC and have 'Z' as its timezone indicator.",
+            "type" : "string"
+          },
+          "reviewer" : {
+            "description" : "The name and, optionally, contact information of the person who performed the review. Values of this property must conform to the agent and tool syntax.",
+            "type" : "string"
+          }
+        },
+        "required" : [ "reviewDate" ],
+        "additionalProperties" : false
+      }
+    },
+    "spdxVersion" : {
+      "description" : "Provide a reference number that can be used to understand how to parse and interpret the rest of the file. It will enable both future changes to the specification and to support backward compatibility. The version number consists of a major and minor version indicator. The major field will be incremented when incompatible changes between versions are made (one or more sections are created, modified or deleted). The minor field will be incremented when backwards compatible changes are made.",
+      "type" : "string"
+    },
     "documentNamespace" : {
       "type" : "string",
       "description" : "The URI provides an unambiguous mechanism for other SPDX documents to reference SPDX elements within this SPDX document."
@@ -232,14 +232,6 @@
             "type" : "string",
             "description" : "Uniquely identify any element in an SPDX document which may be referenced by other elements."
           },
-          "attributionTexts" : {
-            "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
-            "type" : "array",
-            "items" : {
-              "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
-              "type" : "string"
-            }
-          },
           "annotations" : {
             "description" : "Provide additional information about an SpdxElement.",
             "type" : "array",
@@ -250,54 +242,31 @@
                   "description" : "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
                   "type" : "string"
                 },
-                "comment" : {
-                  "type" : "string"
+                "annotationType" : {
+                  "description" : "Type of the annotation.",
+                  "type" : "string",
+                  "enum" : [ "OTHER", "REVIEW" ]
                 },
                 "annotator" : {
                   "description" : "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
                   "type" : "string"
                 },
-                "annotationType" : {
-                  "description" : "Type of the annotation.",
-                  "type" : "string",
-                  "enum" : [ "OTHER", "REVIEW" ]
+                "comment" : {
+                  "type" : "string"
                 }
               },
-              "required" : [ "annotationDate", "comment", "annotator", "annotationType" ],
+              "required" : [ "annotationDate", "annotationType", "annotator", "comment" ],
               "additionalProperties" : false,
               "description" : "An Annotation is a comment on an SpdxItem by an agent."
             }
           },
-          "supplier" : {
-            "description" : "The name and, optionally, contact information of the person or organization who was the immediate supplier of this package to the recipient. The supplier may be different than originator when the software has been repackaged. Values of this property must conform to the agent and tool syntax.",
-            "type" : "string"
-          },
-          "homepage" : {
-            "type" : "string"
-          },
-          "licenseDeclared" : {
-            "description" : "License expression for licenseDeclared.  The licensing that the creators of the software in the package, or the packager, have declared. Declarations by the original software creator should be preferred, if they exist.",
-            "type" : "string"
-          },
-          "packageVerificationCode" : {
-            "type" : "object",
-            "properties" : {
-              "packageVerificationCodeValue" : {
-                "description" : "The actual package verification code as a hex encoded value.",
-                "type" : "string"
-              },
-              "packageVerificationCodeExcludedFiles" : {
-                "description" : "A file that was excluded when calculating the package verification code. This is usually a file containing SPDX data regarding the package. If a package contains more than one SPDX file all SPDX files must be excluded from the package verification code. If this is not done it would be impossible to correctly calculate the verification codes in both files.",
-                "type" : "array",
-                "items" : {
-                  "description" : "A file that was excluded when calculating the package verification code. This is usually a file containing SPDX data regarding the package. If a package contains more than one SPDX file all SPDX files must be excluded from the package verification code. If this is not done it would be impossible to correctly calculate the verification codes in both files.",
-                  "type" : "string"
-                }
-              }
-            },
-            "required" : [ "packageVerificationCodeValue" ],
-            "additionalProperties" : false,
-            "description" : "A manifest based verification code (the algorithm is defined in section 4.7 of the full specification) of the SPDX Item. This allows consumers of this data and/or database to determine if an SPDX item they have in hand is identical to the SPDX item from which the data was produced. This algorithm works even if the SPDX document is included in the SPDX item."
+          "attributionTexts" : {
+            "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+            "type" : "array",
+            "items" : {
+              "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+              "type" : "string"
+            }
           },
           "checksums" : {
             "description" : "The checksum property provides a mechanism that can be used to verify that the contents of a File or Package have not changed.",
@@ -320,13 +289,20 @@
               "description" : "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
             }
           },
+          "comment" : {
+            "type" : "string"
+          },
+          "copyrightText" : {
+            "description" : "The text of copyright declarations recited in the Package or File.",
+            "type" : "string"
+          },
+          "description" : {
+            "description" : "Provides a detailed description of the package.",
+            "type" : "string"
+          },
           "downloadLocation" : {
             "description" : "The URI at which this package is available for download. Private (i.e., not publicly reachable) URIs are acceptable as values of this property. The values http://spdx.org/rdf/terms#none and http://spdx.org/rdf/terms#noassertion may be used to specify that the package is not downloadable or that no attempt was made to determine its download location, respectively.",
             "type" : "string"
-          },
-          "filesAnalyzed" : {
-            "description" : "Indicates whether the file content of this package has been available for or subjected to analysis when creating the SPDX document. If false indicates packages that represent metadata or URI references to a project, product, artifact, distribution or a component. If set to false, the package must not contain any files.",
-            "type" : "boolean"
           },
           "externalRefs" : {
             "description" : "An External Reference allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package.",
@@ -340,7 +316,7 @@
                 "referenceCategory" : {
                   "description" : "Category for the external reference",
                   "type" : "string",
-                  "enum" : [ "OTHER", "SECURITY", "PACKAGE_MANAGER", "PERSISTENT-ID" ]
+                  "enum" : [ "OTHER", "PERSISTENT_ID", "SECURITY", "PACKAGE_MANAGER" ]
                 },
                 "referenceLocator" : {
                   "description" : "The unique string with no spaces necessary to access the package-specific information, metadata, or content within the target location. The format of the locator is subject to constraints defined by the <type>.",
@@ -356,13 +332,9 @@
               "description" : "An External Reference allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package."
             }
           },
-          "licenseComments" : {
-            "description" : "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
-            "type" : "string"
-          },
-          "name" : {
-            "description" : "Identify name of this SpdxElement.",
-            "type" : "string"
+          "filesAnalyzed" : {
+            "description" : "Indicates whether the file content of this package has been available for or subjected to analysis when creating the SPDX document. If false indicates packages that represent metadata or URI references to a project, product, artifact, distribution or a component. If set to false, the package must not contain any files.",
+            "type" : "boolean"
           },
           "hasFiles" : {
             "description" : "Indicates that a particular file belongs to a package.",
@@ -372,23 +344,19 @@
               "type" : "string"
             }
           },
-          "comment" : {
+          "homepage" : {
             "type" : "string"
           },
-          "copyrightText" : {
-            "description" : "The text of copyright declarations recited in the Package or File.",
+          "licenseComments" : {
+            "description" : "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
             "type" : "string"
           },
-          "summary" : {
-            "description" : "Provides a short description of the package.",
+          "licenseConcluded" : {
+            "description" : "License expression for licenseConcluded.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the package.",
             "type" : "string"
           },
-          "originator" : {
-            "description" : "The name and, optionally, contact information of the person or organization that originally created the package. Values of this property must conform to the agent and tool syntax.",
-            "type" : "string"
-          },
-          "packageFileName" : {
-            "description" : "The base name of the package file name. For example, zlib-1.2.5.tar.gz.",
+          "licenseDeclared" : {
+            "description" : "License expression for licenseDeclared.  The licensing that the creators of the software in the package, or the packager, have declared. Declarations by the original software creator should be preferred, if they exist.",
             "type" : "string"
           },
           "licenseInfoFromFiles" : {
@@ -399,24 +367,56 @@
               "type" : "string"
             }
           },
-          "licenseConcluded" : {
-            "description" : "License expression for licenseConcluded.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the package.",
+          "name" : {
+            "description" : "Identify name of this SpdxElement.",
             "type" : "string"
           },
-          "versionInfo" : {
-            "description" : "Provides an indication of the version of the package that is described by this SpdxDocument.",
+          "originator" : {
+            "description" : "The name and, optionally, contact information of the person or organization that originally created the package. Values of this property must conform to the agent and tool syntax.",
             "type" : "string"
+          },
+          "packageFileName" : {
+            "description" : "The base name of the package file name. For example, zlib-1.2.5.tar.gz.",
+            "type" : "string"
+          },
+          "packageVerificationCode" : {
+            "type" : "object",
+            "properties" : {
+              "packageVerificationCodeExcludedFiles" : {
+                "description" : "A file that was excluded when calculating the package verification code. This is usually a file containing SPDX data regarding the package. If a package contains more than one SPDX file all SPDX files must be excluded from the package verification code. If this is not done it would be impossible to correctly calculate the verification codes in both files.",
+                "type" : "array",
+                "items" : {
+                  "description" : "A file that was excluded when calculating the package verification code. This is usually a file containing SPDX data regarding the package. If a package contains more than one SPDX file all SPDX files must be excluded from the package verification code. If this is not done it would be impossible to correctly calculate the verification codes in both files.",
+                  "type" : "string"
+                }
+              },
+              "packageVerificationCodeValue" : {
+                "description" : "The actual package verification code as a hex encoded value.",
+                "type" : "string"
+              }
+            },
+            "required" : [ "packageVerificationCodeValue" ],
+            "additionalProperties" : false,
+            "description" : "A manifest based verification code (the algorithm is defined in section 4.7 of the full specification) of the SPDX Item. This allows consumers of this data and/or database to determine if an SPDX item they have in hand is identical to the SPDX item from which the data was produced. This algorithm works even if the SPDX document is included in the SPDX item."
           },
           "sourceInfo" : {
             "description" : "Allows the producer(s) of the SPDX document to describe how the package was acquired and/or changed from the original source.",
             "type" : "string"
           },
-          "description" : {
-            "description" : "Provides a detailed description of the package.",
+          "summary" : {
+            "description" : "Provides a short description of the package.",
+            "type" : "string"
+          },
+          "supplier" : {
+            "description" : "The name and, optionally, contact information of the person or organization who was the immediate supplier of this package to the recipient. The supplier may be different than originator when the software has been repackaged. Values of this property must conform to the agent and tool syntax.",
+            "type" : "string"
+          },
+          "versionInfo" : {
+            "description" : "Provides an indication of the version of the package that is described by this SpdxDocument.",
             "type" : "string"
           }
         },
-        "required" : [ "SPDXID", "licenseDeclared", "downloadLocation", "name", "copyrightText", "licenseConcluded" ],
+        "required" : [ "SPDXID", "copyrightText", "downloadLocation", "licenseConcluded", "licenseDeclared", "name" ],
         "additionalProperties" : false
       }
     },
@@ -430,23 +430,6 @@
             "type" : "string",
             "description" : "Uniquely identify any element in an SPDX document which may be referenced by other elements."
           },
-          "fileTypes" : {
-            "description" : "The type of the file.",
-            "type" : "array",
-            "items" : {
-              "description" : "The type of the file.",
-              "type" : "string",
-              "enum" : [ "OTHER", "DOCUMENTATION", "IMAGE", "VIDEO", "ARCHIVE", "SPDX", "APPLICATION", "SOURCE", "BINARY", "TEXT", "AUDIO" ]
-            }
-          },
-          "attributionTexts" : {
-            "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
-            "type" : "array",
-            "items" : {
-              "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
-              "type" : "string"
-            }
-          },
           "annotations" : {
             "description" : "Provide additional information about an SpdxElement.",
             "type" : "array",
@@ -457,22 +440,37 @@
                   "description" : "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
                   "type" : "string"
                 },
-                "comment" : {
-                  "type" : "string"
+                "annotationType" : {
+                  "description" : "Type of the annotation.",
+                  "type" : "string",
+                  "enum" : [ "OTHER", "REVIEW" ]
                 },
                 "annotator" : {
                   "description" : "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
                   "type" : "string"
                 },
-                "annotationType" : {
-                  "description" : "Type of the annotation.",
-                  "type" : "string",
-                  "enum" : [ "OTHER", "REVIEW" ]
+                "comment" : {
+                  "type" : "string"
                 }
               },
-              "required" : [ "annotationDate", "comment", "annotator", "annotationType" ],
+              "required" : [ "annotationDate", "annotationType", "annotator", "comment" ],
               "additionalProperties" : false,
               "description" : "An Annotation is a comment on an SpdxItem by an agent."
+            }
+          },
+          "artifactOfs" : {
+            "description" : "Indicates the project in which the SpdxElement originated. Tools must preserve doap:homepage and doap:name properties and the URI (if one is known) of doap:Project resources that are values of this property. All other properties of doap:Projects are not directly supported by SPDX and may be dropped when translating to or from some SPDX formats.",
+            "type" : "array",
+            "items" : {
+              "type" : "object"
+            }
+          },
+          "attributionTexts" : {
+            "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+            "type" : "array",
+            "items" : {
+              "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+              "type" : "string"
             }
           },
           "checksums" : {
@@ -496,25 +494,6 @@
               "additionalProperties" : false,
               "description" : "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
             }
-          },
-          "noticeText" : {
-            "description" : "This field provides a place for the SPDX file creator to record potential legal notices found in the file. This may or may not include copyright statements.",
-            "type" : "string"
-          },
-          "artifactOfs" : {
-            "description" : "Indicates the project in which the SpdxElement originated. Tools must preserve doap:homepage and doap:name properties and the URI (if one is known) of doap:Project resources that are values of this property. All other properties of doap:Projects are not directly supported by SPDX and may be dropped when translating to or from some SPDX formats.",
-            "type" : "array",
-            "items" : {
-              "type" : "object"
-            }
-          },
-          "licenseComments" : {
-            "description" : "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
-            "type" : "string"
-          },
-          "fileName" : {
-            "description" : "The name of the file relative to the root of the package.",
-            "type" : "string"
           },
           "comment" : {
             "type" : "string"
@@ -531,6 +510,34 @@
               "type" : "string"
             }
           },
+          "fileDependencies" : {
+            "type" : "array",
+            "items" : {
+              "description" : "SPDX ID for File",
+              "type" : "string"
+            }
+          },
+          "fileName" : {
+            "description" : "The name of the file relative to the root of the package.",
+            "type" : "string"
+          },
+          "fileTypes" : {
+            "description" : "The type of the file.",
+            "type" : "array",
+            "items" : {
+              "description" : "The type of the file.",
+              "type" : "string",
+              "enum" : [ "OTHER", "DOCUMENTATION", "IMAGE", "VIDEO", "ARCHIVE", "SPDX", "APPLICATION", "SOURCE", "BINARY", "TEXT", "AUDIO" ]
+            }
+          },
+          "licenseComments" : {
+            "description" : "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+            "type" : "string"
+          },
+          "licenseConcluded" : {
+            "description" : "License expression for licenseConcluded.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the package.",
+            "type" : "string"
+          },
           "licenseInfoInFiles" : {
             "description" : "Licensing information that was discovered directly in the subject file. This is also considered a declared license for the file.",
             "minItems" : 1,
@@ -540,19 +547,12 @@
               "type" : "string"
             }
           },
-          "licenseConcluded" : {
-            "description" : "License expression for licenseConcluded.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the package.",
+          "noticeText" : {
+            "description" : "This field provides a place for the SPDX file creator to record potential legal notices found in the file. This may or may not include copyright statements.",
             "type" : "string"
-          },
-          "fileDependencies" : {
-            "type" : "array",
-            "items" : {
-              "description" : "SPDX ID for File",
-              "type" : "string"
-            }
           }
         },
-        "required" : [ "SPDXID", "fileName", "copyrightText", "licenseConcluded" ],
+        "required" : [ "SPDXID", "copyrightText", "fileName", "licenseConcluded" ],
         "additionalProperties" : false
       }
     },
@@ -566,6 +566,69 @@
             "type" : "string",
             "description" : "Uniquely identify any element in an SPDX document which may be referenced by other elements."
           },
+          "annotations" : {
+            "description" : "Provide additional information about an SpdxElement.",
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "annotationDate" : {
+                  "description" : "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                  "type" : "string"
+                },
+                "annotationType" : {
+                  "description" : "Type of the annotation.",
+                  "type" : "string",
+                  "enum" : [ "OTHER", "REVIEW" ]
+                },
+                "annotator" : {
+                  "description" : "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
+                  "type" : "string"
+                },
+                "comment" : {
+                  "type" : "string"
+                }
+              },
+              "required" : [ "annotationDate", "annotationType", "annotator", "comment" ],
+              "additionalProperties" : false,
+              "description" : "An Annotation is a comment on an SpdxItem by an agent."
+            }
+          },
+          "attributionTexts" : {
+            "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+            "type" : "array",
+            "items" : {
+              "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+              "type" : "string"
+            }
+          },
+          "comment" : {
+            "type" : "string"
+          },
+          "copyrightText" : {
+            "description" : "The text of copyright declarations recited in the Package or File.",
+            "type" : "string"
+          },
+          "licenseComments" : {
+            "description" : "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+            "type" : "string"
+          },
+          "licenseConcluded" : {
+            "description" : "License expression for licenseConcluded.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the package.",
+            "type" : "string"
+          },
+          "licenseInfoInSnippets" : {
+            "description" : "Licensing information that was discovered directly in the subject snippet. This is also considered a declared license for the snippet.",
+            "type" : "array",
+            "items" : {
+              "description" : "License expression for licenseInfoInSnippet.  Licensing information that was discovered directly in the subject snippet. This is also considered a declared license for the snippet.",
+              "type" : "string"
+            }
+          },
+          "name" : {
+            "description" : "Identify name of this SpdxElement.",
+            "type" : "string"
+          },
           "ranges" : {
             "description" : "This field defines the byte range in the original host file (in X.2) that the snippet information applies to",
             "minItems" : 1,
@@ -573,25 +636,6 @@
             "items" : {
               "type" : "object",
               "properties" : {
-                "startPointer" : {
-                  "type" : "object",
-                  "properties" : {
-                    "reference" : {
-                      "description" : "SPDX ID for File",
-                      "type" : "string"
-                    },
-                    "offset" : {
-                      "type" : "integer",
-                      "description" : "Byte offset in the file"
-                    },
-                    "lineNumber" : {
-                      "type" : "integer",
-                      "description" : "line number offset in the file"
-                    }
-                  },
-                  "required" : [ "reference" ],
-                  "additionalProperties" : false
-                },
                 "endPointer" : {
                   "type" : "object",
                   "properties" : {
@@ -610,81 +654,37 @@
                   },
                   "required" : [ "reference" ],
                   "additionalProperties" : false
+                },
+                "startPointer" : {
+                  "type" : "object",
+                  "properties" : {
+                    "reference" : {
+                      "description" : "SPDX ID for File",
+                      "type" : "string"
+                    },
+                    "offset" : {
+                      "type" : "integer",
+                      "description" : "Byte offset in the file"
+                    },
+                    "lineNumber" : {
+                      "type" : "integer",
+                      "description" : "line number offset in the file"
+                    }
+                  },
+                  "required" : [ "reference" ],
+                  "additionalProperties" : false
                 }
               },
-              "required" : [ "startPointer", "endPointer" ],
+              "required" : [ "endPointer", "startPointer" ],
               "additionalProperties" : false
             }
-          },
-          "licenseComments" : {
-            "description" : "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
-            "type" : "string"
-          },
-          "attributionTexts" : {
-            "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
-            "type" : "array",
-            "items" : {
-              "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
-              "type" : "string"
-            }
-          },
-          "name" : {
-            "description" : "Identify name of this SpdxElement.",
-            "type" : "string"
           },
           "snippetFromFile" : {
             "description" : "SPDX ID for File.  File containing the SPDX element (e.g. the file contaning a snippet).",
             "type" : "string"
-          },
-          "comment" : {
-            "type" : "string"
-          },
-          "copyrightText" : {
-            "description" : "The text of copyright declarations recited in the Package or File.",
-            "type" : "string"
-          },
-          "licenseInfoInSnippets" : {
-            "description" : "Licensing information that was discovered directly in the subject snippet. This is also considered a declared license for the snippet.",
-            "type" : "array",
-            "items" : {
-              "description" : "License expression for licenseInfoInSnippet.  Licensing information that was discovered directly in the subject snippet. This is also considered a declared license for the snippet.",
-              "type" : "string"
-            }
-          },
-          "annotations" : {
-            "description" : "Provide additional information about an SpdxElement.",
-            "type" : "array",
-            "items" : {
-              "type" : "object",
-              "properties" : {
-                "annotationDate" : {
-                  "description" : "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
-                  "type" : "string"
-                },
-                "comment" : {
-                  "type" : "string"
-                },
-                "annotator" : {
-                  "description" : "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
-                  "type" : "string"
-                },
-                "annotationType" : {
-                  "description" : "Type of the annotation.",
-                  "type" : "string",
-                  "enum" : [ "OTHER", "REVIEW" ]
-                }
-              },
-              "required" : [ "annotationDate", "comment", "annotator", "annotationType" ],
-              "additionalProperties" : false,
-              "description" : "An Annotation is a comment on an SpdxItem by an agent."
-            }
-          },
-          "licenseConcluded" : {
-            "description" : "License expression for licenseConcluded.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the package.",
-            "type" : "string"
           }
         },
-        "required" : [ "SPDXID", "name", "snippetFromFile", "copyrightText", "licenseConcluded" ],
+        "required" : [ "SPDXID", "copyrightText", "licenseConcluded", "name", "snippetFromFile" ],
         "additionalProperties" : false
       }
     },
@@ -701,21 +701,21 @@
           "comment" : {
             "type" : "string"
           },
+          "relatedSpdxElement" : {
+            "description" : "SPDX ID for SpdxElement.  A related SpdxElement.",
+            "type" : "string"
+          },
           "relationshipType" : {
             "description" : "Describes the type of relationship between two SPDX elements.",
             "type" : "string",
             "enum" : [ "VARIANT_OF", "COPY_OF", "PATCH_FOR", "TEST_DEPENDENCY_OF", "CONTAINED_BY", "DATA_FILE_OF", "OPTIONAL_COMPONENT_OF", "ANCESTOR_OF", "GENERATES", "CONTAINS", "OPTIONAL_DEPENDENCY_OF", "FILE_ADDED", "DEV_DEPENDENCY_OF", "DEPENDENCY_OF", "BUILD_DEPENDENCY_OF", "DESCRIBES", "PREREQUISITE_FOR", "HAS_PREREQUISITE", "PROVIDED_DEPENDENCY_OF", "DYNAMIC_LINK", "DESCRIBED_BY", "METAFILE_OF", "DEPENDENCY_MANIFEST_OF", "PATCH_APPLIED", "RUNTIME_DEPENDENCY_OF", "TEST_OF", "TEST_TOOL_OF", "DEPENDS_ON", "FILE_MODIFIED", "DISTRIBUTION_ARTIFACT", "DOCUMENTATION_OF", "GENERATED_FROM", "STATIC_LINK", "OTHER", "BUILD_TOOL_OF", "TEST_CASE_OF", "PACKAGE_OF", "DESCENDANT_OF", "FILE_DELETED", "EXPANDED_FROM_ARCHIVE", "DEV_TOOL_OF", "EXAMPLE_OF" ]
-          },
-          "relatedSpdxElement" : {
-            "description" : "SPDX ID for SpdxElement.  A related SpdxElement.",
-            "type" : "string"
           }
         },
-        "required" : [ "spdxElementId", "relationshipType", "relatedSpdxElement" ],
+        "required" : [ "spdxElementId", "relatedSpdxElement", "relationshipType" ],
         "additionalProperties" : false
       }
     }
   },
-  "required" : [ "SPDXID", "name", "spdxVersion", "dataLicense", "creationInfo" ],
+  "required" : [ "SPDXID", "creationInfo", "dataLicense", "name", "spdxVersion" ],
   "additionalProperties" : false
 }


### PR DESCRIPTION
Resolves issue#618

This schema was generated from the OWL document using a different sort
order than the previous schema.  Going forward, the sort will be more
consistent.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>