### PR TITLE
Reinsert language about SPDX-Metadata in DataLicense section

### DIFF
--- a/chapters/document-creation-information.md
+++ b/chapters/document-creation-information.md
@@ -46,6 +46,7 @@ http://www.w3.org/1999/02/22-rdf-syntax-ns#
 
 Compliance with this document includes populating the SPDX fields therein with data related to such fields ("SPDX-Metadata"). This document contains numerous fields where an SPDX document creator may provide relevant explanatory text in SPDX-Metadata.
 Without opining on the lawfulness of "database rights" (in jurisdictions where applicable), such explanatory text is copyrightable subject matter in most Berne Convention countries.
+By using the SPDX specification, or any portion hereof, you hereby agree that any copyright rights (as determined by your jurisdiction) in any SPDX-Metadata, including without limitation explanatory text, shall be subject to the terms of the Creative Commons CC0 1.0 Universal license. For SPDX-Metadata not containing any copyright rights, you hereby agree and acknowledge that the SPDX-Metadata is provided to you “as-is” and without any representations or warranties of any kind concerning the SPDX-Metadata, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non-infringement, or the absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law.
 The metadata for the data license field is shown in Table 3.
 
 **Table 3 — Metadata for the data license field**


### PR DESCRIPTION
This commit reinserts the DataLicense description language that had been present in all spec versions since 1.1 regarding use of SPDX-Metadata, which appears to have been incorrectly removed in 2.2.1 (commit 938d9f17)

Fixes #492

Signed-off-by: Steve Winslow <steve@swinslow.net>