### PR TITLE
Make required licensing fields optional

### DIFF
--- a/chapters/file-information.md
+++ b/chapters/file-information.md
@@ -243,14 +243,14 @@ A valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions
 
 - the SPDX document creator has intentionally provided no information (no meaning should be implied by doing so).
 
-If the Concluded License is not the same as the License Information in File, a written explanation should be provided in the Comments on License field ([8.7](#8.7)). With respect to `NOASSERTION`, a written explanation in the Comments on License field ([8.7](#8.7)) is preferred. The metadata for the concluded license field is shown in Table 40.
+If the Concluded License is not the same as the License Information in File, a written explanation should be provided in the Comments on License field ([8.7](#8.7)). With respect to `NOASSERTION`, a written explanation in the Comments on License field ([8.7](#8.7)) is preferred. If the Concluded License field is not present for a file, it implies an equivalent meaning to `NOASSERTION`. The metadata for the concluded license field is shown in Table 40.
 
 **Table 40 — Metadata for the concluded license field**
 
 | Attribute | Value |
 | --------- | ----- |
-| Required | Yes |
-| Cardinality | 1..1 |
+| Required | No |
+| Cardinality | 0..1 |
 | Format | `<SPDX License Expression>` \| `NONE` \| `NOASSERTION`<br>where:<br>`<SPDX License Expression>` is a valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions.md). |
 
 ### 8.5.2 Intent
@@ -308,14 +308,14 @@ A reference to the license, denoted by LicenseRef-`[idstring]`, if the license i
 
 - the SPDX document creator has intentionally provided no information (no meaning should be implied by doing so).
 
-If license information for more than one license is contained in the file or if the license information offers the package recipient a choice of licenses, then each of the choices should be listed as a separate entry. The metadata for the license information in file field is shown in Table 41.
+If license information for more than one license is contained in the file or if the license information offers the package recipient a choice of licenses, then each of the choices should be listed as a separate entry. If the License Information in File field is not present for a file, it implies an equivalent meaning to `NOASSERTION`. The metadata for the license information in file field is shown in Table 41.
 
 **Table 41 — Metadata for the license information in file field**
 
 | Attribute | Value |
 | --------- | ----- |
-| Required | Yes |
-| Cardinality | 1..* |
+| Required | No |
+| Cardinality | 0..* |
 | Format | `<SPDX License Expression>` \|<br>["DocumentRef-"`[idstring]`":"]"LicenseRef-"`[idstring]` \|<br>\| `NONE` \| `NOASSERTION`<br>where:<br>`<SPDX License Expression>` is a valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions.md).<br>"DocumentRef-"`[idstring]`: is an optional reference to an external SPDX document as described in [6.6](document-creation-information.md#6.6)<br>`[idstring]` is a unique string containing letters, numbers, `.` and/or `-` |
 
 ### 8.6.2 Intent
@@ -402,14 +402,14 @@ Any text relating to a copyright notice, even if not complete;
 
 - the SPDX document creator has intentionally provided no information (no meaning should be implied from the absence of an assertion).
 
-The metadata for the copyright text field is shown in Table 43.
+If the Copyright Text field is not present for a file, it implies an equivalent meaning to `NOASSERTION`. The metadata for the copyright text field is shown in Table 43.
 
 **Table 43 — Metadata for the copyright text field**
 
 | Attribute | Value |
 | --------- | ----- |
-| Required | Yes |
-| Cardinality | 1..1 |
+| Required | No |
+| Cardinality | 0..1 |
 | Format | Free form text that can span multiple lines \| `NONE` \| `NOASSERTION` |
 
 ### 8.8.2 Intent

--- a/chapters/package-information.md
+++ b/chapters/package-information.md
@@ -857,7 +857,7 @@ The options to populate this field are limited to:
 
     - the SPDX document creator has intentionally provided no information (no meaning should be implied by doing so).
 
-If the Concluded License is not the same as the Declared License ([7.15](#7.15)), a written explanation should be provided in the Comments on License field ([7.16](#7.16)). With respect to `NOASSERTION`, a written explanation in the Comments on License field ([7.16](#7.16)) is preferred.
+If the Concluded License is not the same as the Declared License ([7.15](#7.15)), a written explanation should be provided in the Comments on License field ([7.16](#7.16)). With respect to `NOASSERTION`, a written explanation in the Comments on License field ([7.16](#7.16)) is preferred. If the Concluded License field is not present in a package, it implies an equivalent meaning to `NOASSERTION`.
 
 The metadata for the concluded license field is shown in Table 25.
 
@@ -865,8 +865,8 @@ The metadata for the concluded license field is shown in Table 25.
 
 | Attribute | Value |
 | --------- | ----- |
-| Required | Yes |
-| Cardinality | 1..1 |
+| Required | No |
+| Cardinality | 0..1 |
 | Format | `<SPDX License Expression>` \| `NONE` \| `NOASSERTION`<br>where:<br>`<SPDX License Expression>` is a valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions.md). |
 
 ### 7.13.2 Intent
@@ -925,14 +925,14 @@ The options to populate this field are limited to:
 
     - the SPDX document creator has intentionally provided no information (no meaning should be implied by doing so).
 
-The metadata for the all license information from files field is shown in Table 26.
+If the All Licenses Information from Files field is not present for a package and `FilesAnalyzed` field ([7.8](#7.8)) for that same pacakge is `true` or omitted, it implies an equivalent meaning to `NOASSERTION`. The metadata for all license information from files field is shown in Table 26.
 
 **Table 26 — Metadata for the all licenses information from files field**
 
 | Attribute | Value |
 | --------- | ----- |
-| Required | Yes |
-| Cardinality | 0..* if `FilesAnalyzed` ([7.8](#7.8)) is `true` or omitted, 0..0 (shall be omitted) if `FilesAnalyzed` is `false`. |
+| Required | No |
+| Cardinality | 0..* (optional) if `FilesAnalyzed` ([7.8](#7.8)) is `true` or omitted, 0..0 (must be omitted) if `FilesAnalyzed` is `false`. |
 | Format | `<shortIdentifier>` ([Annex A](SPDX-license-list.md#A.1)) \| ["DocumentRef-"`[idstring]`:]"LicenseRef-"`[idstring]` \| `NONE` \| `NOASSERTION`<br>where:<br><ul><li> "DocumentRef-"`[idstring]` is an optional reference to an external SPDX document as described in [6.6](document-creation-information.md#6.6).</li><li>`[idstring]` is a unique string containing letters, numbers, `.`, or `-`. </li></ul> |
 
 ### 7.14.2 Intent
@@ -984,14 +984,14 @@ The options to populate this field are limited to:
 
     - the SPDX document creator has intentionally provided no information (no meaning should be implied by doing so).
 
-The metadata for the declared license field is shown in Table 27.
+If the Declared License field is not present for a package, it implies an equivalent meaning to `NOASSERTION`. The metadata for the declared license field is shown in Table 27.
 
 **Table 27 — Metadata for the declared license field**
 
 | Attribute | Value |
 | --------- | ----- |
-| Required | Yes |
-| Cardinality | 1..1 |
+| Required | No |
+| Cardinality | 0..1 |
 | Format | `<SPDX License Expression>` \| `NONE` \| `NOASSERTION`<br>where:<br><ul><li>`<SPDX License Expression>` is a valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions.md).</li></ul> |
 
 ### 7.15.2 Intent
@@ -1089,14 +1089,14 @@ Identify the copyright holders of the package, as well as any dates present. Thi
 
     - the SPDX document creator has intentionally provided no information (no meaning should be implied by doing so).
 
-The metadata for the copyright text field is shown in Table 29.
+If the Copyright Text field is not present for a package, it implies an equivalent meaning to `NOASSERTION`. The metadata for the copyright text field is shown in Table 29.
 
 **Table 29 — Metadata for the copyright text field**
 
 | Attribute | Value |
 | --------- | ----- |
-| Required | Yes |
-| Cardinality | 1..1 |
+| Required | No |
+| Cardinality | 0..1 |
 | Format | Free form text that can span multiple lines \| `NONE` \| `NOASSERTION` |
 
 ### 7.17.2 Intent

--- a/chapters/snippet-information.md
+++ b/chapters/snippet-information.md
@@ -243,14 +243,14 @@ A valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions
 
 - the SPDX document creator has intentionally provided no information (no meaning should be implied by doing so).
 
-If the Concluded License is not the same as the License Information in Snippet, a written explanation should be provided in the Comments on License field (see [9.7](#9.7)). With respect to `NOASSERTION`, a written explanation in the Comments on License field (see [9.7](#9.7)) is preferred. The metadata for the snippet concluded license field is shown in Table 56.
+If the Concluded License is not the same as the License Information in Snippet, a written explanation should be provided in the Comments on License field (see [9.7](#9.7)). With respect to `NOASSERTION`, a written explanation in the Comments on License field (see [9.7](#9.7)) is preferred. If the Snippet Concluded License field is not present for a snippet, it implies an equivalent meaning to `NOASSERTION`. The metadata for the snippet concluded license field is shown in Table 56.
 
 **Table 56 — Metadata for the snippet concluded license field**
 
 | Attribute | Value |
 | --------- | ----- |
-| Required | Yes |
-| Cardinality | 1..1 |
+| Required | No |
+| Cardinality | 0..1 |
 | Format | `<SPDX License Expression>` \| `NONE` \| `NOASSERTION`<br>where:<br>`<SPDX License Expression>` is a valid SPDX License Expression as defined in [Annex D](SPDX-license-expressions.md). |
 
 ### 9.5.2 Intent
@@ -310,7 +310,7 @@ A reference to the license, denoted by LicenseRef-`[idstring]`, if the license i
 
 - the SPDX document creator has intentionally provided no information (no meaning should be implied by doing so).
 
-If license information for more than one license is contained in the snippet or if the license information offers a choice of licenses, then each of the choices should be listed as a separate entry. The metadata for the license information in snippet field is shown in Table 57.
+If license information for more than one license is contained in the snippet or if the license information offers a choice of licenses, then each of the choices should be listed as a separate entry. If the License Information in Snippet field is not present for a snippet, it implies an equivalent meaning to `NOASSERTION`. The metadata for the license information in snippet field is shown in Table 57.
 
 **Table 57 — Metadata for the license information in snippet field**
 
@@ -401,14 +401,14 @@ any text relating to a copyright notice, even if not complete;
 
 `NOASSERTION`, if the SPDX document creator has not examined the contents of the actual snippet or if the SPDX document creator has intentionally provided no information (no meaning should be implied from the absence of an assertion).
 
-The metadata for the snippet copyright text field is shown in Table 59.
+If the Snippet Copyright Text field is not present for a snippet, it implies an equivalent meaning to `NOASSERTION`. The metadata for the snippet copyright text field is shown in Table 59.
 
 **Table 59 — Metadata for the snippet copyright text field**
 
 | Attribute | Value |
 | --------- | ----- |
-| Required | Yes |
-| Cardinality | 1..1 |
+| Required | No |
+| Cardinality | 0..1 |
 | Format | Free form text that can span multiple lines \| `NONE` \| `NOASSERTION` |
 
 ### 9.8.2 Intent


### PR DESCRIPTION
Currently, licensing fields like `Concluded License`, `Declared License`
and `Copyright Text` are required for package elements. Given that we
are working to communicate security information in SPDX 2.3, this commit
proposes a change to make the fields related to [package, file, snippet]
licensing optional so those who want to use SPDX to only communicate
security information can do that without the bloat of NOASSERTION
licensing field values.

This PR specifically changes the following fields to optional:
```
Package Concluded license - 7.13
Package Declared license - 7.15
Package Copyright text - 7.17
File Concluded license - 8.5
License information in file - 8.6
File Copyright text - 8.8
Snippet Concluded license - 9.5
Snippet Copyright text - 9.8
```


Resolves #634

Signed-off-by: Rose Judge <rjudge@vmware.com>