### PR TITLE
Add mapping of NTIA Minimum SBOM Elements to SPDX Fields

### DIFF
--- a/chapters/how-to-use.md
+++ b/chapters/how-to-use.md
@@ -178,3 +178,36 @@ One can also use it to refer to guidance related to a vulnerability such as CISA
   "referenceType" : "url"
 } ]
 ```
+
+## G.2 Satisfying NTIA Minimum Elements for an SBOM using SPDX
+
+### G.2.1 US Executive Order 14028 Minimum Elements for an SBOM
+
+US Executive Order 14028 in conjunction with the National Telecommunications and Information Administration (NTIA) outlined minimum elements for an SBOM. The minimum elements are detailed in [NTIA's Framing Software Component Transparency: Establishing a Common Software Bill of Maternials](https://www.ntia.gov/files/ntia/publications/framingsbom_20191112.pdf) and [The Minimum Elements for a SBOM](https://www.ntia.doc.gov/files/ntia/publications/sbom_minimum_elements_report.pdf) documents and summarized below:
+
+| SBOM Minimum Field | Description |
+| ----------- | :----------- |
+| Author Name | Author of the SBOM entry (this may not always be the supplier). |
+| Supplier Name  | Name or identity of the supplier of the component in the SBOM entry. |
+| Component Name | Designation assigned to a unit of software defined by the original supplier. |
+| Version String | Version used to identify a component. |
+| Component Hash | A cryptographic hash to uniquely identify a component. |
+| Unique Identifier | A unique identifier to help identify components or serve as a look-up key for relevant databases. |
+| Relationship | Characterizing the relationship that an upstream component X is included in software Y. |
+| Timestamp | Record of the date and time of the SBOM data assembly. |
+
+
+### G.2.2 Mapping NTIA Minimum Elements to SPDX Fields
+
+The SPDX Specification contains fields able to address each of the NTIA minimum required data fields.
+
+| NTIA SBOM Minimum Field | Satisfying SPDX field |
+| ----------- | :----------- |
+| Author Name | (6.8) Creator |
+| Supplier Name | (7.5) Package Supplier |
+| Component Name | (7.1) Package Name |
+| Version String | (7.3) Package Version |
+| Component Hash | (7.10) Package Checksum |
+| Unique Identifier | (7.2) Package SPDX Identifier <br>(6.5) SPDX Document Namespace</br> |
+| Relationship | (11.1) Relationship: `CONTAINS`, `DESCRIBES` <br>The document must `DESCRIBES` at least one package.</br> |
+| Timestamp | (6.9) Created |


### PR DESCRIPTION
This commit adds information about which SPDX fields map to the NTIA
Minimum Elements for an SBOM.

Signed-off-by: Rose Judge <rjudge@vmware.com>