### PR TITLE
Fix continuous integration DCO sign-off check

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,22 @@
+name: Check for DCO sign-off messages
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  dco:
+    name: Check for DCO sign-off messages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dco-check
+        run: sudo apt install -y python3-pip && pip install dco-check
+      - name: Run `dco-check`
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: dco-check


### PR DESCRIPTION
This commit introduces to this repository the same DCO check as in the [SPDX Canonical Serialisation specification repository](https://github.com/spdx/canonical-serialisation) (with some minor modifications).

Some recent pull requests have been failing the automated checks (<https://github.com/spdx/spdx-spec/pull/758> for instance). The intention of this commit is to replace the 'GitHub App' DCO check with the `dco-check` open source Python package, which does not fail for such pull requests.

After merging this pull request, the commit will need to be merged/rebased into the other branches on which checks should be run. Also, the DCO GitHub App will need to be disabled by a SPDX organisation admin who holds sufficient GitHub permissions.

`Signed-off-by: Sebastian Crane <seabass-labrax@gmx.com>`