### PR TITLE
Fix typos in JSON Schema

### DIFF
--- a/schemas/spdx-schema.json
+++ b/schemas/spdx-schema.json
@@ -24,7 +24,7 @@
             "enum" : [ "OTHER", "REVIEW" ]
           },
           "annotator" : {
-            "description" : "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
+            "description" : "This field identifies the person, organization, or tool that has commented on a file, package, or the entire document.",
             "type" : "string"
           },
           "comment" : {
@@ -99,7 +99,7 @@
             "type" : "string"
           },
           "spdxDocument" : {
-            "description" : "SPDX ID for SpdxDocument.  A propoerty containing an SPDX document.",
+            "description" : "SPDX ID for SpdxDocument.  A property containing an SPDX document.",
             "type" : "string"
           }
         },
@@ -162,7 +162,7 @@
             "type" : "string"
           },
           "licenseId" : {
-            "description" : "A human readable short form license identifier for a license. The license ID is iether on the standard license oist or the form \"LicenseRef-\"[idString] where [idString] is a unique string containing letters, numbers, \".\", \"-\" or \"+\".",
+            "description" : "A human readable short form license identifier for a license. The license ID is ether on the standard license list or the form \"LicenseRef-\"[idString] where [idString] is a unique string containing letters, numbers, \".\", \"-\" or \"+\".",
             "type" : "string"
           },
           "name" : {
@@ -219,7 +219,8 @@
       "description" : "Packages, files and/or Snippets described by this SPDX document",
       "type" : "array",
       "items" : {
-        "type" : "string"
+        "type" : "string",
+        "description" : "SPDX ID for each Package, File, or Snippet."
       }
     },
     "packages" : {
@@ -248,7 +249,7 @@
                   "enum" : [ "OTHER", "REVIEW" ]
                 },
                 "annotator" : {
-                  "description" : "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
+                  "description" : "This field identifies the person, organization, or tool that has commented on a file, package, or the entire document.",
                   "type" : "string"
                 },
                 "comment" : {
@@ -261,10 +262,10 @@
             }
           },
           "attributionTexts" : {
-            "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+            "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
             "type" : "array",
             "items" : {
-              "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+              "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
               "type" : "string"
             }
           },
@@ -446,7 +447,7 @@
                   "enum" : [ "OTHER", "REVIEW" ]
                 },
                 "annotator" : {
-                  "description" : "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
+                  "description" : "This field identifies the person, organization, or tool that has commented on a file, package, or the entire document.",
                   "type" : "string"
                 },
                 "comment" : {
@@ -466,10 +467,10 @@
             }
           },
           "attributionTexts" : {
-            "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+            "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
             "type" : "array",
             "items" : {
-              "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+              "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
               "type" : "string"
             }
           },
@@ -582,7 +583,7 @@
                   "enum" : [ "OTHER", "REVIEW" ]
                 },
                 "annotator" : {
-                  "description" : "This field identifies the person, organization or tool that has commented on a file, package, or the entire document.",
+                  "description" : "This field identifies the person, organization, or tool that has commented on a file, package, or the entire document.",
                   "type" : "string"
                 },
                 "comment" : {
@@ -595,10 +596,10 @@
             }
           },
           "attributionTexts" : {
-            "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+            "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
             "type" : "array",
             "items" : {
-              "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+              "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
               "type" : "string"
             }
           },

--- a/schemas/spdx-schema.json
+++ b/schemas/spdx-schema.json
@@ -162,7 +162,7 @@
             "type" : "string"
           },
           "licenseId" : {
-            "description" : "A human readable short form license identifier for a license. The license ID is ether on the standard license list or the form \"LicenseRef-\"[idString] where [idString] is a unique string containing letters, numbers, \".\", \"-\" or \"+\".",
+            "description" : "A human readable short form license identifier for a license. The license ID is either on the standard license list or the form \"LicenseRef-\"[idString] where [idString] is a unique string containing letters, numbers, \".\", \"-\" or \"+\".",
             "type" : "string"
           },
           "name" : {


### PR DESCRIPTION
This commit includes changes from PR#586 but as a generated file.

I will create a separate PR with similar fixes to the OWL document since it will contain several other fixes.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>