### PR TITLE
Spelling: filesAnnalyzed --> filesAnalyzed

### DIFF
--- a/chapters/diffs-from-previous-editions.md
+++ b/chapters/diffs-from-previous-editions.md
@@ -74,7 +74,7 @@ Differences from Earlier SPDX Versions            | N/A           | Annex J/I* |
 
 * Snippets have been added to allow a portion of a file to be identified as having different properties from the file it resides in.  The use of snippets is completely optional and it is not mandatory for snippets to be identified. See section 5 Snippet Information for further details on the fields available to describe snippets.
 
-* External Packages can now be refered to in SPDX documents.  When there is no SPDX file information available to document the content of these external packages, then the filesAnalyzed attribute on a package should be set to false. See section 3.8 Files Analyzed for more information.
+* External Packages can now be referred to in SPDX documents.  When there is no SPDX file information available to document the content of these external packages, then the filesAnalyzed attribute on a package should be set to false. See section 3.8 Files Analyzed for more information.
 
 * Packages are now able to associate with an “External Reference” which allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package.   See: section 3.21  External Reference, 3.22 External Reference Comment and Appendix VI:  External Repository Identifiers for
 more information.

--- a/chapters/diffs-from-previous-editions.md
+++ b/chapters/diffs-from-previous-editions.md
@@ -74,7 +74,7 @@ Differences from Earlier SPDX Versions            | N/A           | Annex J/I* |
 
 * Snippets have been added to allow a portion of a file to be identified as having different properties from the file it resides in.  The use of snippets is completely optional and it is not mandatory for snippets to be identified. See section 5 Snippet Information for further details on the fields available to describe snippets.
 
-* External Packages can now be refered to in SPDX documents.  When there is no SPDX file information available to document the content of these external packages, then the filesAnnalyzed attribute on a package should be set to false. See section 3.8 Files Analyzed for more information.
+* External Packages can now be refered to in SPDX documents.  When there is no SPDX file information available to document the content of these external packages, then the filesAnalyzed attribute on a package should be set to false. See section 3.8 Files Analyzed for more information.
 
 * Packages are now able to associate with an “External Reference” which allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package.   See: section 3.21  External Reference, 3.22 External Reference Comment and Appendix VI:  External Repository Identifiers for
 more information.


### PR DESCRIPTION
In `chapters/diffs-from-previous-editions.md`, fix spelling.

```
filesAnnalyzed --> filesAnalyzed
```

Signed-off-by: Marc-Etienne Vargenau marc-etienne.vargenau@nokia.com