### PR TITLE
Remove range from FileType in Ontology

### DIFF
--- a/ontology/spdx-ontology.owl.ttl
+++ b/ontology/spdx-ontology.owl.ttl
@@ -164,25 +164,6 @@ xsd:date rdf:type rdfs:Datatype .
 ###  http://spdx.org/rdf/terms#fileType
 :fileType rdf:type owl:ObjectProperty ;
           rdfs:domain :File ;
-          rdfs:range [ rdf:type owl:Class ;
-                       owl:unionOf ( [ rdf:type owl:Restriction ;
-                                       owl:onProperty :fileType ;
-                                       owl:hasValue :fileType_archive
-                                     ]
-                                     [ rdf:type owl:Restriction ;
-                                       owl:onProperty :fileType ;
-                                       owl:hasValue :fileType_binary
-                                     ]
-                                     [ rdf:type owl:Restriction ;
-                                       owl:onProperty :fileType ;
-                                       owl:hasValue :fileType_other
-                                     ]
-                                     [ rdf:type owl:Restriction ;
-                                       owl:onProperty :fileType ;
-                                       owl:hasValue :fileType_source
-                                     ]
-                                   )
-                     ] ;
           rdfs:comment "The type of the file."@en ;
           ns:term_status "stable" .
 

--- a/ontology/spdx-ontology.owl.xml
+++ b/ontology/spdx-ontology.owl.xml
@@ -242,28 +242,6 @@ Known issues:
 
     <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#fileType">
         <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#File"/>
-        <rdfs:range>
-            <owl:Class>
-                <owl:unionOf rdf:parseType="Collection">
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#fileType"/>
-                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#fileType_archive"/>
-                    </owl:Restriction>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#fileType"/>
-                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#fileType_binary"/>
-                    </owl:Restriction>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#fileType"/>
-                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#fileType_other"/>
-                    </owl:Restriction>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://spdx.org/rdf/terms#fileType"/>
-                        <owl:hasValue rdf:resource="http://spdx.org/rdf/terms#fileType_source"/>
-                    </owl:Restriction>
-                </owl:unionOf>
-            </owl:Class>
-        </rdfs:range>
         <rdfs:comment xml:lang="en">The type of the file.</rdfs:comment>
         <ns:term_status>stable</ns:term_status>
     </owl:ObjectProperty>


### PR DESCRIPTION
The enumeration values of file type is defined by the type associated with each individual value, so there is no need for a range.

Fixes #745 

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>