### PR TITLE
Fix minor ontology errors

### DIFF
--- a/ontology/spdx-ontology.owl.ttl
+++ b/ontology/spdx-ontology.owl.ttl
@@ -140,6 +140,7 @@ xsd:date rdf:type rdfs:Datatype .
 ###  http://spdx.org/rdf/terms#externalDocumentRef
 :externalDocumentRef rdf:type owl:ObjectProperty ;
                      rdfs:domain :SpdxDocument ;
+                     rdfs:range :ExternalDocumentRef ;
                      rdfs:comment "Identify any external SPDX documents referenced within this SPDX document."@en ;
                      ns:term_status "stable"@en .
 
@@ -170,8 +171,8 @@ xsd:date rdf:type rdfs:Datatype .
 
 ###  http://spdx.org/rdf/terms#hasExtractedLicensingInfo
 :hasExtractedLicensingInfo rdf:type owl:ObjectProperty ;
-                           rdfs:domain :ExtractedLicensingInfo ,
-                                       :SpdxDocument ;
+                           rdfs:domain :SpdxDocument ;
+                           rdfs:range :ExtractedLicensingInfo ;
                            rdfs:comment "Indicates that a particular ExtractedLicensingInfo was defined in the subject SpdxDocument."@en ;
                            ns:term_status "stable"@en .
 
@@ -311,6 +312,7 @@ If the licenseInfoInSnippet field is not present for a snippet, it implies an eq
 ###  http://spdx.org/rdf/terms#primaryPackagePurpose
 :primaryPackagePurpose rdf:type owl:ObjectProperty ;
                        rdfs:domain :Package ;
+                       rdfs:range :Purpose ;
                        rdfs:comment "This field provides information about the primary purpose of the identified package. Package Purpose is intrinsic to how the package is being used rather than the content of the package."@en ;
                        ns:term_status "stable"@en .
 
@@ -326,6 +328,7 @@ If the licenseInfoInSnippet field is not present for a snippet, it implies an eq
 ###  http://spdx.org/rdf/terms#referenceCategory
 :referenceCategory rdf:type owl:ObjectProperty ;
                    rdfs:domain :ExternalRef ;
+                   rdfs:range :ReferenceCategory ;
                    rdfs:comment "Category for the external reference"@en ;
                    ns:term_status "stable"@en .
 
@@ -518,10 +521,6 @@ If the licenseInfoInSnippet field is not present for a snippet, it implies an eq
               rdfs:range :SpdxDocument ;
               rdfs:comment "A property containing an SPDX document."@en ;
               ns:term_status "stable"@en .
-
-
-###  http://www.w3.org/2000/01/rdf-schema#member
-rdfs:member rdf:type owl:ObjectProperty .
 
 
 ###  http://www.w3.org/2009/pointers#endPointer
@@ -871,6 +870,7 @@ If the copyrightText field is not present, it implies an equivalent meaning to N
 
 ###  http://spdx.org/rdf/terms#order
 :order rdf:type owl:DatatypeProperty ;
+       rdfs:domain :CrossRef ;
        rdfs:range xsd:nonNegativeInteger ;
        rdfs:comment "The ordinal order of this element within a list"@en .
 
@@ -993,7 +993,7 @@ If the copyrightText field is not present, it implies an equivalent meaning to N
 
 ###  http://spdx.org/rdf/terms#standardLicenseHeaderTemplate
 :standardLicenseHeaderTemplate rdf:type owl:DatatypeProperty ;
-                               rdfs:domain :ListedLicense ;
+                               rdfs:domain :License ;
                                rdfs:range xsd:string ;
                                rdfs:comment "License template which describes sections of the license header which can be varied. See License Template section of the specification for format information."@en ;
                                ns:term_status "stable"@en .

--- a/ontology/spdx-ontology.owl.ttl
+++ b/ontology/spdx-ontology.owl.ttl
@@ -320,7 +320,7 @@ If the licenseInfoInSnippet field is not present for a snippet, it implies an eq
 ###  http://spdx.org/rdf/terms#range
 :range rdf:type owl:ObjectProperty ;
        rdfs:domain :Snippet ;
-       rdfs:range <http://www.w3.org/2009/pointers#CompoundPointer> ;
+       rdfs:range <http://www.w3.org/2009/pointers#StartEndPointer> ;
        rdfs:comment "This field defines the byte range in the original host file (in X.2) that the snippet information applies to"@en ;
        ns:term_status "stable"@en .
 

--- a/ontology/spdx-ontology.owl.xml
+++ b/ontology/spdx-ontology.owl.xml
@@ -209,6 +209,7 @@ Known issues:
 
     <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#externalDocumentRef">
         <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#SpdxDocument"/>
+        <rdfs:range rdf:resource="http://spdx.org/rdf/terms#ExternalDocumentRef"/>
         <rdfs:comment xml:lang="en">Identify any external SPDX documents referenced within this SPDX document.</rdfs:comment>
         <ns:term_status xml:lang="en">stable</ns:term_status>
     </owl:ObjectProperty>
@@ -251,8 +252,8 @@ Known issues:
     <!-- http://spdx.org/rdf/terms#hasExtractedLicensingInfo -->
 
     <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#hasExtractedLicensingInfo">
-        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#ExtractedLicensingInfo"/>
         <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#SpdxDocument"/>
+        <rdfs:range rdf:resource="http://spdx.org/rdf/terms#ExtractedLicensingInfo"/>
         <rdfs:comment xml:lang="en">Indicates that a particular ExtractedLicensingInfo was defined in the subject SpdxDocument.</rdfs:comment>
         <ns:term_status xml:lang="en">stable</ns:term_status>
     </owl:ObjectProperty>
@@ -437,6 +438,7 @@ If the licenseInfoInSnippet field is not present for a snippet, it implies an eq
 
     <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#primaryPackagePurpose">
         <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Package"/>
+        <rdfs:range rdf:resource="http://spdx.org/rdf/terms#Purpose"/>
         <rdfs:comment xml:lang="en">This field provides information about the primary purpose of the identified package. Package Purpose is intrinsic to how the package is being used rather than the content of the package.</rdfs:comment>
         <ns:term_status xml:lang="en">stable</ns:term_status>
     </owl:ObjectProperty>
@@ -458,6 +460,7 @@ If the licenseInfoInSnippet field is not present for a snippet, it implies an eq
 
     <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#referenceCategory">
         <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#ExternalRef"/>
+        <rdfs:range rdf:resource="http://spdx.org/rdf/terms#ReferenceCategory"/>
         <rdfs:comment xml:lang="en">Category for the external reference</rdfs:comment>
         <ns:term_status xml:lang="en">stable</ns:term_status>
     </owl:ObjectProperty>
@@ -678,12 +681,6 @@ If the licenseInfoInSnippet field is not present for a snippet, it implies an eq
         <rdfs:comment xml:lang="en">A property containing an SPDX document.</rdfs:comment>
         <ns:term_status xml:lang="en">stable</ns:term_status>
     </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.w3.org/2000/01/rdf-schema#member -->
-
-    <owl:ObjectProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#member"/>
     
 
 
@@ -1174,6 +1171,7 @@ If the copyrightText field is not present, it implies an equivalent meaning to N
     <!-- http://spdx.org/rdf/terms#order -->
 
     <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#order">
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#CrossRef"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"/>
         <rdfs:comment xml:lang="en">The ordinal order of this element within a list</rdfs:comment>
     </owl:DatatypeProperty>
@@ -1341,7 +1339,7 @@ If the copyrightText field is not present, it implies an equivalent meaning to N
     <!-- http://spdx.org/rdf/terms#standardLicenseHeaderTemplate -->
 
     <owl:DatatypeProperty rdf:about="http://spdx.org/rdf/terms#standardLicenseHeaderTemplate">
-        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#ListedLicense"/>
+        <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#License"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">License template which describes sections of the license header which can be varied. See License Template section of the specification for format information.</rdfs:comment>
         <ns:term_status xml:lang="en">stable</ns:term_status>

--- a/ontology/spdx-ontology.owl.xml
+++ b/ontology/spdx-ontology.owl.xml
@@ -449,7 +449,7 @@ If the licenseInfoInSnippet field is not present for a snippet, it implies an eq
 
     <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#range">
         <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#Snippet"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2009/pointers#CompoundPointer"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2009/pointers#StartEndPointer"/>
         <rdfs:comment xml:lang="en">This field defines the byte range in the original host file (in X.2) that the snippet information applies to</rdfs:comment>
         <ns:term_status xml:lang="en">stable</ns:term_status>
     </owl:ObjectProperty>


### PR DESCRIPTION
Fixes the following items from #757:

- `1.` `primaryPackagePurpose` has no range (should be `Purpose`)
- `2.` `referenceCategory` has no range (should be `ReferenceCategory`)
- `3.` `externalDocumentRef` has no range (should be `ExternalDocumentRef`)
- `4.` `order` has no domain (should be `CrossRef`)
- `8.` there is a reference to `http://www.w3.org/2000/01/rdf-schema#member` which is confusing, given that we have our own `http://spdx.org/rdf/terms#member`
- `10.` `License` has `licenseText`, `standardLicenseTemplate`, `standardLicenseHeader`, and `standardLicenseHeaderTemplate`.  `ListedLicense` has `licenseTextHtml` `standardLicenseHeaderHtml`.  However, `standardLicenseHeaderTemplate` has domain `ListedLicense` instead of `License`.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>