### PR TITLE
Make creators attribute mandatory in JSON schema

### DIFF
--- a/schemas/spdx-schema.json
+++ b/schemas/spdx-schema.json
@@ -63,7 +63,7 @@
           "type" : "string"
         }
       },
-      "required" : [ "created" ],
+      "required" : [ "created, creators" ],
       "additionalProperties" : false,
       "description" : "One instance is required for each SPDX file produced. It provides the necessary information for forward and backward compatibility for processing tools."
     },


### PR DESCRIPTION
In the JSON schema, the `creators` field of `createrInfo` was not listed as a `required` although the latest specification denotes the creator as mandatory (cp. 2.8.3 Cardinality, p. 19, [SPEC](https://spdx.dev/wp-content/uploads/sites/41/2020/08/SPDX-specification-2-2.pdf)).