### PR TITLE
Typo: fix missing hyphen in 7.4.3 RDF Example 2

### DIFF
--- a/chapters/package-information.md
+++ b/chapters/package-information.md
@@ -160,7 +160,7 @@ EXAMPLE 2 RDF: Property `spdx:packageFileName` in class `spdx:Package`
 ```text
 <Package rdf:about="...">
     ...
-    <packageFileName>glibc 2.11.1.tar.gz</packageFileName>
+    <packageFileName>glibc-2.11.1.tar.gz</packageFileName>
     ...
 </Package>
 ```


### PR DESCRIPTION
This commit fixes a missing hyphen typo in RDF Example 2 in section
7.4.3.

Fixes #604

Signed-off-by: Rose Judge <rjudge@vmware.com>