### PR TITLE
Same text in tag:value and RDF examples

### DIFF
--- a/chapters/other-licensing-information-detected.md
+++ b/chapters/other-licensing-information-detected.md
@@ -80,7 +80,7 @@ If indeed full text of license present in File:
 ExtractedText: <text>"THE WHISKEY-WARE LICENSE": whiskeyfan@example.com
 wrote this file. As long as you retain this notice you can do whatever
 you want with this stuff. If we meet some day, and you think this stuff
-is worth it, you can buy me a bottle of whiskey in return </text>
+is worth it, you can buy me a bottle of whiskey in return.</text>
 ```
 
 EXAMPLE 2 RDF: Property `spdx:extractedText` in class `spdx:ExtractedLicensingInfo`


### PR DESCRIPTION
In `other-licensing-information-detected.md`, add a full stop at the end of the sentence, so that the text is the same in tag:value and RDF.

Signed-off-by: Marc-Etienne Vargenau <marc-etienne.vargenau@nokia.com>