### PR TITLE
Update OWL document for SPDX 2.2.2

### DIFF
--- a/ontology/spdx-ontology.owl.xml
+++ b/ontology/spdx-ontology.owl.xml
@@ -10,7 +10,7 @@
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
     <owl:Ontology rdf:about="http://spdx.org/rdf/terms">
         <owl:versionIRI rdf:resource="http://spdx.org/rdf/terms/2.2"/>
-        <rdfs:comment xml:lang="en">This specification describes the SPDX® language, defined as a dictionary of named properties and classes using W3C&apos;s RDF Technology. 
+        <rdfs:comment>This specification describes the SPDX® language, defined as a dictionary of named properties and classes using W3C&apos;s RDF Technology.
 
 SPDX® is a designed to allow the exchange of data about software packages. This information includes general information about the package, licensing information about the package as a whole, a manifest of files contained in the package and licensing information related to the contained files.
 
@@ -82,24 +82,6 @@ Known issues:</rdfs:comment>
 
     <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#algorithm">
         <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Checksum"/>
-        <rdfs:range>
-            <owl:Class>
-                <owl:unionOf rdf:parseType="Collection">
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#algorithm"/>
-                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_md5"/>
-                    </owl:Restriction>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#algorithm"/>
-                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
-                    </owl:Restriction>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#algorithm"/>
-                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha256"/>
-                    </owl:Restriction>
-                </owl:unionOf>
-            </owl:Class>
-        </rdfs:range>
         <rdfs:comment xml:lang="en">Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.</rdfs:comment>
         <ns:term_status>stable</ns:term_status>
     </owl:ObjectProperty>
@@ -178,6 +160,15 @@ Known issues:</rdfs:comment>
         <rdfs:range rdf:resource="http://spdx.org/rdf/terms#CreationInfo"/>
         <rdfs:comment xml:lang="en">The creationInfo property relates an SpdxDocument to a set of information about the creation of the SpdxDocument.</rdfs:comment>
         <ns:term_status>stable</ns:term_status>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#crossRef -->
+
+    <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#crossRef">
+        <rdfs:range rdf:resource="http://spdx.org/rdf/terms#SimpleLicensingInfo"/>
+        <rdfs:comment xml:lang="en">Cross Reference Detail for a license SeeAlso URL</rdfs:comment>
     </owl:ObjectProperty>
     
 
@@ -466,24 +457,6 @@ Known issues:</rdfs:comment>
 
     <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#referenceCategory">
         <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#ExternalRef"/>
-        <rdfs:range>
-            <owl:Class>
-                <owl:unionOf rdf:parseType="Collection">
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#referenceCategory"/>
-                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#referenceCategory_other"/>
-                    </owl:Restriction>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#referenceCategory"/>
-                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#referenceCategory_packageManager"/>
-                    </owl:Restriction>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#referenceCategory"/>
-                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#referenceCategory_security"/>
-                    </owl:Restriction>
-                </owl:unionOf>
-            </owl:Class>
-        </rdfs:range>
         <rdfs:comment xml:lang="en">Category for the external reference</rdfs:comment>
         <ns:term_status xml:lang="en">stable</ns:term_status>
     </owl:ObjectProperty>
@@ -700,7 +673,7 @@ Known issues:</rdfs:comment>
     <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#spdxDocument">
         <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#ExternalDocumentRef"/>
         <rdfs:range rdf:resource="http://spdx.org/rdf/terms#SpdxDocument"/>
-        <rdfs:comment xml:lang="en">A propoerty containing an SPDX document.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A property containing an SPDX document.</rdfs:comment>
         <ns:term_status xml:lang="en">stable</ns:term_status>
     </owl:ObjectProperty>
     
@@ -778,7 +751,7 @@ Known issues:</rdfs:comment>
     <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#attributionText">
         <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#SpdxItem"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <rdfs:comment xml:lang="en">This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include theactual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.</rdfs:comment>
+        <rdfs:comment xml:lang="en">This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.</rdfs:comment>
         <ns:term_status xml:lang="en">stable</ns:term_status>
     </owl:DatatypeProperty>
     
@@ -845,10 +818,34 @@ Known issues:</rdfs:comment>
     <!-- http://spdx.org/rdf/terms#date -->
 
     <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#date">
-        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Annotation"/>
-        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#CreationInfo"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://spdx.org/rdf/terms#Annotation"/>
+                    <rdf:Description rdf:about="http://spdx.org/rdf/terms#CreationInfo"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
         <rdfs:comment xml:lang="en">A date-time stamp.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#deprecatedVersion -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#deprecatedVersion">
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://spdx.org/rdf/terms#ListedLicense"/>
+                    <rdf:Description rdf:about="http://spdx.org/rdf/terms#ListedLicenseException"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment xml:lang="en">License list version where this license was decprecated</rdfs:comment>
         <ns:term_status xml:lang="en">stable</ns:term_status>
     </owl:DatatypeProperty>
     
@@ -893,6 +890,17 @@ Known issues:</rdfs:comment>
         <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#LicenseException"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">Text for examples in describing an SPDX element.</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#exceptionTextHtml -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#exceptionTextHtml">
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#ListedLicenseException"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment xml:lang="en">HTML representation of the License Exception Text</rdfs:comment>
         <ns:term_status xml:lang="en">stable</ns:term_status>
     </owl:DatatypeProperty>
     
@@ -983,6 +991,16 @@ Known issues:</rdfs:comment>
     
 
 
+    <!-- http://spdx.org/rdf/terms#isLive -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#isLive">
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#CrossRef"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
+        <rdfs:comment xml:lang="en">Indicate a URL is still a live accessible location on the public internet</rdfs:comment>
+    </owl:DatatypeProperty>
+    
+
+
     <!-- http://spdx.org/rdf/terms#isOsiApproved -->
 
     <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#isOsiApproved">
@@ -990,6 +1008,26 @@ Known issues:</rdfs:comment>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
         <rdfs:comment xml:lang="en">Indicates if the OSI has approved the license.</rdfs:comment>
         <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#isValid -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#isValid">
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#CrossRef"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
+        <rdfs:comment xml:lang="en">True if the URL is a valid well formed URL</rdfs:comment>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#isWayBackLink -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#isWayBackLink">
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#CrossRef"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
+        <rdfs:comment xml:lang="en">True if the License SeeAlso URL points to a Wayback archive</rdfs:comment>
     </owl:DatatypeProperty>
     
 
@@ -1016,6 +1054,17 @@ Known issues:</rdfs:comment>
     
 
 
+    <!-- http://spdx.org/rdf/terms#licenseExceptionTemplate -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#licenseExceptionTemplate">
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#LicenseException"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment xml:lang="en">Template for matching license exception text</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:DatatypeProperty>
+    
+
+
     <!-- http://spdx.org/rdf/terms#licenseExceptionText -->
 
     <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#licenseExceptionText">
@@ -1032,7 +1081,7 @@ Known issues:</rdfs:comment>
     <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#licenseId">
         <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#SimpleLicensingInfo"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <rdfs:comment xml:lang="en">A human readable short form license identifier for a license. The license ID is iether on the standard license oist or the form &quot;LicenseRef-&quot;[idString] where [idString] is a unique string containing letters, numbers, &quot;.&quot;, &quot;-&quot; or &quot;+&quot;.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A human readable short form license identifier for a license. The license ID is either on the standard license list or the form &quot;LicenseRef-&quot;[idString] where [idString] is a unique string containing letters, numbers, &quot;.&quot;, &quot;-&quot; or &quot;+&quot;.</rdfs:comment>
         <ns:term_status xml:lang="en">stable</ns:term_status>
     </owl:DatatypeProperty>
     
@@ -1061,6 +1110,27 @@ Known issues:</rdfs:comment>
     
 
 
+    <!-- http://spdx.org/rdf/terms#licenseTextHtml -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#licenseTextHtml">
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#ListedLicense"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment xml:lang="en">License text in HTML format</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#match -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#match">
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#CrossRef"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment>Status of a License List SeeAlso URL reference if it refers to a website that matches the license text.</rdfs:comment>
+    </owl:DatatypeProperty>
+    
+
+
     <!-- http://spdx.org/rdf/terms#name -->
 
     <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#name">
@@ -1079,6 +1149,15 @@ Known issues:</rdfs:comment>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">This field provides a place for the SPDX file creator to record potential legal notices found in the file. This may or may not include copyright statements.</rdfs:comment>
         <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#order -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#order">
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"/>
+        <rdfs:comment xml:lang="en">The ordinal order of this element within a list</rdfs:comment>
     </owl:DatatypeProperty>
     
 
@@ -1217,6 +1296,17 @@ Known issues:</rdfs:comment>
     
 
 
+    <!-- http://spdx.org/rdf/terms#standardLicenseHeaderHtml -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#standardLicenseHeaderHtml">
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#ListedLicense"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment xml:lang="en">HTML representation of the standard license header</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:DatatypeProperty>
+    
+
+
     <!-- http://spdx.org/rdf/terms#standardLicenseHeaderTemplate -->
 
     <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#standardLicenseHeaderTemplate">
@@ -1257,6 +1347,26 @@ Known issues:</rdfs:comment>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">The name and, optionally, contact information of the person or organization who was the immediate supplier of this package to the recipient. The supplier may be different than originator when the software has been repackaged. Values of this property must conform to the agent and tool syntax.</rdfs:comment>
         <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#timestamp -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#timestamp">
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#CrossRef"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+        <rdfs:comment xml:lang="en">Timestamp</rdfs:comment>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#url -->
+
+    <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#url">
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#CrossRef"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
+        <rdfs:comment xml:lang="en">URL Reference</rdfs:comment>
     </owl:DatatypeProperty>
     
 
@@ -1468,6 +1578,64 @@ Known issues:</rdfs:comment>
     
 
 
+    <!-- http://spdx.org/rdf/terms#CrossRef -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#CrossRef">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#url"/>
+                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#isLive"/>
+                <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#isValid"/>
+                <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#isWayBackLink"/>
+                <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#match"/>
+                <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#order"/>
+                <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#timestamp"/>
+                <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">Cross reference details for the a URL reference</rdfs:comment>
+        <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:Class>
+    
+
+
     <!-- http://spdx.org/rdf/terms#DisjunctiveLicenseSet -->
 
     <owl:Class rdf:about="http://spdx.org/rdf/terms#DisjunctiveLicenseSet">
@@ -1564,7 +1732,7 @@ Known issues:</rdfs:comment>
                 <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <rdfs:comment xml:lang="en">An ExtractedLicensingInfo represents a license or licensing notice that was found in the package. Any license text that is recognized as a license may be represented as a License rather than an ExtractedLicensingInfo.</rdfs:comment>
+        <rdfs:comment xml:lang="en">An ExtractedLicensingInfo represents a license or licensing notice that was found in a package, file or snippet. Any license text that is recognized as a license may be represented as a License rather than an ExtractedLicensingInfo.</rdfs:comment>
         <ns:term_status>stable</ns:term_status>
     </owl:Class>
     
@@ -1750,6 +1918,13 @@ Known issues:</rdfs:comment>
                 <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#licenseExceptionTemplate"/>
+                <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">An exception to a license.</rdfs:comment>
         <ns:term_status xml:lang="en">stable</ns:term_status>
     </owl:Class>
@@ -1762,13 +1937,50 @@ Known issues:</rdfs:comment>
         <rdfs:subClassOf rdf:resource="http://spdx.org/rdf/terms#License"/>
         <rdfs:subClassOf>
             <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#deprecatedVersion"/>
+                <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
                 <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#isDeprecatedLicenseId"/>
                 <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
                 <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#licenseTextHtml"/>
+                <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#standardLicenseHeaderHtml"/>
+                <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A license which is included in the SPDX License List (http://spdx.org/licenses).</rdfs:comment>
         <ns:term_status xml:lang="en">stable</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://spdx.org/rdf/terms#ListedLicenseException -->
+
+    <owl:Class rdf:about="http://spdx.org/rdf/terms#ListedLicenseException">
+        <rdfs:subClassOf rdf:resource="http://spdx.org/rdf/terms#LicenseException"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#exceptionTextHtml"/>
+                <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment>License exception specific to ListedLicenses</rdfs:comment>
     </owl:Class>
     
 
@@ -2054,6 +2266,13 @@ Known issues:</rdfs:comment>
         <rdfs:subClassOf rdf:resource="http://spdx.org/rdf/terms#AnyLicenseInfo"/>
         <rdfs:subClassOf>
             <owl:Restriction>
+                <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#crossRef"/>
+                <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">0</owl:minQualifiedCardinality>
+                <owl:onClass rdf:resource="http://spdx.org/rdf/terms#CrossRef"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
                 <owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#seeAlso"/>
                 <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">0</owl:minQualifiedCardinality>
                 <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
@@ -2069,7 +2288,7 @@ Known issues:</rdfs:comment>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#name"/>
-                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
                 <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
             </owl:Restriction>
         </rdfs:subClassOf>
@@ -3164,8 +3383,8 @@ IMAGE if the file is assoicated with an picture image file (MIME type of image/*
      -->
 
     <rdf:Description rdf:about="http://spdx.org/rdf/terms#annotator">
-        <rdfs:comment>This field identifies the person, organization or tool that has commented on a file, package, or the entire document.</rdfs:comment>
         <ns:term_status xml:lang="en">stable</ns:term_status>
+        <rdfs:comment>This field identifies the person, organization, or tool that has commented on a file, package, snippet, or the entire document.</rdfs:comment>
     </rdf:Description>
     <rdf:Description rdf:about="http://spdx.org/rdf/terms#reviewed">
         <rdfs:comment>Reviewed</rdfs:comment>

--- a/schemas/spdx-schema.json
+++ b/schemas/spdx-schema.json
@@ -24,7 +24,7 @@
             "enum" : [ "OTHER", "REVIEW" ]
           },
           "annotator" : {
-            "description" : "This field identifies the person, organization, or tool that has commented on a file, package, or the entire document.",
+            "description" : "This field identifies the person, organization, or tool that has commented on a file, package, snippet, or the entire document.",
             "type" : "string"
           },
           "comment" : {
@@ -178,7 +178,7 @@
         },
         "required" : [ "extractedText", "licenseId" ],
         "additionalProperties" : false,
-        "description" : "An ExtractedLicensingInfo represents a license or licensing notice that was found in the package. Any license text that is recognized as a license may be represented as a License rather than an ExtractedLicensingInfo."
+        "description" : "An ExtractedLicensingInfo represents a license or licensing notice that was found in a package, file or snippet. Any license text that is recognized as a license may be represented as a License rather than an ExtractedLicensingInfo."
       }
     },
     "name" : {
@@ -249,7 +249,7 @@
                   "enum" : [ "OTHER", "REVIEW" ]
                 },
                 "annotator" : {
-                  "description" : "This field identifies the person, organization, or tool that has commented on a file, package, or the entire document.",
+                  "description" : "This field identifies the person, organization, or tool that has commented on a file, package, snippet, or the entire document.",
                   "type" : "string"
                 },
                 "comment" : {
@@ -447,7 +447,7 @@
                   "enum" : [ "OTHER", "REVIEW" ]
                 },
                 "annotator" : {
-                  "description" : "This field identifies the person, organization, or tool that has commented on a file, package, or the entire document.",
+                  "description" : "This field identifies the person, organization, or tool that has commented on a file, package, snippet, or the entire document.",
                   "type" : "string"
                 },
                 "comment" : {
@@ -583,7 +583,7 @@
                   "enum" : [ "OTHER", "REVIEW" ]
                 },
                 "annotator" : {
-                  "description" : "This field identifies the person, organization, or tool that has commented on a file, package, or the entire document.",
+                  "description" : "This field identifies the person, organization, or tool that has commented on a file, package, snippet, or the entire document.",
                   "type" : "string"
                 },
                 "comment" : {


### PR DESCRIPTION
Brings the OWL document up to date with what has been used to generate the JSON schema.

This PR supersedes and obsoletes PR #491 

This PR Resolves issues #578 #532, and #459.

This PR also syncs the changes in the OWL document for PR #631

In addition to the OWL document, a newly generated JSON Schema file includes the changes related to issue #459 

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>