### PR TITLE
Change to not to use requirements.txt for fixing #705

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,6 @@ on:
 jobs:
   build_current:
     name: Build current
-    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     container: python:3
     steps:
@@ -13,7 +12,7 @@ jobs:
       with:
         ref: 'master'
     - name: Install pre-requisites
-      run: pip install -r requirements.txt
+      run: pip install mkdocs==1.3.0 json-schema-for-humans==0.39.5
     - name: Build
       run: mkdocs build -v --clean
     - name: Schema
@@ -25,7 +24,6 @@ jobs:
         path: ./site
   build_v2-draft:
     name: Build v2-draft
-    if: github.ref == 'refs/heads/development/v2.3'
     runs-on: ubuntu-latest
     container: python:3
     steps:
@@ -33,7 +31,7 @@ jobs:
       with:
         ref: 'development/v2.3'
     - name: Install pre-requisites
-      run: pip install -r requirements.txt
+      run: pip install mkdocs==1.3.0 json-schema-for-humans==0.39.5
     - name: Build
       run: mkdocs build -v --clean
     - name: Schema

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-mkdocs==1.3.0
-json-schema-for-humans==0.39.5
-


### PR DESCRIPTION
If requirements.txt exists in a separate file, we have to modify all monitored branches if the dependent libraries in requirements.txt need to be upgraded.
Therefore, I re-documented all dependent library installations in the publish.yml.
With this change, from now on we only need to maintain and update the publish.yml of the default branch for the generation of github pages.
Signed-off-by: Norio Kobota <norio.kobota@sony.com>