### PR TITLE
Update SPDX license list Annex to version 3.17

### DIFF
--- a/chapters/SPDX-license-list.md
+++ b/chapters/SPDX-license-list.md
@@ -48,17 +48,18 @@ The OSI column in Table A.1 refers to Open Source Initiative licenses [see Refer
 | Apple MIT License                                                            | [AML](https://spdx.org/licenses/AML.html)                                                                   |      |     |
 | Academy of Motion Picture Arts and Sciences BSD                              | [AMPAS](https://spdx.org/licenses/AMPAS.html)                                                               |      |     |
 | ANTLR Software Rights Notice                                                 | [ANTLR-PD](https://spdx.org/licenses/ANTLR-PD.html)                                                         |      |     |
+| ANTLR Software Rights Notice with license fallback                           | [ANTLR-PD-fallback](https://spdx.org/licenses/ANTLR-PD-fallback.html)                                                         |      |     |
 | Apache License 1.0                                                           | [Apache-1.0](https://spdx.org/licenses/Apache-1.0.html)                                                     | Y    |     |
 | Apache License 1.1                                                           | [Apache-1.1](https://spdx.org/licenses/Apache-1.1.html)                                                     | Y    | Y   |
 | Apache License 2.0                                                           | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html)                                                     | Y    | Y   |
 | Adobe Postscript AFM License                                                 | [APAFML](https://spdx.org/licenses/APAFML.html)                                                             |      |     |
 | Adaptive Public License 1.0                                                  | [APL-1.0](https://spdx.org/licenses/APL-1.0.html)                                                           |      | Y   |
-| App::s2p License                                                             | [App-2sp](https://spdx.org/licenses/App-s2p.html)                                                           |      |     |
+| App::s2p License                                                             | [App-s2p](https://spdx.org/licenses/App-s2p.html)                                                           |      |     |
 | Apple Public Source License 1.0                                              | [APSL-1.0](https://spdx.org/licenses/APSL-1.0.html)                                                         |      | Y   |
 | Apple Public Source License 1.1                                              | [APSL-1.1](https://spdx.org/licenses/APSL-1.1.html)                                                         |      | Y   |
 | Apple Public Source License 1.2                                              | [APSL-1.2](https://spdx.org/licenses/APSL-1.2.html)                                                         |      | Y   |
 | Apple Public Source License 2.0                                              | [APSL-2.0](https://spdx.org/licenses/APSL-2.0.html)                                                         | Y    | Y   |
-| Arphic Public Source                                                         | [Arphic-1999](https://spdx.org/licenses/Arphic-1999.html)                                                   |      |     |
+| Arphic Public License                                                        | [Arphic-1999](https://spdx.org/licenses/Arphic-1999.html)                                                   |      |     |
 | Artistic License 1.0                                                         | [Artistic-1.0](https://spdx.org/licenses/Artistic-1.0.html)                                                 |      | Y   |
 | Artistic License 1.0 w/clause 8                                              | [Artistic-1.0-cl8](https://spdx.org/licenses/Artistic-1.0-cl8.html)                                         |      | Y   |
 | Artistic License 1.0 (Perl)                                                  | [Artistic-1.0-Perl](https://spdx.org/licenses/Artistic-1.0-Perl.html)                                       |      | Y   |
@@ -67,6 +68,7 @@ The OSI column in Table A.1 refers to Open Source Initiative licenses [see Refer
 | Bahyph License                                                               | [Bahyph](https://spdx.org/licenses/Bahyph.html)                                                             |      |     |
 | Barr License                                                                 | [Barr](https://spdx.org/licenses/Barr.html)                                                                 |      |     |
 | Beerware License                                                             | [Beerware](https://spdx.org/licenses/Beerware.html)                                                         |      |     |
+| BitStream Vera Font License                                                  | [Bitstream-Vera](https://spdx.org/licenses/Bitstream-Vera.html)                                             |      |     |
 | BitTorrent Open Source License v1.0                                          | [BitTorrent-1.0](https://spdx.org/licenses/BitTorrent-1.0.html)                                             |      |     |
 | BitTorrent Open Source License v1.1                                          | [BitTorrent-1.1](https://spdx.org/licenses/BitTorrent-1.1.html)                                             | Y    |     |
 | SQLite Blessing                                                              | [blessing](https://spdx.org/licenses/blessing.html)                                                         |      |     |
@@ -74,7 +76,7 @@ The OSI column in Table A.1 refers to Open Source Initiative licenses [see Refer
 | Borceux license                                                              | [Borceux](https://spdx.org/licenses/Borceux.html)                                                           |      |     |
 | BSD 1-Clause License                                                         | [BSD-1-Clause](https://spdx.org/licenses/BSD-1-Clause.html)                                                 |      | Y   |
 | BSD 2-Clause "Simplified" License                                            | [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html)                                                 | Y    | Y   |
-| BSD 2-Clause Plus Patent License                                             | [BSD-2-Clause-Patent](https://spdx.org/licenses/BSD-2-Clause-Patent.html)                                   |      | Y   |
+| BSD-2-Clause Plus Patent License                                             | [BSD-2-Clause-Patent](https://spdx.org/licenses/BSD-2-Clause-Patent.html)                                   |      | Y   |
 | BSD 2-Clause with views sentence                                             | [BSD-2-Clause-Views](https://spdx.org/licenses/BSD-2-Clause-Views.html)                                     |      |     |
 | BSD 3-Clause "New" or "Revised" License                                      | [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html)                                                 | Y    | Y   |
 | BSD with attribution                                                         | [BSD-3-Clause-Attribution](https://spdx.org/licenses/BSD-3-Clause-Attribution.html)                         |      |     |
@@ -87,7 +89,7 @@ The OSI column in Table A.1 refers to Open Source Initiative licenses [see Refer
 | BSD 3-Clause No Nuclear Warranty                                             | [BSD-3-Clause-No-Nuclear-Warranty](https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.html)         |      |     |
 | BSD 3-Clause Open MPI variant                                                | [BSD-3-Clause-Open-MPI](https://spdx.org/licenses/BSD-3-Clause-Open-MPI.html)                               |      |     |
 | BSD 4-Clause "Original" or "Old" License                                     | [BSD-4-Clause](https://spdx.org/licenses/BSD-4-Clause.html)                                                 | Y    |     |
-| BSD 4-Clause Shortened                                                       | [BSD-4-Clause-Shortened](https://spdx.org/licenses/BSD-4-Clause-Shortened.html)                             |      |     |
+| BSD 4 Clause Shortened                                                       | [BSD-4-Clause-Shortened](https://spdx.org/licenses/BSD-4-Clause-Shortened.html)                             |      |     |
 | BSD-4-Clause (University of California-Specific)                             | [BSD-4-Clause-UC](https://spdx.org/licenses/BSD-4-Clause-UC.html)                                           |      |     |
 | BSD Protection License                                                       | [BSD-Protection](https://spdx.org/licenses/BSD-Protection.html)                                             |      |     |
 | BSD Source Code Attribution                                                  | [BSD-Source-Code](https://spdx.org/licenses/BSD-Source-Code.html)                                           |      |     |
@@ -124,7 +126,7 @@ The OSI column in Table A.1 refers to Open Source Initiative licenses [see Refer
 | Creative Commons Attribution Non Commercial No Derivatives 4.0 International | [CC-BY-NC-ND-4.0](https://spdx.org/licenses/CC-BY-NC-ND-4.0.html)                                           |      |     |
 | Creative Commons Attribution Non Commercial Share Alike 1.0 Generic          | [CC-BY-NC-SA-1.0](https://spdx.org/licenses/CC-BY-NC-SA-1.0.html)                                           |      |     |
 | Creative Commons Attribution Non Commercial Share Alike 2.0 Generic          | [CC-BY-NC-SA-2.0](https://spdx.org/licenses/CC-BY-NC-SA-2.0.html)                                           |      |     |
-| Creative Commons Attribution Non Commercial Share Alike 2.0 France           | [CC-BY-NC-SA-2.0-FR](https://spdx.org/licenses/CC-BY-NC-SA-2.0-FR.html)                                     |      |     |
+| Creative Commons Attribution-NonCommercial-ShareAlike 2.0 France             | [CC-BY-NC-SA-2.0-FR](https://spdx.org/licenses/CC-BY-NC-SA-2.0-FR.html)                                     |      |     |
 | Creative Commons Attribution Non Commercial Share Alike 2.0 England and Wales| [CC-BY-NC-SA-2.0-UK](https://spdx.org/licenses/CC-BY-NC-SA-2.0-UK.html)                                     |      |     |
 | Creative Commons Attribution Non Commercial Share Alike 2.5 Generic          | [CC-BY-NC-SA-2.5](https://spdx.org/licenses/CC-BY-NC-SA-2.5.html)                                           |      |     |
 | Creative Commons Attribution Non Commercial Share Alike 3.0 Unported         | [CC-BY-NC-SA-3.0](https://spdx.org/licenses/CC-BY-NC-SA-3.0.html)                                           |      |     |
@@ -139,7 +141,7 @@ The OSI column in Table A.1 refers to Open Source Initiative licenses [see Refer
 | Creative Commons Attribution No Derivatives 4.0 International                | [CC-BY-ND-4.0](https://spdx.org/licenses/CC-BY-ND-4.0.html)                                                 |      |     |
 | Creative Commons Attribution Share Alike 1.0 Generic                         | [CC-BY-SA-1.0](https://spdx.org/licenses/CC-BY-SA-1.0.html)                                                 |      |     |
 | Creative Commons Attribution Share Alike 2.0 Generic                         | [CC-BY-SA-2.0](https://spdx.org/licenses/CC-BY-SA-2.0.html)                                                 |      |     |
-| Creative Commons Attribution Share Alike 2.0 England and Wales               | [CC-BY-SA-2.1-UK](https://spdx.org/licenses/CC-BY-SA-2.0-UK.html)                                           |      |     |
+| Creative Commons Attribution Share Alike 2.0 England and Wales               | [CC-BY-SA-2.0-UK](https://spdx.org/licenses/CC-BY-SA-2.0-UK.html)                                           |      |     |
 | Creative Commons Attribution Share Alike 2.1 Japan                           | [CC-BY-SA-2.1-JP](https://spdx.org/licenses/CC-BY-SA-2.1-JP.html)                                           |      |     |
 | Creative Commons Attribution Share Alike 2.5 Generic                         | [CC-BY-SA-2.5](https://spdx.org/licenses/CC-BY-SA-2.5.html)                                                 |      |     |
 | Creative Commons Attribution Share Alike 3.0 Unported                        | [CC-BY-SA-3.0](https://spdx.org/licenses/CC-BY-SA-3.0.html)                                                 |      |     |
@@ -249,7 +251,7 @@ The OSI column in Table A.1 refers to Open Source Initiative licenses [see Refer
 | GNU General Public License v3.0 or later                                     | [GPL-3.0-or-later](https://spdx.org/licenses/GPL-3.0-or-later.html)                                         | Y    | Y   |
 | gSOAP Public License v1.3b                                                   | [gSOAP-1.3b](https://spdx.org/licenses/gSOAP-1.3b.html)                                                     |      |     |
 | Haskell Language Report License                                              | [HaskellReport](https://spdx.org/licenses/HaskellReport.html)                                               |      |     |
-| Hippocratic License 2.1                                                      | [Hippocratic-2.1](https://spdx.org/licenses/Hippocratic-2.1)                                                |      |     |
+| Hippocratic License 2.1                                                      | [Hippocratic-2.1](https://spdx.org/licenses/Hippocratic-2.1.html)                                                |      |     |
 | Historical Permission Notice and Disclaimer                                  | [HPND](https://spdx.org/licenses/HPND.html)                                                                 | Y    | Y   |
 | Historical Permission Notice and Disclaimer - sell variant                   | [HPND-sell-variant](https://spdx.org/licenses/HPND-sell-variant.html)                                       |      |     |
 | HTML Tidy License                                                            | [HTMLTIDY](https://spdx.org/licenses/HTMLTIDY.html)                                                         |      |     |
@@ -286,9 +288,9 @@ The OSI column in Table A.1 refers to Open Source Initiative licenses [see Refer
 | PNG Reference Library version 2                                              | [libpng-2.0](https://spdx.org/licenses/libpng-2.0.html)                                                     |      |     |
 | libselinux public domain notice                                              | [libselinux-1.0](https://spdx.org/licenses/libselinux-1.0.html)                                             |      |     |
 | libtiff License                                                              | [libtiff](https://spdx.org/licenses/libtiff.html)                                                           |      |     |
-| Licence Libre du Québec – Permissive version 1.1                             | [LiLiQ-P-1.1](https://spdx.org/licenses/LiLiQ-P-1.1.html)                                                   | Y    | Y   |
-| Licence Libre du Québec – Réciprocité version 1.1                            | [LiLiQ-R-1.1](https://spdx.org/licenses/LiLiQ-R-1.1.html)                                                   | Y    | Y   |
-| Licence Libre du Québec – Réciprocité forte version 1.1                      | [LiLiQ-Rplus-1.1](https://spdx.org/licenses/LiLiQ-Rplus-1.1.html)                                           | Y    | Y   |
+| Licence Libre du Québec – Permissive version 1.1                             | [LiLiQ-P-1.1](https://spdx.org/licenses/LiLiQ-P-1.1.html)                                                   |      | Y   |
+| Licence Libre du Québec – Réciprocité version 1.1                            | [LiLiQ-R-1.1](https://spdx.org/licenses/LiLiQ-R-1.1.html)                                                   |      | Y   |
+| Licence Libre du Québec – Réciprocité forte version 1.1                      | [LiLiQ-Rplus-1.1](https://spdx.org/licenses/LiLiQ-Rplus-1.1.html)                                           |      | Y   |
 | Linux man-pages Copyleft                                                     | [Linux-man-pages-copyleft](https://spdx.org/licenses/Linux-man-pages-copyleft.html)                         |      |     |
 | Linux Kernel Variant of OpenIB.org license                                   | [Linux-OpenIB](https://spdx.org/licenses/Linux-OpenIB.html)                                                 |      |     |
 | Lucent Public License Version 1.0                                            | [LPL-1.0](https://spdx.org/licenses/LPL-1.0.html)                                                           |      | Y   |
@@ -333,8 +335,8 @@ The OSI column in Table A.1 refers to Open Source Initiative licenses [see Refer
 | NetCDF license                                                               | [NetCDF](https://spdx.org/licenses/NetCDF.html)                                                             |      |     |
 | Newsletr License                                                             | [Newsletr](https://spdx.org/licenses/Newsletr.html)                                                         |      |     |
 | Nethack General Public License                                               | [NGPL](https://spdx.org/licenses/NGPL.html)                                                                 |      | Y   |
-| NIST Public Domain Notice                                                    | [NIST-PD](https://spdx.org/licenes/NIST-PD.html)                                                            |      |     |
-| NIST Public Domain Notice with license fallback                              | [NIST-PD-fallback](https//spdx.org/licenes/NIST-PD-fallback.html)                                           |      |     |
+| NIST Public Domain Notice                                                    | [NIST-PD](https://spdx.org/licenses/NIST-PD.html)                                                            |      |     |
+| NIST Public Domain Notice with license fallback                              | [NIST-PD-fallback](https://spdx.org/licenses/NIST-PD-fallback.html)                                           |      |     |
 | Norwegian Licence for Open Government Data (NLOD) 1.0                        | [NLOD-1.0](https://spdx.org/licenses/NLOD-1.0.html)                                                         |      |     |
 | Norwegian Licence for Open Government Data (NLOD) 2.0                        | [NLOD-2.0](https://spdx.org/licenses/NLOD-2.0.html)                                                         |      |     |
 | No Limit Public License                                                      | [NLPL](https://spdx.org/licenses/NLPL.html)                                                                 |      |     |
@@ -350,7 +352,7 @@ The OSI column in Table A.1 refers to Open Source Initiative licenses [see Refer
 | Open Use of Data Agreement v1.0                                              | [O-UDA-1.0](https://spdx.org/licenses/O-UDA-1.0.html)                                                       |      |     |
 | Open CASCADE Technology Public License                                       | [OCCT-PL](https://spdx.org/licenses/OCCT-PL.html)                                                           |      |     |
 | OCLC Research Public License 2.0                                             | [OCLC-2.0](https://spdx.org/licenses/OCLC-2.0.html)                                                         |      | Y   |
-| ODC Open Database License v1.0                                               | [ODbL-1.0](https://spdx.org/licenses/ODbL-1.0.html)                                                         | Y    |     |
+| Open Data Commons Open Database License v1.0                                 | [ODbL-1.0](https://spdx.org/licenses/ODbL-1.0.html)                                                         | Y    |     |
 | Open Data Commons Attribution License v1.0                                   | [ODC-By-1.0](https://spdx.org/licenses/ODC-By-1.0.html)                                                     |      |     |
 | SIL Open Font License 1.0                                                    | [OFL-1.0](https://spdx.org/licenses/OFL-1.0.html)                                                           | Y    |     |
 | SIL Open Font License 1.0 with no Reserved Font Name                         | [OFL-1.0-no-RFN](https://spdx.org/licenses/OFL-1.0-no-RFN.html)                                             |      |     |
@@ -358,12 +360,13 @@ The OSI column in Table A.1 refers to Open Source Initiative licenses [see Refer
 | SIL Open Font License 1.1                                                    | [OFL-1.1](https://spdx.org/licenses/OFL-1.1.html)                                                           | Y    | Y   |
 | SIL Open Font License 1.1 with no Reserved Font Name                         | [OFL-1.1-no-RFN](https://spdx.org/licenses/OFL-1.1-no-RFN.html)                                             |      | Y   |
 | SIL Open Font License 1.1 with Reserved Font Name                            | [OFL-1.1-RFN](https://spdx.org/licenses/OFL-1.1-RFN.html)                                                   |      | Y   |
-| Taiwan Open Government Data Licence, version 1.0                             | [OGDL-Taiwan-1.0](https://spdx.org/licenses/OGDL-Taiwan-1.0.html)                                           |      |     |
+| OGC Software License, Version 1.0                                            | [OGC-1.0](https://spdx.org/licenses/OGC-1.0.html)                                             |      |     |
+| Taiwan Open Government Data License, version 1.0                             | [OGDL-Taiwan-1.0](https://spdx.org/licenses/OGDL-Taiwan-1.0.html)                                           |      |     |
 | Open Government Licence - Canada                                             | [OGL-Canada-2.0](https://spdx.org/licenses/OGL-Canada-2.0.html)                                             |      |     |
 | Open Government Licence v1.0                                                 | [OGL-UK-1.0](https://spdx.org/licenses/OGL-UK-1.0.html)                                                     |      |     |
 | Open Government Licence v2.0                                                 | [OGL-UK-2.0](https://spdx.org/licenses/OGL-UK-2.0.html)                                                     |      |     |
 | Open Government Licence v3.0                                                 | [OGL-UK-3.0](https://spdx.org/licenses/OGL-UK-3.0.html)                                                     |      |     |
-| Open Group Test Suite License                                                | [OGTSL](https://spdx.org/licenses/OGTSL.html)                                                               | Y    | Y   |
+| Open Group Test Suite License                                                | [OGTSL](https://spdx.org/licenses/OGTSL.html)                                                               |      | Y   |
 | Open LDAP Public License v1.1                                                | [OLDAP-1.1](https://spdx.org/licenses/OLDAP-1.1.html)                                                       |      |     |
 | Open LDAP Public License v1.2                                                | [OLDAP-1.2](https://spdx.org/licenses/OLDAP-1.2.html)                                                       |      |     |
 | Open LDAP Public License v1.3                                                | [OLDAP-1.3](https://spdx.org/licenses/OLDAP-1.3.html)                                                       |      |     |
@@ -383,7 +386,7 @@ The OSI column in Table A.1 refers to Open Source Initiative licenses [see Refer
 | Open Market License                                                          | [OML](https://spdx.org/licenses/OML.html)                                                                   |      |     |
 | OpenSSL License                                                              | [OpenSSL](https://spdx.org/licenses/OpenSSL.html)                                                           | Y    |     |
 | Open Public License v1.0                                                     | [OPL-1.0](https://spdx.org/licenses/OPL-1.0.html)                                                           |      |     |
-| Open Publication License v1.0                                                | [OPBL-1.0](https://spdx.org/licenses/OPBL-1.0.html)                                                         |      |     |
+| Open Publication License v1.0                                                | [OPUBL-1.0](https://spdx.org/licenses/OPUBL-1.0.html)                                                         |      |     |
 | OSET Public License version 2.1                                              | [OSET-PL-2.1](https://spdx.org/licenses/OSET-PL-2.1.html)                                                   |      | Y   |
 | Open Software License 1.0                                                    | [OSL-1.0](https://spdx.org/licenses/OSL-1.0.html)                                                           | Y    | Y   |
 | Open Software License 1.1                                                    | [OSL-1.1](https://spdx.org/licenses/OSL-1.1.html)                                                           | Y    |     |
@@ -392,7 +395,7 @@ The OSI column in Table A.1 refers to Open Source Initiative licenses [see Refer
 | Open Software License 3.0                                                    | [OSL-3.0](https://spdx.org/licenses/OSL-3.0.html)                                                           | Y    | Y   |
 | The Parity Public License 6.0.0                                              | [Parity-6.0.0](https://spdx.org/licenses/Parity-6.0.0.html)                                                 |      |     |
 | The Parity Public License 7.0.0                                              | [Parity-7.0.0](https://spdx.org/licenses/Parity-7.0.0.html)                                                 |      |     |
-| ODC Public Domain Dedication & License 1.0                                   | [PDDL-1.0](https://spdx.org/licenses/PDDL-1.0.html)                                                         |      |     |
+| Open Data Commons Public Domain Dedication & License 1.0                     | [PDDL-1.0](https://spdx.org/licenses/PDDL-1.0.html)                                                         |      |     |
 | PHP License v3.0                                                             | [PHP-3.0](https://spdx.org/licenses/PHP-3.0.html)                                                           |      | Y   |
 | PHP License v3.01                                                            | [PHP-3.01](https://spdx.org/licenses/PHP-3.01.html)                                                         | Y    | Y   |
 | Plexus Classworlds License                                                   | [Plexus](https://spdx.org/licenses/Plexus.html)                                                             |      |     |
@@ -450,13 +453,13 @@ The OSI column in Table A.1 refers to Open Source Initiative licenses [see Refer
 | Technische Universitaet Berlin License 2.0                                   | [TU-Berlin-2.0](https://spdx.org/licenses/TU-Berlin-2.0.html)                                               |      |     |
 | Upstream Compatibility License v1.0                                          | [UCL-1.0](https://spdx.org/licenses/UCL-1.0.html)                                                           |      | Y   |
 | Unicode License Agreement - Data Files and Software (2015)                   | [Unicode-DFS-2015](https://spdx.org/licenses/Unicode-DFS-2015.html)                                         |      |     |
-| Unicode License Agreement - Data Files and Software (2016)                   | [Unicode-DFS-2016](https://spdx.org/licenses/Unicode-DFS-2016.html)                                         |      |     |
+| Unicode License Agreement - Data Files and Software (2016)                   | [Unicode-DFS-2016](https://spdx.org/licenses/Unicode-DFS-2016.html)                                         |      | Y   |
 | Unicode Terms of Use                                                         | [Unicode-TOU](https://spdx.org/licenses/Unicode-TOU.html)                                                   |      |     |
 | The Unlicense                                                                | [Unlicense](https://spdx.org/licenses/Unlicense.html)                                                       | Y    | Y   |
 | Universal Permissive License v1.0                                            | [UPL-1.0](https://spdx.org/licenses/UPL-1.0.html)                                                           | Y    | Y   |
 | Vim License                                                                  | [Vim](https://spdx.org/licenses/Vim.html)                                                                   | Y    |     |
 | VOSTROM Public License for Open Source                                       | [VOSTROM](https://spdx.org/licenses/VOSTROM.html)                                                           |      |     |
-| Vovida Software License v1.0                                                 | [VSL-1.0](https://spdx.org/licenses/VSL-1.0.html)                                                           | Y    | Y   |
+| Vovida Software License v1.0                                                 | [VSL-1.0](https://spdx.org/licenses/VSL-1.0.html)                                                           |      | Y   |
 | W3C Software Notice and License (2002-12-31)                                 | [W3C](https://spdx.org/licenses/W3C.html)                                                                   | Y    | Y   |
 | W3C Software Notice and License (1998-07-20)                                 | [W3C-19980720](https://spdx.org/licenses/W3C-19980720.html)                                                 |      |     |
 | W3C Software Notice and Document License (2015-05-13)                        | [W3C-20150513](https://spdx.org/licenses/W3C-20150513.html)                                                 |      |     |
@@ -464,7 +467,7 @@ The OSI column in Table A.1 refers to Open Source Initiative licenses [see Refer
 | Wsuipa License                                                               | [Wsuipa](https://spdx.org/licenses/Wsuipa.html)                                                             |      |     |
 | Do What The F\*ck You Want To Public License                                  | [WTFPL](https://spdx.org/licenses/WTFPL.html)                                                               | Y    |     |
 | X11 License                                                                  | [X11](https://spdx.org/licenses/X11.html)                                                                   | Y    |     |
-| X11 License Distribution Modification Variant                                | [X11-distribute-modifications-variant](https://spdx.org/licenses/X11-distribute-modifciations-variant.html) |      |     |
+| X11 License Distribution Modification Variant                                | [X11-distribute-modifications-variant](https://spdx.org/licenses/X11-distribute-modifications-variant.html) |      |     |
 | Xerox License                                                                | [Xerox](https://spdx.org/licenses/Xerox.html)                                                               |      |     |
 | XFree86 License 1.1                                                          | [XFree86-1.1](https://spdx.org/licenses/XFree86-1.1.html)                                                   | Y    |     |
 | xinetd License                                                               | [xinetd](https://spdx.org/licenses/xinetd.html)                                                             | Y    |     |

--- a/chapters/SPDX-license-list.md
+++ b/chapters/SPDX-license-list.md
@@ -1,20 +1,23 @@
 # Annex A SPDX license List (Informative)
 
-The SPDX License List is a list of commonly found licenses and exceptions used for open source and other collaborative software. The purpose of the SPDX License List is to enable easy and efficient identification of such licenses and exceptions in an SPDX document (or elsewhere). The SPDX License List includes a standardized short identifier, full name for each license, vetted license text, other basic information, and a canonical permanent URL for each license and exception. By providing a short identifier, users can efficiently refer to a license without having to redundantly reproduce the full license. License exceptions can be used with the License Expression Syntax operator, "WITH" to create a license with an exception.
+The SPDX License List is an integral part of the SPDX Specification. The SPDX License List itself is a list of commonly found licenses and exceptions used in free and open or collaborative software, data, hardware, or documentation. The SPDX License List includes a standardized short identifier, the full name, the license text, and a canonical permanent URL for each license and exception.
 
+The purpose of the SPDX License List is to enable efficient and reliable identification of such licenses and exceptions in an SPDX document, in source files or elsewhere.
+
+* [Overview][overview]: For general information about the SPDX License List, including principles for inclusion of a license and an explanation of the [fields][fields] contained on the list.
+* [Matching Guidelines][matching]: Guidelines for what constitutes a license match to the SPDX License List. For licenses that include markup, the license text on the HTML pages here will display omitable text in blue and replaceable text in red (see Guideline #2 for more information).
 * [License Exceptions][exceptions]: The list of commonly found exceptions to open source licenses, which can be used with the License Expression operator, "WITH" to create a license with an exception.
 * [License List Repository][license-list-repo]: The HTML pages you see here are generated from the SPDX license-list-XML Repository. The repository contains XML files for all licenses, deprecated licenses, and license exceptions.
-* [Overview][overview]: For general information about the SPDX License List, including principles for inclusion of a license and an explanation of the fields contained on the list.
-* [Matching Guidelines][matching]: Guidelines for what constitutes a license match to the SPDX License List. For licenses that include markup, the license text on the HTML pages here will display omitable text in blue and replaceable text in red (see Guideline #2 for more information).
 * [Request New License][new-license]: For instructions on how to propose additional licenses or license exceptions be added to the SPDX License List.
 
 [exceptions]: https://spdx.org/licenses/exceptions-index.html
 [matching]: https://spdx.org/spdx-license-list/matching-guidelines
 [license-list-repo]: https://github.com/spdx/license-list-XML
 [new-license]: https://github.com/spdx/license-list-XML/blob/master/CONTRIBUTING.md
-[overview]: https://spdx.org/spdx-license-list/license-list-overview
+[overview]: https://spdx.org/licenses/
+[fields]: https://github.com/spdx/license-list-XML/blob/master/DOCS/license-fields.md
 
-The following table contains the full names and short identifiers for the SPDX License List, v3.8 which was released 2020-02-09. For the full and most up-to-date version of the SPDX License List as well as other related information, please see [http://spdx.org/licenses/](http://spdx.org/licenses/)
+The following table contains the full names and short identifiers for the SPDX License List, v3.17 which was released 2022-05-08. For the full and most up-to-date version of the SPDX License List as well as other related information, please see [http://spdx.org/licenses/](http://spdx.org/licenses/)
 
 ## A.1 Licenses with short identifiers <a name="A.1"></a>
 
@@ -22,391 +25,467 @@ The OSI column in Table A.1 refers to Open Source Initiative licenses [see Refer
 
 **Table A.1 — License names and corresponding short identifiers**
 
-| Full Name of License                                                         | Short Identifier                                                                                            | OSI? |
-|------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|------|
-| BSD Zero Clause License                                                      | [0BSD](https://spdx.org/licenses/0BSD.html)                                                                 | Y    |
-| Attribution Assurance License                                                | [AAL](https://spdx.org/licenses/AAL.html)                                                                   | Y    |
-| Abstyles License                                                             | [Abstyles](https://spdx.org/licenses/Abstyles.html)                                                         |      |
-| Adobe Systems Incorporated Source Code License Agreement                     | [Adobe-2006](https://spdx.org/licenses/Adobe-2006.html)                                                     |      |
-| Adobe Glyph List License                                                     | [Adobe-Glyph](https://spdx.org/licenses/Adobe-Glyph.html)                                                   |      |
-| Amazon Digital Services License                                              | [ADSL](https://spdx.org/licenses/ADSL.html)                                                                 |      |
-| Academic Free License v1.1                                                   | [AFL-1.1](https://spdx.org/licenses/AFL-1.1.html)                                                           | Y    |
-| Academic Free License v1.2                                                   | [AFL-1.2](https://spdx.org/licenses/AFL-1.2.html)                                                           | Y    |
-| Academic Free License v2.0                                                   | [AFL-2.0](https://spdx.org/licenses/AFL-2.0.html)                                                           | Y    |
-| Academic Free License v2.1                                                   | [AFL-2.1](https://spdx.org/licenses/AFL-2.1.html)                                                           | Y    |
-| Academic Free License v3.0                                                   | [AFL-3.0](https://spdx.org/licenses/AFL-3.0.html)                                                           | Y    |
-| Afmparse License                                                             | [Afmparse](https://spdx.org/licenses/Afmparse.html)                                                         |      |
-| Affero General Public License v1.0 only                                      | [AGPL-1.0-only](https://spdx.org/licenses/AGPL-1.0-only.html)                                               |      |
-| Affero General Public License v1.0 or later                                  | [AGPL-1.0-or-later](https://spdx.org/licenses/AGPL-1.0-or-later.html)                                       |      |
-| GNU Affero General Public License v3.0 only                                  | [AGPL-3.0-only](https://spdx.org/licenses/AGPL-3.0-only.html)                                               | Y    |
-| GNU Affero General Public License v3.0 or later                              | [AGPL-3.0-or-later](https://spdx.org/licenses/AGPL-3.0-or-later.html)                                       | Y    |
-| Aladdin Free Public License                                                  | [Aladdin](https://spdx.org/licenses/Aladdin.html)                                                           |      |
-| AMD's plpa_map.c License                                                     | [AMDPLPA](https://spdx.org/licenses/AMDPLPA.html)                                                           |      |
-| Apple MIT License                                                            | [AML](https://spdx.org/licenses/AML.html)                                                                   |      |
-| Academy of Motion Picture Arts and Sciences BSD                              | [AMPAS](https://spdx.org/licenses/AMPAS.html)                                                               |      |
-| ANTLR Software Rights Notice                                                 | [ANTLR-PD](https://spdx.org/licenses/ANTLR-PD.html)                                                         |      |
-| Apache License 1.0                                                           | [Apache-1.0](https://spdx.org/licenses/Apache-1.0.html)                                                     |      |
-| Apache License 1.1                                                           | [Apache-1.1](https://spdx.org/licenses/Apache-1.1.html)                                                     | Y    |
-| Apache License 2.0                                                           | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html)                                                     | Y    |
-| Adobe Postscript AFM License                                                 | [APAFML](https://spdx.org/licenses/APAFML.html)                                                             |      |
-| Adaptive Public License 1.0                                                  | [APL-1.0](https://spdx.org/licenses/APL-1.0.html)                                                           | Y    |
-| Apple Public Source License 1.0                                              | [APSL-1.0](https://spdx.org/licenses/APSL-1.0.html)                                                         | Y    |
-| Apple Public Source License 1.1                                              | [APSL-1.1](https://spdx.org/licenses/APSL-1.1.html)                                                         | Y    |
-| Apple Public Source License 1.2                                              | [APSL-1.2](https://spdx.org/licenses/APSL-1.2.html)                                                         | Y    |
-| Apple Public Source License 2.0                                              | [APSL-2.0](https://spdx.org/licenses/APSL-2.0.html)                                                         | Y    |
-| Artistic License 1.0                                                         | [Artistic-1.0](https://spdx.org/licenses/Artistic-1.0.html)                                                 | Y    |
-| Artistic License 1.0 w/clause 8                                              | [Artistic-1.0-cl8](https://spdx.org/licenses/Artistic-1.0-cl8.html)                                         | Y    |
-| Artistic License 1.0 (Perl)                                                  | [Artistic-1.0-Perl](https://spdx.org/licenses/Artistic-1.0-Perl.html)                                       | Y    |
-| Artistic License 2.0                                                         | [Artistic-2.0](https://spdx.org/licenses/Artistic-2.0.html)                                                 | Y    |
-| Bahyph License                                                               | [Bahyph](https://spdx.org/licenses/Bahyph.html)                                                             |      |
-| Barr License                                                                 | [Barr](https://spdx.org/licenses/Barr.html)                                                                 |      |
-| Beerware License                                                             | [Beerware](https://spdx.org/licenses/Beerware.html)                                                         |      |
-| BitTorrent Open Source License v1.0                                          | [BitTorrent-1.0](https://spdx.org/licenses/BitTorrent-1.0.html)                                             |      |
-| BitTorrent Open Source License v1.1                                          | [BitTorrent-1.1](https://spdx.org/licenses/BitTorrent-1.1.html)                                             |      |
-| SQLite Blessing                                                              | [blessing](https://spdx.org/licenses/blessing.html)                                                         |      |
-| Blue Oak Model License 1.0.0                                                 | [BlueOak-1.0.0](https://spdx.org/licenses/BlueOak-1.0.0.html)                                               |      |
-| Borceux license                                                              | [Borceux](https://spdx.org/licenses/Borceux.html)                                                           |      |
-| BSD 1-Clause License                                                         | [BSD-1-Clause](https://spdx.org/licenses/BSD-1-Clause.html)                                                 |      |
-| BSD 2-Clause "Simplified" License                                            | [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html)                                                 | Y    |
-| BSD 2-Clause FreeBSD License                                                 | [BSD-2-Clause-FreeBSD](https://spdx.org/licenses/BSD-2-Clause-FreeBSD.html)                                 |      |
-| BSD 2-Clause NetBSD License                                                  | [BSD-2-Clause-NetBSD](https://spdx.org/licenses/BSD-2-Clause-NetBSD.html)                                   |      |
-| BSD-2-Clause Plus Patent License                                             | [BSD-2-Clause-Patent](https://spdx.org/licenses/BSD-2-Clause-Patent.html)                                   | Y    |
-| BSD 3-Clause "New" or "Revised" License                                      | [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html)                                                 | Y    |
-| BSD with attribution                                                         | [BSD-3-Clause-Attribution](https://spdx.org/licenses/BSD-3-Clause-Attribution.html)                         |      |
-| BSD 3-Clause Clear License                                                   | [BSD-3-Clause-Clear](https://spdx.org/licenses/BSD-3-Clause-Clear.html)                                     |      |
-| Lawrence Berkeley National Labs BSD variant license                          | [BSD-3-Clause-LBNL](https://spdx.org/licenses/BSD-3-Clause-LBNL.html)                                       | Y    |
-| BSD 3-Clause No Nuclear License                                              | [BSD-3-Clause-No-Nuclear-License](https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.html)           |      |
-| BSD 3-Clause No Nuclear License 2014                                         | [BSD-3-Clause-No-Nuclear-License-2014](https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.html) |      |
-| BSD 3-Clause No Nuclear Warranty                                             | [BSD-3-Clause-No-Nuclear-Warranty](https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.html)         |      |
-| BSD 3-Clause Open MPI variant                                                | [BSD-3-Clause-Open-MPI](https://spdx.org/licenses/BSD-3-Clause-Open-MPI.html)                               |      |
-| BSD 4-Clause "Original" or "Old" License                                     | [BSD-4-Clause](https://spdx.org/licenses/BSD-4-Clause.html)                                                 |      |
-| BSD-4-Clause (University of California-Specific)                             | [BSD-4-Clause-UC](https://spdx.org/licenses/BSD-4-Clause-UC.html)                                           |      |
-| BSD Protection License                                                       | [BSD-Protection](https://spdx.org/licenses/BSD-Protection.html)                                             |      |
-| BSD Source Code Attribution                                                  | [BSD-Source-Code](https://spdx.org/licenses/BSD-Source-Code.html)                                           |      |
-| Boost Software License 1.0                                                   | [BSL-1.0](https://spdx.org/licenses/BSL-1.0.html)                                                           | Y    |
-| bzip2 and libbzip2 License v1.0.5                                            | [bzip2-1.0.5](https://spdx.org/licenses/bzip2-1.0.5.html)                                                   |      |
-| bzip2 and libbzip2 License v1.0.6                                            | [bzip2-1.0.6](https://spdx.org/licenses/bzip2-1.0.6.html)                                                   |      |
-| Caldera License                                                              | [Caldera](https://spdx.org/licenses/Caldera.html)                                                           |      |
-| Computer Associates Trusted Open Source License 1.1                          | [CATOSL-1.1](https://spdx.org/licenses/CATOSL-1.1.html)                                                     | Y    |
-| Creative Commons Attribution 1.0 Generic                                     | [CC-BY-1.0](https://spdx.org/licenses/CC-BY-1.0.html)                                                       |      |
-| Creative Commons Attribution 2.0 Generic                                     | [CC-BY-2.0](https://spdx.org/licenses/CC-BY-2.0.html)                                                       |      |
-| Creative Commons Attribution 2.5 Generic                                     | [CC-BY-2.5](https://spdx.org/licenses/CC-BY-2.5.html)                                                       |      |
-| Creative Commons Attribution 3.0 Unported                                    | [CC-BY-3.0](https://spdx.org/licenses/CC-BY-3.0.html)                                                       |      |
-| Creative Commons Attribution 4.0 International                               | [CC-BY-4.0](https://spdx.org/licenses/CC-BY-4.0.html)                                                       |      |
-| Creative Commons Attribution Non Commercial 1.0 Generic                      | [CC-BY-NC-1.0](https://spdx.org/licenses/CC-BY-NC-1.0.html)                                                 |      |
-| Creative Commons Attribution Non Commercial 2.0 Generic                      | [CC-BY-NC-2.0](https://spdx.org/licenses/CC-BY-NC-2.0.html)                                                 |      |
-| Creative Commons Attribution Non Commercial 2.5 Generic                      | [CC-BY-NC-2.5](https://spdx.org/licenses/CC-BY-NC-2.5.html)                                                 |      |
-| Creative Commons Attribution Non Commercial 3.0 Unported                     | [CC-BY-NC-3.0](https://spdx.org/licenses/CC-BY-NC-3.0.html)                                                 |      |
-| Creative Commons Attribution Non Commercial 4.0 International                | [CC-BY-NC-4.0](https://spdx.org/licenses/CC-BY-NC-4.0.html)                                                 |      |
-| Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic       | [CC-BY-NC-ND-1.0](https://spdx.org/licenses/CC-BY-NC-ND-1.0.html)                                           |      |
-| Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic       | [CC-BY-NC-ND-2.0](https://spdx.org/licenses/CC-BY-NC-ND-2.0.html)                                           |      |
-| Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic       | [CC-BY-NC-ND-2.5](https://spdx.org/licenses/CC-BY-NC-ND-2.5.html)                                           |      |
-| Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported      | [CC-BY-NC-ND-3.0](https://spdx.org/licenses/CC-BY-NC-ND-3.0.html)                                           |      |
-| Creative Commons Attribution Non Commercial No Derivatives 4.0 International | [CC-BY-NC-ND-4.0](https://spdx.org/licenses/CC-BY-NC-ND-4.0.html)                                           |      |
-| Creative Commons Attribution Non Commercial Share Alike 1.0 Generic          | [CC-BY-NC-SA-1.0](https://spdx.org/licenses/CC-BY-NC-SA-1.0.html)                                           |      |
-| Creative Commons Attribution Non Commercial Share Alike 2.0 Generic          | [CC-BY-NC-SA-2.0](https://spdx.org/licenses/CC-BY-NC-SA-2.0.html)                                           |      |
-| Creative Commons Attribution Non Commercial Share Alike 2.5 Generic          | [CC-BY-NC-SA-2.5](https://spdx.org/licenses/CC-BY-NC-SA-2.5.html)                                           |      |
-| Creative Commons Attribution Non Commercial Share Alike 3.0 Unported         | [CC-BY-NC-SA-3.0](https://spdx.org/licenses/CC-BY-NC-SA-3.0.html)                                           |      |
-| Creative Commons Attribution Non Commercial Share Alike 4.0 International    | [CC-BY-NC-SA-4.0](https://spdx.org/licenses/CC-BY-NC-SA-4.0.html)                                           |      |
-| Creative Commons Attribution No Derivatives 1.0 Generic                      | [CC-BY-ND-1.0](https://spdx.org/licenses/CC-BY-ND-1.0.html)                                                 |      |
-| Creative Commons Attribution No Derivatives 2.0 Generic                      | [CC-BY-ND-2.0](https://spdx.org/licenses/CC-BY-ND-2.0.html)                                                 |      |
-| Creative Commons Attribution No Derivatives 2.5 Generic                      | [CC-BY-ND-2.5](https://spdx.org/licenses/CC-BY-ND-2.5.html)                                                 |      |
-| Creative Commons Attribution No Derivatives 3.0 Unported                     | [CC-BY-ND-3.0](https://spdx.org/licenses/CC-BY-ND-3.0.html)                                                 |      |
-| Creative Commons Attribution No Derivatives 4.0 International                | [CC-BY-ND-4.0](https://spdx.org/licenses/CC-BY-ND-4.0.html)                                                 |      |
-| Creative Commons Attribution Share Alike 1.0 Generic                         | [CC-BY-SA-1.0](https://spdx.org/licenses/CC-BY-SA-1.0.html)                                                 |      |
-| Creative Commons Attribution Share Alike 2.0 Generic                         | [CC-BY-SA-2.0](https://spdx.org/licenses/CC-BY-SA-2.0.html)                                                 |      |
-| Creative Commons Attribution Share Alike 2.5 Generic                         | [CC-BY-SA-2.5](https://spdx.org/licenses/CC-BY-SA-2.5.html)                                                 |      |
-| Creative Commons Attribution Share Alike 3.0 Unported                        | [CC-BY-SA-3.0](https://spdx.org/licenses/CC-BY-SA-3.0.html)                                                 |      |
-| Creative Commons Attribution Share Alike 4.0 International                   | [CC-BY-SA-4.0](https://spdx.org/licenses/CC-BY-SA-4.0.html)                                                 |      |
-| Creative Commons Public Domain Dedication and Certification                  | [CC-PDDC](https://spdx.org/licenses/CC-PDDC.html)                                                           |      |
-| Creative Commons Zero v1.0 Universal                                         | [CC0-1.0](https://spdx.org/licenses/CC0-1.0.html)                                                           |      |
-| Common Development and Distribution License 1.0                              | [CDDL-1.0](https://spdx.org/licenses/CDDL-1.0.html)                                                         | Y    |
-| Common Development and Distribution License 1.1                              | [CDDL-1.1](https://spdx.org/licenses/CDDL-1.1.html)                                                         |      |
-| Community Data License Agreement Permissive 1.0                              | [CDLA-Permissive-1.0](https://spdx.org/licenses/CDLA-Permissive-1.0.html)                                   |      |
-| Community Data License Agreement Sharing 1.0                                 | [CDLA-Sharing-1.0](https://spdx.org/licenses/CDLA-Sharing-1.0.html)                                         |      |
-| CeCILL Free Software License Agreement v1.0                                  | [CECILL-1.0](https://spdx.org/licenses/CECILL-1.0.html)                                                     |      |
-| CeCILL Free Software License Agreement v1.1                                  | [CECILL-1.1](https://spdx.org/licenses/CECILL-1.1.html)                                                     |      |
-| CeCILL Free Software License Agreement v2.0                                  | [CECILL-2.0](https://spdx.org/licenses/CECILL-2.0.html)                                                     |      |
-| CeCILL Free Software License Agreement v2.1                                  | [CECILL-2.1](https://spdx.org/licenses/CECILL-2.1.html)                                                     | Y    |
-| CeCILL-B Free Software License Agreement                                     | [CECILL-B](https://spdx.org/licenses/CECILL-B.html)                                                         |      |
-| CeCILL-C Free Software License Agreement                                     | [CECILL-C](https://spdx.org/licenses/CECILL-C.html)                                                         |      |
-| CERN Open Hardware Licence v1.1                                              | [CERN-OHL-1.1](https://spdx.org/licenses/CERN-OHL-1.1.html)                                                 |      |
-| CERN Open Hardware Licence v1.2                                              | [CERN-OHL-1.2](https://spdx.org/licenses/CERN-OHL-1.2.html)                                                 |      |
-| Clarified Artistic License                                                   | [ClArtistic](https://spdx.org/licenses/ClArtistic.html)                                                     |      |
-| CNRI Jython License                                                          | [CNRI-Jython](https://spdx.org/licenses/CNRI-Jython.html)                                                   |      |
-| CNRI Python License                                                          | [CNRI-Python](https://spdx.org/licenses/CNRI-Python.html)                                                   | Y    |
-| CNRI Python Open Source GPL Compatible License Agreement                     | [CNRI-Python-GPL-Compatible](https://spdx.org/licenses/CNRI-Python-GPL-Compatible.html)                     |      |
-| Condor Public License v1.1                                                   | [Condor-1.1](https://spdx.org/licenses/Condor-1.1.html)                                                     |      |
-| copyleft-next 0.3.0                                                          | [copyleft-next-0.3.0](https://spdx.org/licenses/copyleft-next-0.3.0.html)                                   |      |
-| copyleft-next 0.3.1                                                          | [copyleft-next-0.3.1](https://spdx.org/licenses/copyleft-next-0.3.1.html)                                   |      |
-| Common Public Attribution License 1.0                                        | [CPAL-1.0](https://spdx.org/licenses/CPAL-1.0.html)                                                         | Y    |
-| Common Public License 1.0                                                    | [CPL-1.0](https://spdx.org/licenses/CPL-1.0.html)                                                           | Y    |
-| Code Project Open License 1.02                                               | [CPOL-1.02](https://spdx.org/licenses/CPOL-1.02.html)                                                       |      |
-| Crossword License                                                            | [Crossword](https://spdx.org/licenses/Crossword.html)                                                       |      |
-| CrystalStacker License                                                       | [CrystalStacker](https://spdx.org/licenses/CrystalStacker.html)                                             |      |
-| CUA Office Public License v1.0                                               | [CUA-OPL-1.0](https://spdx.org/licenses/CUA-OPL-1.0.html)                                                   | Y    |
-| Cube License                                                                 | [Cube](https://spdx.org/licenses/Cube.html)                                                                 |      |
-| curl License                                                                 | [curl](https://spdx.org/licenses/curl.html)                                                                 |      |
-| Deutsche Freie Software Lizenz                                               | [D-FSL-1.0](https://spdx.org/licenses/D-FSL-1.0.html)                                                       |      |
-| diffmark license                                                             | [diffmark](https://spdx.org/licenses/diffmark.html)                                                         |      |
-| DOC License                                                                  | [DOC](https://spdx.org/licenses/DOC.html)                                                                   |      |
-| Dotseqn License                                                              | [Dotseqn](https://spdx.org/licenses/Dotseqn.html)                                                           |      |
-| DSDP License                                                                 | [DSDP](https://spdx.org/licenses/DSDP.html)                                                                 |      |
-| dvipdfm License                                                              | [dvipdfm](https://spdx.org/licenses/dvipdfm.html)                                                           |      |
-| Educational Community License v1.0                                           | [ECL-1.0](https://spdx.org/licenses/ECL-1.0.html)                                                           | Y    |
-| Educational Community License v2.0                                           | [ECL-2.0](https://spdx.org/licenses/ECL-2.0.html)                                                           | Y    |
-| Eiffel Forum License v1.0                                                    | [EFL-1.0](https://spdx.org/licenses/EFL-1.0.html)                                                           | Y    |
-| Eiffel Forum License v2.0                                                    | [EFL-2.0](https://spdx.org/licenses/EFL-2.0.html)                                                           | Y    |
-| eGenix.com Public License 1.1.0                                              | [eGenix](https://spdx.org/licenses/eGenix.html)                                                             |      |
-| Entessa Public License v1.0                                                  | [Entessa](https://spdx.org/licenses/Entessa.html)                                                           | Y    |
-| Eclipse Public License 1.0                                                   | [EPL-1.0](https://spdx.org/licenses/EPL-1.0.html)                                                           | Y    |
-| Eclipse Public License 2.0                                                   | [EPL-2.0](https://spdx.org/licenses/EPL-2.0.html)                                                           | Y    |
-| Erlang Public License v1.1                                                   | [ErlPL-1.1](https://spdx.org/licenses/ErlPL-1.1.html)                                                       |      |
-| Etalab Open License 2.0                                                      | [etalab-2.0](https://spdx.org/licenses/etalab-2.0.html)                                                     |      |
-| EU DataGrid Software License                                                 | [EUDatagrid](https://spdx.org/licenses/EUDatagrid.html)                                                     | Y    |
-| European Union Public License 1.0                                            | [EUPL-1.0](https://spdx.org/licenses/EUPL-1.0.html)                                                         |      |
-| European Union Public License 1.1                                            | [EUPL-1.1](https://spdx.org/licenses/EUPL-1.1.html)                                                         | Y    |
-| European Union Public License 1.2                                            | [EUPL-1.2](https://spdx.org/licenses/EUPL-1.2.html)                                                         | Y    |
-| Eurosym License                                                              | [Eurosym](https://spdx.org/licenses/Eurosym.html)                                                           |      |
-| Fair License                                                                 | [Fair](https://spdx.org/licenses/Fair.html)                                                                 | Y    |
-| Frameworx Open License 1.0                                                   | [Frameworx-1.0](https://spdx.org/licenses/Frameworx-1.0.html)                                               | Y    |
-| FreeImage Public License v1.0                                                | [FreeImage](https://spdx.org/licenses/FreeImage.html)                                                       |      |
-| FSF All Permissive License                                                   | [FSFAP](https://spdx.org/licenses/FSFAP.html)                                                               |      |
-| FSF Unlimited License                                                        | [FSFUL](https://spdx.org/licenses/FSFUL.html)                                                               |      |
-| FSF Unlimited License (with License Retention)                               | [FSFULLR](https://spdx.org/licenses/FSFULLR.html)                                                           |      |
-| Freetype Project License                                                     | [FTL](https://spdx.org/licenses/FTL.html)                                                                   |      |
-| GNU Free Documentation License v1.1 only                                     | [GFDL-1.1-only](https://spdx.org/licenses/GFDL-1.1-only.html)                                               |      |
-| GNU Free Documentation License v1.1 or later                                 | [GFDL-1.1-or-later](https://spdx.org/licenses/GFDL-1.1-or-later.html)                                       |      |
-| GNU Free Documentation License v1.2 only                                     | [GFDL-1.2-only](https://spdx.org/licenses/GFDL-1.2-only.html)                                               |      |
-| GNU Free Documentation License v1.2 or later                                 | [GFDL-1.2-or-later](https://spdx.org/licenses/GFDL-1.2-or-later.html)                                       |      |
-| GNU Free Documentation License v1.3 only                                     | [GFDL-1.3-only](https://spdx.org/licenses/GFDL-1.3-only.html)                                               |      |
-| GNU Free Documentation License v1.3 or later                                 | [GFDL-1.3-or-later](https://spdx.org/licenses/GFDL-1.3-or-later.html)                                       |      |
-| Giftware License                                                             | [Giftware](https://spdx.org/licenses/Giftware.html)                                                         |      |
-| GL2PS License                                                                | [GL2PS](https://spdx.org/licenses/GL2PS.html)                                                               |      |
-| 3dfx Glide License                                                           | [Glide](https://spdx.org/licenses/Glide.html)                                                               |      |
-| Glulxe License                                                               | [Glulxe](https://spdx.org/licenses/Glulxe.html)                                                             |      |
-| gnuplot License                                                              | [gnuplot](https://spdx.org/licenses/gnuplot.html)                                                           |      |
-| GNU General Public License v1.0 only                                         | [GPL-1.0-only](https://spdx.org/licenses/GPL-1.0-only.html)                                                 |      |
-| GNU General Public License v1.0 or later                                     | [GPL-1.0-or-later](https://spdx.org/licenses/GPL-1.0-or-later.html)                                         |      |
-| GNU General Public License v2.0 only                                         | [GPL-2.0-only](https://spdx.org/licenses/GPL-2.0-only.html)                                                 | Y    |
-| GNU General Public License v2.0 or later                                     | [GPL-2.0-or-later](https://spdx.org/licenses/GPL-2.0-or-later.html)                                         | Y    |
-| GNU General Public License v3.0 only                                         | [GPL-3.0-only](https://spdx.org/licenses/GPL-3.0-only.html)                                                 | Y    |
-| GNU General Public License v3.0 or later                                     | [GPL-3.0-or-later](https://spdx.org/licenses/GPL-3.0-or-later.html)                                         | Y    |
-| gSOAP Public License v1.3b                                                   | [gSOAP-1.3b](https://spdx.org/licenses/gSOAP-1.3b.html)                                                     |      |
-| Haskell Language Report License                                              | [HaskellReport](https://spdx.org/licenses/HaskellReport.html)                                               |      |
-| Historical Permission Notice and Disclaimer                                  | [HPND](https://spdx.org/licenses/HPND.html)                                                                 | Y    |
-| Historical Permission Notice and Disclaimer - sell variant                   | [HPND-sell-variant](https://spdx.org/licenses/HPND-sell-variant.html)                                       |      |
-| IBM PowerPC Initialization and Boot Software                                 | [IBM-pibs](https://spdx.org/licenses/IBM-pibs.html)                                                         |      |
-| ICU License                                                                  | [ICU](https://spdx.org/licenses/ICU.html)                                                                   |      |
-| Independent JPEG Group License                                               | [IJG](https://spdx.org/licenses/IJG.html)                                                                   |      |
-| ImageMagick License                                                          | [ImageMagick](https://spdx.org/licenses/ImageMagick.html)                                                   |      |
-| iMatix Standard Function Library Agreement                                   | [iMatix](https://spdx.org/licenses/iMatix.html)                                                             |      |
-| Imlib2 License                                                               | [Imlib2](https://spdx.org/licenses/Imlib2.html)                                                             |      |
-| Info-ZIP License                                                             | [Info-ZIP](https://spdx.org/licenses/Info-ZIP.html)                                                         |      |
-| Intel Open Source License                                                    | [Intel](https://spdx.org/licenses/Intel.html)                                                               | Y    |
-| Intel ACPI Software License Agreement                                        | [Intel-ACPI](https://spdx.org/licenses/Intel-ACPI.html)                                                     |      |
-| Interbase Public License v1.0                                                | [Interbase-1.0](https://spdx.org/licenses/Interbase-1.0.html)                                               |      |
-| IPA Font License                                                             | [IPA](https://spdx.org/licenses/IPA.html)                                                                   | Y    |
-| IBM Public License v1.0                                                      | [IPL-1.0](https://spdx.org/licenses/IPL-1.0.html)                                                           | Y    |
-| ISC License                                                                  | [ISC](https://spdx.org/licenses/ISC.html)                                                                   | Y    |
-| JasPer License                                                               | [JasPer-2.0](https://spdx.org/licenses/JasPer-2.0.html)                                                     |      |
-| Japan Network Information Center License                                     | [JPNIC](https://spdx.org/licenses/JPNIC.html)                                                               |      |
-| JSON License                                                                 | [JSON](https://spdx.org/licenses/JSON.html)                                                                 |      |
-| Licence Art Libre 1.2                                                        | [LAL-1.2](https://spdx.org/licenses/LAL-1.2.html)                                                           |      |
-| Licence Art Libre 1.3                                                        | [LAL-1.3](https://spdx.org/licenses/LAL-1.3.html)                                                           |      |
-| Latex2e License                                                              | [Latex2e](https://spdx.org/licenses/Latex2e.html)                                                           |      |
-| Leptonica License                                                            | [Leptonica](https://spdx.org/licenses/Leptonica.html)                                                       |      |
-| GNU Library General Public License v2 only                                   | [LGPL-2.0-only](https://spdx.org/licenses/LGPL-2.0-only.html)                                               | Y    |
-| GNU Library General Public License v2 or later                               | [LGPL-2.0-or-later](https://spdx.org/licenses/LGPL-2.0-or-later.html)                                       | Y    |
-| GNU Lesser General Public License v2.1 only                                  | [LGPL-2.1-only](https://spdx.org/licenses/LGPL-2.1-only.html)                                               | Y    |
-| GNU Lesser General Public License v2.1 or later                              | [LGPL-2.1-or-later](https://spdx.org/licenses/LGPL-2.1-or-later.html)                                       | Y    |
-| GNU Lesser General Public License v3.0 only                                  | [LGPL-3.0-only](https://spdx.org/licenses/LGPL-3.0-only.html)                                               | Y    |
-| GNU Lesser General Public License v3.0 or later                              | [LGPL-3.0-or-later](https://spdx.org/licenses/LGPL-3.0-or-later.html)                                       | Y    |
-| Lesser General Public License For Linguistic Resources                       | [LGPLLR](https://spdx.org/licenses/LGPLLR.html)                                                             |      |
-| libpng License                                                               | [Libpng](https://spdx.org/licenses/Libpng.html)                                                             |      |
-| PNG Reference Library version 2                                              | [libpng-2.0](https://spdx.org/licenses/libpng-2.0.html)                                                     |      |
-| libselinux public domain notice                                              | [libselinux-1.0](https://spdx.org/licenses/libselinux-1.0.html)                                             |      |
-| libtiff License                                                              | [libtiff](https://spdx.org/licenses/libtiff.html)                                                           |      |
-| Licence Libre du Québec – Permissive version 1.1                             | [LiLiQ-P-1.1](https://spdx.org/licenses/LiLiQ-P-1.1.html)                                                   | Y    |
-| Licence Libre du Québec – Réciprocité version 1.1                            | [LiLiQ-R-1.1](https://spdx.org/licenses/LiLiQ-R-1.1.html)                                                   | Y    |
-| Licence Libre du Québec – Réciprocité forte version 1.1                      | [LiLiQ-Rplus-1.1](https://spdx.org/licenses/LiLiQ-Rplus-1.1.html)                                           | Y    |
-| Linux Kernel Variant of OpenIB.org license                                   | [Linux-OpenIB](https://spdx.org/licenses/Linux-OpenIB.html)                                                 |      |
-| Lucent Public License Version 1.0                                            | [LPL-1.0](https://spdx.org/licenses/LPL-1.0.html)                                                           | Y    |
-| Lucent Public License v1.02                                                  | [LPL-1.02](https://spdx.org/licenses/LPL-1.02.html)                                                         | Y    |
-| LaTeX Project Public License v1.0                                            | [LPPL-1.0](https://spdx.org/licenses/LPPL-1.0.html)                                                         |      |
-| LaTeX Project Public License v1.1                                            | [LPPL-1.1](https://spdx.org/licenses/LPPL-1.1.html)                                                         |      |
-| LaTeX Project Public License v1.2                                            | [LPPL-1.2](https://spdx.org/licenses/LPPL-1.2.html)                                                         |      |
-| LaTeX Project Public License v1.3a                                           | [LPPL-1.3a](https://spdx.org/licenses/LPPL-1.3a.html)                                                       |      |
-| LaTeX Project Public License v1.3c                                           | [LPPL-1.3c](https://spdx.org/licenses/LPPL-1.3c.html)                                                       | Y    |
-| MakeIndex License                                                            | [MakeIndex](https://spdx.org/licenses/MakeIndex.html)                                                       |      |
-| The MirOS Licence                                                            | [MirOS](https://spdx.org/licenses/MirOS.html)                                                               | Y    |
-| MIT License                                                                  | [MIT](https://spdx.org/licenses/MIT.html)                                                                   | Y    |
-| MIT No Attribution                                                           | [MIT-0](https://spdx.org/licenses/MIT-0.html)                                                               |      |
-| Enlightenment License (e16)                                                  | [MIT-advertising](https://spdx.org/licenses/MIT-advertising.html)                                           |      |
-| CMU License                                                                  | [MIT-CMU](https://spdx.org/licenses/MIT-CMU.html)                                                           |      |
-| enna License                                                                 | [MIT-enna](https://spdx.org/licenses/MIT-enna.html)                                                         |      |
-| feh License                                                                  | [MIT-feh](https://spdx.org/licenses/MIT-feh.html)                                                           |      |
-| MIT +no-false-attribs license                                                | [MITNFA](https://spdx.org/licenses/MITNFA.html)                                                             |      |
-| Motosoto License                                                             | [Motosoto](https://spdx.org/licenses/Motosoto.html)                                                         | Y    |
-| mpich2 License                                                               | [mpich2](https://spdx.org/licenses/mpich2.html)                                                             |      |
-| Mozilla Public License 1.0                                                   | [MPL-1.0](https://spdx.org/licenses/MPL-1.0.html)                                                           | Y    |
-| Mozilla Public License 1.1                                                   | [MPL-1.1](https://spdx.org/licenses/MPL-1.1.html)                                                           | Y    |
-| Mozilla Public License 2.0                                                   | [MPL-2.0](https://spdx.org/licenses/MPL-2.0.html)                                                           | Y    |
-| Mozilla Public License 2.0 (no copyleft exception)                           | [MPL-2.0-no-copyleft-exception](https://spdx.org/licenses/MPL-2.0-no-copyleft-exception.html)               | Y    |
-| Microsoft Public License                                                     | [MS-PL](https://spdx.org/licenses/MS-PL.html)                                                               | Y    |
-| Microsoft Reciprocal License                                                 | [MS-RL](https://spdx.org/licenses/MS-RL.html)                                                               | Y    |
-| Matrix Template Library License                                              | [MTLL](https://spdx.org/licenses/MTLL.html)                                                                 |      |
-| Mulan Permissive Software License, Version 1                                 | [MulanPSL-1.0](https://spdx.org/licenses/MulanPSL-1.0.html)                                                 |      |
-| Multics License                                                              | [Multics](https://spdx.org/licenses/Multics.html)                                                           | Y    |
-| Mup License                                                                  | [Mup](https://spdx.org/licenses/Mup.html)                                                                   |      |
-| NASA Open Source Agreement 1.3                                               | [NASA-1.3](https://spdx.org/licenses/NASA-1.3.html)                                                         | Y    |
-| Naumen Public License                                                        | [Naumen](https://spdx.org/licenses/Naumen.html)                                                             | Y    |
-| Net Boolean Public License v1                                                | [NBPL-1.0](https://spdx.org/licenses/NBPL-1.0.html)                                                         |      |
-| University of Illinois/NCSA Open Source License                              | [NCSA](https://spdx.org/licenses/NCSA.html)                                                                 | Y    |
-| Net-SNMP License                                                             | [Net-SNMP](https://spdx.org/licenses/Net-SNMP.html)                                                         |      |
-| NetCDF license                                                               | [NetCDF](https://spdx.org/licenses/NetCDF.html)                                                             |      |
-| Newsletr License                                                             | [Newsletr](https://spdx.org/licenses/Newsletr.html)                                                         |      |
-| Nethack General Public License                                               | [NGPL](https://spdx.org/licenses/NGPL.html)                                                                 | Y    |
-| Norwegian Licence for Open Government Data                                   | [NLOD-1.0](https://spdx.org/licenses/NLOD-1.0.html)                                                         |      |
-| No Limit Public License                                                      | [NLPL](https://spdx.org/licenses/NLPL.html)                                                                 |      |
-| Nokia Open Source License                                                    | [Nokia](https://spdx.org/licenses/Nokia.html)                                                               | Y    |
-| Netizen Open Source License                                                  | [NOSL](https://spdx.org/licenses/NOSL.html)                                                                 |      |
-| Noweb License                                                                | [Noweb](https://spdx.org/licenses/Noweb.html)                                                               |      |
-| Netscape Public License v1.0                                                 | [NPL-1.0](https://spdx.org/licenses/NPL-1.0.html)                                                           |      |
-| Netscape Public License v1.1                                                 | [NPL-1.1](https://spdx.org/licenses/NPL-1.1.html)                                                           |      |
-| Non-Profit Open Software License 3.0                                         | [NPOSL-3.0](https://spdx.org/licenses/NPOSL-3.0.html)                                                       | Y    |
-| NRL License                                                                  | [NRL](https://spdx.org/licenses/NRL.html)                                                                   |      |
-| NTP License                                                                  | [NTP](https://spdx.org/licenses/NTP.html)                                                                   | Y    |
-| NTP No Attribution                                                           | [NTP-0](https://spdx.org/licenses/NTP-0.html)                                                               |      |
-| Open CASCADE Technology Public License                                       | [OCCT-PL](https://spdx.org/licenses/OCCT-PL.html)                                                           |      |
-| OCLC Research Public License 2.0                                             | [OCLC-2.0](https://spdx.org/licenses/OCLC-2.0.html)                                                         | Y    |
-| ODC Open Database License v1.0                                               | [ODbL-1.0](https://spdx.org/licenses/ODbL-1.0.html)                                                         |      |
-| Open Data Commons Attribution License v1.0                                   | [ODC-By-1.0](https://spdx.org/licenses/ODC-By-1.0.html)                                                     |      |
-| SIL Open Font License 1.0                                                    | [OFL-1.0](https://spdx.org/licenses/OFL-1.0.html)                                                           |      |
-| SIL Open Font License 1.0 with no Reserved Font Name                         | [OFL-1.0-no-RFN](https://spdx.org/licenses/OFL-1.0-no-RFN.html)                                             |      |
-| SIL Open Font License 1.0 with Reserved Font Name                            | [OFL-1.0-RFN](https://spdx.org/licenses/OFL-1.0-RFN.html)                                                   |      |
-| SIL Open Font License 1.1                                                    | [OFL-1.1](https://spdx.org/licenses/OFL-1.1.html)                                                           | Y    |
-| SIL Open Font License 1.1 with no Reserved Font Name                         | [OFL-1.1-no-RFN](https://spdx.org/licenses/OFL-1.1-no-RFN.html)                                             | Y    |
-| SIL Open Font License 1.1 with Reserved Font Name                            | [OFL-1.1-RFN](https://spdx.org/licenses/OFL-1.1-RFN.html)                                                   | Y    |
-| Open Government Licence - Canada                                             | [OGL-Canada-2.0](https://spdx.org/licenses/OGL-Canada-2.0.html)                                             |      |
-| Open Government Licence v1.0                                                 | [OGL-UK-1.0](https://spdx.org/licenses/OGL-UK-1.0.html)                                                     |      |
-| Open Government Licence v2.0                                                 | [OGL-UK-2.0](https://spdx.org/licenses/OGL-UK-2.0.html)                                                     |      |
-| Open Government Licence v3.0                                                 | [OGL-UK-3.0](https://spdx.org/licenses/OGL-UK-3.0.html)                                                     |      |
-| Open Group Test Suite License                                                | [OGTSL](https://spdx.org/licenses/OGTSL.html)                                                               | Y    |
-| Open LDAP Public License v1.1                                                | [OLDAP-1.1](https://spdx.org/licenses/OLDAP-1.1.html)                                                       |      |
-| Open LDAP Public License v1.2                                                | [OLDAP-1.2](https://spdx.org/licenses/OLDAP-1.2.html)                                                       |      |
-| Open LDAP Public License v1.3                                                | [OLDAP-1.3](https://spdx.org/licenses/OLDAP-1.3.html)                                                       |      |
-| Open LDAP Public License v1.4                                                | [OLDAP-1.4](https://spdx.org/licenses/OLDAP-1.4.html)                                                       |      |
-| Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)                    | [OLDAP-2.0](https://spdx.org/licenses/OLDAP-2.0.html)                                                       |      |
-| Open LDAP Public License v2.0.1                                              | [OLDAP-2.0.1](https://spdx.org/licenses/OLDAP-2.0.1.html)                                                   |      |
-| Open LDAP Public License v2.1                                                | [OLDAP-2.1](https://spdx.org/licenses/OLDAP-2.1.html)                                                       |      |
-| Open LDAP Public License v2.2                                                | [OLDAP-2.2](https://spdx.org/licenses/OLDAP-2.2.html)                                                       |      |
-| Open LDAP Public License v2.2.1                                              | [OLDAP-2.2.1](https://spdx.org/licenses/OLDAP-2.2.1.html)                                                   |      |
-| Open LDAP Public License 2.2.2                                               | [OLDAP-2.2.2](https://spdx.org/licenses/OLDAP-2.2.2.html)                                                   |      |
-| Open LDAP Public License v2.3                                                | [OLDAP-2.3](https://spdx.org/licenses/OLDAP-2.3.html)                                                       |      |
-| Open LDAP Public License v2.4                                                | [OLDAP-2.4](https://spdx.org/licenses/OLDAP-2.4.html)                                                       |      |
-| Open LDAP Public License v2.5                                                | [OLDAP-2.5](https://spdx.org/licenses/OLDAP-2.5.html)                                                       |      |
-| Open LDAP Public License v2.6                                                | [OLDAP-2.6](https://spdx.org/licenses/OLDAP-2.6.html)                                                       |      |
-| Open LDAP Public License v2.7                                                | [OLDAP-2.7](https://spdx.org/licenses/OLDAP-2.7.html)                                                       |      |
-| Open LDAP Public License v2.8                                                | [OLDAP-2.8](https://spdx.org/licenses/OLDAP-2.8.html)                                                       |      |
-| Open Market License                                                          | [OML](https://spdx.org/licenses/OML.html)                                                                   |      |
-| OpenSSL License                                                              | [OpenSSL](https://spdx.org/licenses/OpenSSL.html)                                                           |      |
-| Open Public License v1.0                                                     | [OPL-1.0](https://spdx.org/licenses/OPL-1.0.html)                                                           |      |
-| OSET Public License version 2.1                                              | [OSET-PL-2.1](https://spdx.org/licenses/OSET-PL-2.1.html)                                                   | Y    |
-| Open Software License 1.0                                                    | [OSL-1.0](https://spdx.org/licenses/OSL-1.0.html)                                                           | Y    |
-| Open Software License 1.1                                                    | [OSL-1.1](https://spdx.org/licenses/OSL-1.1.html)                                                           |      |
-| Open Software License 2.0                                                    | [OSL-2.0](https://spdx.org/licenses/OSL-2.0.html)                                                           | Y    |
-| Open Software License 2.1                                                    | [OSL-2.1](https://spdx.org/licenses/OSL-2.1.html)                                                           | Y    |
-| Open Software License 3.0                                                    | [OSL-3.0](https://spdx.org/licenses/OSL-3.0.html)                                                           | Y    |
-| The Parity Public License 6.0.0                                              | [Parity-6.0.0](https://spdx.org/licenses/Parity-6.0.0.html)                                                 |      |
-| ODC Public Domain Dedication & License 1.0                                   | [PDDL-1.0](https://spdx.org/licenses/PDDL-1.0.html)                                                         |      |
-| PHP License v3.0                                                             | [PHP-3.0](https://spdx.org/licenses/PHP-3.0.html)                                                           | Y    |
-| PHP License v3.01                                                            | [PHP-3.01](https://spdx.org/licenses/PHP-3.01.html)                                                         |      |
-| Plexus Classworlds License                                                   | [Plexus](https://spdx.org/licenses/Plexus.html)                                                             |      |
-| PostgreSQL License                                                           | [PostgreSQL](https://spdx.org/licenses/PostgreSQL.html)                                                     | Y    |
-| Python Software Foundation License 2.0                                       | [PSF-2.0](https://spdx.org/licenses/PSF-2.0.html)                                                           |      |
-| psfrag License                                                               | [psfrag](https://spdx.org/licenses/psfrag.html)                                                             |      |
-| psutils License                                                              | [psutils](https://spdx.org/licenses/psutils.html)                                                           |      |
-| Python License 2.0                                                           | [Python-2.0](https://spdx.org/licenses/Python-2.0.html)                                                     | Y    |
-| Qhull License                                                                | [Qhull](https://spdx.org/licenses/Qhull.html)                                                               |      |
-| Q Public License 1.0                                                         | [QPL-1.0](https://spdx.org/licenses/QPL-1.0.html)                                                           | Y    |
-| Rdisc License                                                                | [Rdisc](https://spdx.org/licenses/Rdisc.html)                                                               |      |
-| Red Hat eCos Public License v1.1                                             | [RHeCos-1.1](https://spdx.org/licenses/RHeCos-1.1.html)                                                     |      |
-| Reciprocal Public License 1.1                                                | [RPL-1.1](https://spdx.org/licenses/RPL-1.1.html)                                                           | Y    |
-| Reciprocal Public License 1.5                                                | [RPL-1.5](https://spdx.org/licenses/RPL-1.5.html)                                                           | Y    |
-| RealNetworks Public Source License v1.0                                      | [RPSL-1.0](https://spdx.org/licenses/RPSL-1.0.html)                                                         | Y    |
-| RSA Message-Digest License                                                   | [RSA-MD](https://spdx.org/licenses/RSA-MD.html)                                                             |      |
-| Ricoh Source Code Public License                                             | [RSCPL](https://spdx.org/licenses/RSCPL.html)                                                               | Y    |
-| Ruby License                                                                 | [Ruby](https://spdx.org/licenses/Ruby.html)                                                                 |      |
-| Sax Public Domain Notice                                                     | [SAX-PD](https://spdx.org/licenses/SAX-PD.html)                                                             |      |
-| Saxpath License                                                              | [Saxpath](https://spdx.org/licenses/Saxpath.html)                                                           |      |
-| SCEA Shared Source License                                                   | [SCEA](https://spdx.org/licenses/SCEA.html)                                                                 |      |
-| Sendmail License                                                             | [Sendmail](https://spdx.org/licenses/Sendmail.html)                                                         |      |
-| Sendmail License 8.23                                                        | [Sendmail-8.23](https://spdx.org/licenses/Sendmail-8.23.html)                                               |      |
-| SGI Free Software License B v1.0                                             | [SGI-B-1.0](https://spdx.org/licenses/SGI-B-1.0.html)                                                       |      |
-| SGI Free Software License B v1.1                                             | [SGI-B-1.1](https://spdx.org/licenses/SGI-B-1.1.html)                                                       |      |
-| SGI Free Software License B v2.0                                             | [SGI-B-2.0](https://spdx.org/licenses/SGI-B-2.0.html)                                                       |      |
-| Solderpad Hardware License v0.5                                              | [SHL-0.5](https://spdx.org/licenses/SHL-0.5.html)                                                           |      |
-| Solderpad Hardware License, Version 0.51                                     | [SHL-0.51](https://spdx.org/licenses/SHL-0.51.html)                                                         |      |
-| Simple Public License 2.0                                                    | [SimPL-2.0](https://spdx.org/licenses/SimPL-2.0.html)                                                       | Y    |
-| Sun Industry Standards Source License v1.1                                   | [SISSL](https://spdx.org/licenses/SISSL.html)                                                               | Y    |
-| Sun Industry Standards Source License v1.2                                   | [SISSL-1.2](https://spdx.org/licenses/SISSL-1.2.html)                                                       |      |
-| Sleepycat License                                                            | [Sleepycat](https://spdx.org/licenses/Sleepycat.html)                                                       | Y    |
-| Standard ML of New Jersey License                                            | [SMLNJ](https://spdx.org/licenses/SMLNJ.html)                                                               |      |
-| Secure Messaging Protocol Public License                                     | [SMPPL](https://spdx.org/licenses/SMPPL.html)                                                               |      |
-| SNIA Public License 1.1                                                      | [SNIA](https://spdx.org/licenses/SNIA.html)                                                                 |      |
-| Spencer License 86                                                           | [Spencer-86](https://spdx.org/licenses/Spencer-86.html)                                                     |      |
-| Spencer License 94                                                           | [Spencer-94](https://spdx.org/licenses/Spencer-94.html)                                                     |      |
-| Spencer License 99                                                           | [Spencer-99](https://spdx.org/licenses/Spencer-99.html)                                                     |      |
-| Sun Public License v1.0                                                      | [SPL-1.0](https://spdx.org/licenses/SPL-1.0.html)                                                           | Y    |
-| SSH OpenSSH license                                                          | [SSH-OpenSSH](https://spdx.org/licenses/SSH-OpenSSH.html)                                                   |      |
-| SSH short notice                                                             | [SSH-short](https://spdx.org/licenses/SSH-short.html)                                                       |      |
-| Server Side Public License, v 1                                              | [SSPL-1.0](https://spdx.org/licenses/SSPL-1.0.html)                                                         |      |
-| SugarCRM Public License v1.1.3                                               | [SugarCRM-1.1.3](https://spdx.org/licenses/SugarCRM-1.1.3.html)                                             |      |
-| Scheme Widget Library (SWL) Software License Agreement                       | [SWL](https://spdx.org/licenses/SWL.html)                                                                   |      |
-| TAPR Open Hardware License v1.0                                              | [TAPR-OHL-1.0](https://spdx.org/licenses/TAPR-OHL-1.0.html)                                                 |      |
-| TCL/TK License                                                               | [TCL](https://spdx.org/licenses/TCL.html)                                                                   |      |
-| TCP Wrappers License                                                         | [TCP-wrappers](https://spdx.org/licenses/TCP-wrappers.html)                                                 |      |
-| TMate Open Source License                                                    | [TMate](https://spdx.org/licenses/TMate.html)                                                               |      |
-| TORQUE v2.5+ Software License v1.1                                           | [TORQUE-1.1](https://spdx.org/licenses/TORQUE-1.1.html)                                                     |      |
-| Trusster Open Source License                                                 | [TOSL](https://spdx.org/licenses/TOSL.html)                                                                 |      |
-| Technische Universitaet Berlin License 1.0                                   | [TU-Berlin-1.0](https://spdx.org/licenses/TU-Berlin-1.0.html)                                               |      |
-| Technische Universitaet Berlin License 2.0                                   | [TU-Berlin-2.0](https://spdx.org/licenses/TU-Berlin-2.0.html)                                               |      |
-| Upstream Compatibility License v1.0                                          | [UCL-1.0](https://spdx.org/licenses/UCL-1.0.html)                                                           | Y    |
-| Unicode License Agreement - Data Files and Software (2015)                   | [Unicode-DFS-2015](https://spdx.org/licenses/Unicode-DFS-2015.html)                                         |      |
-| Unicode License Agreement - Data Files and Software (2016)                   | [Unicode-DFS-2016](https://spdx.org/licenses/Unicode-DFS-2016.html)                                         |      |
-| Unicode Terms of Use                                                         | [Unicode-TOU](https://spdx.org/licenses/Unicode-TOU.html)                                                   |      |
-| The Unlicense                                                                | [Unlicense](https://spdx.org/licenses/Unlicense.html)                                                       |      |
-| Universal Permissive License v1.0                                            | [UPL-1.0](https://spdx.org/licenses/UPL-1.0.html)                                                           | Y    |
-| Vim License                                                                  | [Vim](https://spdx.org/licenses/Vim.html)                                                                   |      |
-| VOSTROM Public License for Open Source                                       | [VOSTROM](https://spdx.org/licenses/VOSTROM.html)                                                           |      |
-| Vovida Software License v1.0                                                 | [VSL-1.0](https://spdx.org/licenses/VSL-1.0.html)                                                           | Y    |
-| W3C Software Notice and License (2002-12-31)                                 | [W3C](https://spdx.org/licenses/W3C.html)                                                                   | Y    |
-| W3C Software Notice and License (1998-07-20)                                 | [W3C-19980720](https://spdx.org/licenses/W3C-19980720.html)                                                 |      |
-| W3C Software Notice and Document License (2015-05-13)                        | [W3C-20150513](https://spdx.org/licenses/W3C-20150513.html)                                                 |      |
-| Sybase Open Watcom Public License 1.0                                        | [Watcom-1.0](https://spdx.org/licenses/Watcom-1.0.html)                                                     | Y    |
-| Wsuipa License                                                               | [Wsuipa](https://spdx.org/licenses/Wsuipa.html)                                                             |      |
-| Do What The F\*ck You Want To Public License                                  | [WTFPL](https://spdx.org/licenses/WTFPL.html)                                                               |      |
-| X11 License                                                                  | [X11](https://spdx.org/licenses/X11.html)                                                                   |      |
-| Xerox License                                                                | [Xerox](https://spdx.org/licenses/Xerox.html)                                                               |      |
-| XFree86 License 1.1                                                          | [XFree86-1.1](https://spdx.org/licenses/XFree86-1.1.html)                                                   |      |
-| xinetd License                                                               | [xinetd](https://spdx.org/licenses/xinetd.html)                                                             |      |
-| X.Net License                                                                | [Xnet](https://spdx.org/licenses/Xnet.html)                                                                 | Y    |
-| XPP License                                                                  | [xpp](https://spdx.org/licenses/xpp.html)                                                                   |      |
-| XSkat License                                                                | [XSkat](https://spdx.org/licenses/XSkat.html)                                                               |      |
-| Yahoo! Public License v1.0                                                   | [YPL-1.0](https://spdx.org/licenses/YPL-1.0.html)                                                           |      |
-| Yahoo! Public License v1.1                                                   | [YPL-1.1](https://spdx.org/licenses/YPL-1.1.html)                                                           |      |
-| Zed License                                                                  | [Zed](https://spdx.org/licenses/Zed.html)                                                                   |      |
-| Zend License v2.0                                                            | [Zend-2.0](https://spdx.org/licenses/Zend-2.0.html)                                                         |      |
-| Zimbra Public License v1.3                                                   | [Zimbra-1.3](https://spdx.org/licenses/Zimbra-1.3.html)                                                     |      |
-| Zimbra Public License v1.4                                                   | [Zimbra-1.4](https://spdx.org/licenses/Zimbra-1.4.html)                                                     |      |
-| zlib License                                                                 | [Zlib](https://spdx.org/licenses/Zlib.html)                                                                 | Y    |
-| zlib/libpng License with Acknowledgement                                     | [zlib-acknowledgement](https://spdx.org/licenses/zlib-acknowledgement.html)                                 |      |
-| Zope Public License 1.1                                                      | [ZPL-1.1](https://spdx.org/licenses/ZPL-1.1.html)                                                           |      |
-| Zope Public License 2.0                                                      | [ZPL-2.0](https://spdx.org/licenses/ZPL-2.0.html)                                                           | Y    |
-| Zope Public License 2.1                                                      | [ZPL-2.1](https://spdx.org/licenses/ZPL-2.1.html)                                                           |      |
+| Full Name of License                                                         | Short Identifier                                                                                            | FSF? |OSI? |
+|------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|------|-----|
+| BSD Zero Clause License                                                      | [0BSD](https://spdx.org/licenses/0BSD.html)                                                                 |      | Y   |
+| Attribution Assurance License                                                | [AAL](https://spdx.org/licenses/AAL.html)                                                                   |      | Y   |
+| Abstyles License                                                             | [Abstyles](https://spdx.org/licenses/Abstyles.html)                                                         |      |     |
+| Adobe Systems Incorporated Source Code License Agreement                     | [Adobe-2006](https://spdx.org/licenses/Adobe-2006.html)                                                     |      |     |
+| Adobe Glyph List License                                                     | [Adobe-Glyph](https://spdx.org/licenses/Adobe-Glyph.html)                                                   |      |     |
+| Amazon Digital Services License                                              | [ADSL](https://spdx.org/licenses/ADSL.html)                                                                 |      |     |
+| Academic Free License v1.1                                                   | [AFL-1.1](https://spdx.org/licenses/AFL-1.1.html)                                                           | Y    | Y   |
+| Academic Free License v1.2                                                   | [AFL-1.2](https://spdx.org/licenses/AFL-1.2.html)                                                           | Y    | Y   |
+| Academic Free License v2.0                                                   | [AFL-2.0](https://spdx.org/licenses/AFL-2.0.html)                                                           | Y    | Y   |
+| Academic Free License v2.1                                                   | [AFL-2.1](https://spdx.org/licenses/AFL-2.1.html)                                                           | Y    | Y   |
+| Academic Free License v3.0                                                   | [AFL-3.0](https://spdx.org/licenses/AFL-3.0.html)                                                           | Y    | Y   |
+| Afmparse License                                                             | [Afmparse](https://spdx.org/licenses/Afmparse.html)                                                         |      |     |
+| Affero General Public License v1.0 only                                      | [AGPL-1.0-only](https://spdx.org/licenses/AGPL-1.0-only.html)                                               |      |     |
+| Affero General Public License v1.0 or later                                  | [AGPL-1.0-or-later](https://spdx.org/licenses/AGPL-1.0-or-later.html)                                       |      |     |
+| GNU Affero General Public License v3.0 only                                  | [AGPL-3.0-only](https://spdx.org/licenses/AGPL-3.0-only.html)                                               | Y    | Y   |
+| GNU Affero General Public License v3.0 or later                              | [AGPL-3.0-or-later](https://spdx.org/licenses/AGPL-3.0-or-later.html)                                       | Y    | Y   |
+| Aladdin Free Public License                                                  | [Aladdin](https://spdx.org/licenses/Aladdin.html)                                                           |      |     |
+| AMD's plpa_map.c License                                                     | [AMDPLPA](https://spdx.org/licenses/AMDPLPA.html)                                                           |      |     |
+| Apple MIT License                                                            | [AML](https://spdx.org/licenses/AML.html)                                                                   |      |     |
+| Academy of Motion Picture Arts and Sciences BSD                              | [AMPAS](https://spdx.org/licenses/AMPAS.html)                                                               |      |     |
+| ANTLR Software Rights Notice                                                 | [ANTLR-PD](https://spdx.org/licenses/ANTLR-PD.html)                                                         |      |     |
+| Apache License 1.0                                                           | [Apache-1.0](https://spdx.org/licenses/Apache-1.0.html)                                                     | Y    |     |
+| Apache License 1.1                                                           | [Apache-1.1](https://spdx.org/licenses/Apache-1.1.html)                                                     | Y    | Y   |
+| Apache License 2.0                                                           | [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html)                                                     | Y    | Y   |
+| Adobe Postscript AFM License                                                 | [APAFML](https://spdx.org/licenses/APAFML.html)                                                             |      |     |
+| Adaptive Public License 1.0                                                  | [APL-1.0](https://spdx.org/licenses/APL-1.0.html)                                                           |      | Y   |
+| App::s2p License                                                             | [App-2sp](https://spdx.org/licenses/App-s2p.html)                                                           |      |     |
+| Apple Public Source License 1.0                                              | [APSL-1.0](https://spdx.org/licenses/APSL-1.0.html)                                                         |      | Y   |
+| Apple Public Source License 1.1                                              | [APSL-1.1](https://spdx.org/licenses/APSL-1.1.html)                                                         |      | Y   |
+| Apple Public Source License 1.2                                              | [APSL-1.2](https://spdx.org/licenses/APSL-1.2.html)                                                         |      | Y   |
+| Apple Public Source License 2.0                                              | [APSL-2.0](https://spdx.org/licenses/APSL-2.0.html)                                                         | Y    | Y   |
+| Arphic Public Source                                                         | [Arphic-1999](https://spdx.org/licenses/Arphic-1999.html)                                                   |      |     |
+| Artistic License 1.0                                                         | [Artistic-1.0](https://spdx.org/licenses/Artistic-1.0.html)                                                 |      | Y   |
+| Artistic License 1.0 w/clause 8                                              | [Artistic-1.0-cl8](https://spdx.org/licenses/Artistic-1.0-cl8.html)                                         |      | Y   |
+| Artistic License 1.0 (Perl)                                                  | [Artistic-1.0-Perl](https://spdx.org/licenses/Artistic-1.0-Perl.html)                                       |      | Y   |
+| Artistic License 2.0                                                         | [Artistic-2.0](https://spdx.org/licenses/Artistic-2.0.html)                                                 | Y    | Y   |
+| Baekmuk License                                                              | [Baekmuk](https://spdx.org/licenses/Baekmuk.html)                                                           |      |     |
+| Bahyph License                                                               | [Bahyph](https://spdx.org/licenses/Bahyph.html)                                                             |      |     |
+| Barr License                                                                 | [Barr](https://spdx.org/licenses/Barr.html)                                                                 |      |     |
+| Beerware License                                                             | [Beerware](https://spdx.org/licenses/Beerware.html)                                                         |      |     |
+| BitTorrent Open Source License v1.0                                          | [BitTorrent-1.0](https://spdx.org/licenses/BitTorrent-1.0.html)                                             |      |     |
+| BitTorrent Open Source License v1.1                                          | [BitTorrent-1.1](https://spdx.org/licenses/BitTorrent-1.1.html)                                             | Y    |     |
+| SQLite Blessing                                                              | [blessing](https://spdx.org/licenses/blessing.html)                                                         |      |     |
+| Blue Oak Model License 1.0.0                                                 | [BlueOak-1.0.0](https://spdx.org/licenses/BlueOak-1.0.0.html)                                               |      |     |
+| Borceux license                                                              | [Borceux](https://spdx.org/licenses/Borceux.html)                                                           |      |     |
+| BSD 1-Clause License                                                         | [BSD-1-Clause](https://spdx.org/licenses/BSD-1-Clause.html)                                                 |      | Y   |
+| BSD 2-Clause "Simplified" License                                            | [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html)                                                 | Y    | Y   |
+| BSD 2-Clause Plus Patent License                                             | [BSD-2-Clause-Patent](https://spdx.org/licenses/BSD-2-Clause-Patent.html)                                   |      | Y   |
+| BSD 2-Clause with views sentence                                             | [BSD-2-Clause-Views](https://spdx.org/licenses/BSD-2-Clause-Views.html)                                     |      |     |
+| BSD 3-Clause "New" or "Revised" License                                      | [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html)                                                 | Y    | Y   |
+| BSD with attribution                                                         | [BSD-3-Clause-Attribution](https://spdx.org/licenses/BSD-3-Clause-Attribution.html)                         |      |     |
+| BSD 3-Clause Clear License                                                   | [BSD-3-Clause-Clear](https://spdx.org/licenses/BSD-3-Clause-Clear.html)                                     | Y    |     |
+| Lawrence Berkeley National Labs BSD variant license                          | [BSD-3-Clause-LBNL](https://spdx.org/licenses/BSD-3-Clause-LBNL.html)                                       |      | Y   |
+| BSD 3-Clause Modification                                                    | [BSD-3-Clause-Modification](https://spdx.org/licenses/BSD-3-Clause-Modification.html)                       |      |     |
+| BSD 3-Clause No Military License                                             | [BSD-3-Clause-No-Military-License](https://spdx.org/licenses/BSD-3-Clause-No-Military-License.html)         |      |     |
+| BSD 3-Clause No Nuclear License                                              | [BSD-3-Clause-No-Nuclear-License](https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.html)           |      |     |
+| BSD 3-Clause No Nuclear License 2014                                         | [BSD-3-Clause-No-Nuclear-License-2014](https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.html) |      |     |
+| BSD 3-Clause No Nuclear Warranty                                             | [BSD-3-Clause-No-Nuclear-Warranty](https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.html)         |      |     |
+| BSD 3-Clause Open MPI variant                                                | [BSD-3-Clause-Open-MPI](https://spdx.org/licenses/BSD-3-Clause-Open-MPI.html)                               |      |     |
+| BSD 4-Clause "Original" or "Old" License                                     | [BSD-4-Clause](https://spdx.org/licenses/BSD-4-Clause.html)                                                 | Y    |     |
+| BSD 4-Clause Shortened                                                       | [BSD-4-Clause-Shortened](https://spdx.org/licenses/BSD-4-Clause-Shortened.html)                             |      |     |
+| BSD-4-Clause (University of California-Specific)                             | [BSD-4-Clause-UC](https://spdx.org/licenses/BSD-4-Clause-UC.html)                                           |      |     |
+| BSD Protection License                                                       | [BSD-Protection](https://spdx.org/licenses/BSD-Protection.html)                                             |      |     |
+| BSD Source Code Attribution                                                  | [BSD-Source-Code](https://spdx.org/licenses/BSD-Source-Code.html)                                           |      |     |
+| Boost Software License 1.0                                                   | [BSL-1.0](https://spdx.org/licenses/BSL-1.0.html)                                                           | Y    | Y   |
+| Business Source License 1.1                                                  | [BUSL-1.1](https://spdx.org/licenses/BUSL-1.1.html)                                                         |      |     |
+| bzip2 and libbzip2 License v1.0.6                                            | [bzip2-1.0.6](https://spdx.org/licenses/bzip2-1.0.6.html)                                                   |      |     |
+| Computational Use of Data Agreement v1.0                                     | [C-UDA-1.0](https://spdx.org/licenses/C-UDA-1.0.html)                                                       |      |     |
+| Cryptographic Autonomy License 1.0                                           | [CAL-1.0](https://spdx.org/licenses/CAL-1.0.html)                                                           |      | Y   |
+| Cryptographic Autonomy License 1.0 (Combined Work Exception)                 | [CAL-1.0-Combined-Work-Exception](https://spdx.org/licenses/CAL-1.0-Combined-Work-Exception.html)           |      | Y   |
+| Caldera License                                                              | [Caldera](https://spdx.org/licenses/Caldera.html)                                                           |      |     |
+| Computer Associates Trusted Open Source License 1.1                          | [CATOSL-1.1](https://spdx.org/licenses/CATOSL-1.1.html)                                                     |      | Y   |
+| Creative Commons Attribution 1.0 Generic                                     | [CC-BY-1.0](https://spdx.org/licenses/CC-BY-1.0.html)                                                       |      |     |
+| Creative Commons Attribution 2.0 Generic                                     | [CC-BY-2.0](https://spdx.org/licenses/CC-BY-2.0.html)                                                       |      |     |
+| Creative Commons Attribution 2.5 Generic                                     | [CC-BY-2.5](https://spdx.org/licenses/CC-BY-2.5.html)                                                       |      |     |
+| Creative Commons Attribution 2.5 Australia                                   | [CC-BY-2.5-AU](https://spdx.org/licenses/CC-BY-2.5-AU.html)                                                 |      |     |
+| Creative Commons Attribution 3.0 Unported                                    | [CC-BY-3.0](https://spdx.org/licenses/CC-BY-3.0.html)                                                       |      |     |
+| Creative Commons Attribution 3.0 Austria                                     | [CC-BY-3.0-AT](https://spdx.org/licenses/CC-BY-3.0-AT.html)                                                 |      |     |
+| Creative Commons Attribution 3.0 Germany                                     | [CC-BY-3.0-DE](https://spdx.org/licenses/CC-BY-3.0-DE.html)                                                 |      |     |
+| Creative Commons Attribution 3.0 Netherlands                                 | [CC-BY-3.0-NL](https://spdx.org/licenses/CC-BY-3.0-NL.html)                                                 |      |     |
+| Creative Commons Attribution 3.0 United States                               | [CC-BY-3.0-US](https://spdx.org/licenses/CC-BY-3.0-US.html)                                                 |      |     |
+| Creative Commons Attribution 4.0 International                               | [CC-BY-4.0](https://spdx.org/licenses/CC-BY-4.0.html)                                                       | Y    |     |
+| Creative Commons Attribution Non Commercial 1.0 Generic                      | [CC-BY-NC-1.0](https://spdx.org/licenses/CC-BY-NC-1.0.html)                                                 |      |     |
+| Creative Commons Attribution Non Commercial 2.0 Generic                      | [CC-BY-NC-2.0](https://spdx.org/licenses/CC-BY-NC-2.0.html)                                                 |      |     |
+| Creative Commons Attribution Non Commercial 2.5 Generic                      | [CC-BY-NC-2.5](https://spdx.org/licenses/CC-BY-NC-2.5.html)                                                 |      |     |
+| Creative Commons Attribution Non Commercial 3.0 Unported                     | [CC-BY-NC-3.0](https://spdx.org/licenses/CC-BY-NC-3.0.html)                                                 |      |     |
+| Creative Commons Attribution Non Commercial 3.0 Germany                      | [CC-BY-NC-3.0-DE](https://spdx.org/licenses/CC-BY-NC-3.0-DE.html)                                           |      |     |
+| Creative Commons Attribution Non Commercial 4.0 International                | [CC-BY-NC-4.0](https://spdx.org/licenses/CC-BY-NC-4.0.html)                                                 |      |     |
+| Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic       | [CC-BY-NC-ND-1.0](https://spdx.org/licenses/CC-BY-NC-ND-1.0.html)                                           |      |     |
+| Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic       | [CC-BY-NC-ND-2.0](https://spdx.org/licenses/CC-BY-NC-ND-2.0.html)                                           |      |     |
+| Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic       | [CC-BY-NC-ND-2.5](https://spdx.org/licenses/CC-BY-NC-ND-2.5.html)                                           |      |     |
+| Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported      | [CC-BY-NC-ND-3.0](https://spdx.org/licenses/CC-BY-NC-ND-3.0.html)                                           |      |     |
+| Creative Commons Attribution Non Commercial No Derivatives 3.0 Germany       | [CC-BY-NC-ND-3.0-DE](https://spdx.org/licenses/CC-BY-NC-ND-3.0-DE.html)                                     |      |     |
+| Creative Commons Attribution Non Commercial No Derivatives 3.0 IGO           | [CC-BY-NC-ND-3.0-IGO](https://spdx.org/licenses/CC-BY-NC-ND-3.0-IGO.html)                                   |      |     |
+| Creative Commons Attribution Non Commercial No Derivatives 4.0 International | [CC-BY-NC-ND-4.0](https://spdx.org/licenses/CC-BY-NC-ND-4.0.html)                                           |      |     |
+| Creative Commons Attribution Non Commercial Share Alike 1.0 Generic          | [CC-BY-NC-SA-1.0](https://spdx.org/licenses/CC-BY-NC-SA-1.0.html)                                           |      |     |
+| Creative Commons Attribution Non Commercial Share Alike 2.0 Generic          | [CC-BY-NC-SA-2.0](https://spdx.org/licenses/CC-BY-NC-SA-2.0.html)                                           |      |     |
+| Creative Commons Attribution Non Commercial Share Alike 2.0 France           | [CC-BY-NC-SA-2.0-FR](https://spdx.org/licenses/CC-BY-NC-SA-2.0-FR.html)                                     |      |     |
+| Creative Commons Attribution Non Commercial Share Alike 2.0 England and Wales| [CC-BY-NC-SA-2.0-UK](https://spdx.org/licenses/CC-BY-NC-SA-2.0-UK.html)                                     |      |     |
+| Creative Commons Attribution Non Commercial Share Alike 2.5 Generic          | [CC-BY-NC-SA-2.5](https://spdx.org/licenses/CC-BY-NC-SA-2.5.html)                                           |      |     |
+| Creative Commons Attribution Non Commercial Share Alike 3.0 Unported         | [CC-BY-NC-SA-3.0](https://spdx.org/licenses/CC-BY-NC-SA-3.0.html)                                           |      |     |
+| Creative Commons Attribution Non Commercial Share Alike 3.0 Germany          | [CC-BY-NC-SA-3.0-DE](https://spdx.org/licenses/CC-BY-NC-SA-3.0-DE.html)                                     |      |     |
+| Creative Commons Attribution Non Commercial Share Alike 3.0 IGO              | [CC-BY-NC-SA-3.0-IGO](https://spdx.org/licenses/CC-BY-NC-SA-3.0-IGO.html)                                   |      |     |
+| Creative Commons Attribution Non Commercial Share Alike 4.0 International    | [CC-BY-NC-SA-4.0](https://spdx.org/licenses/CC-BY-NC-SA-4.0.html)                                           |      |     |
+| Creative Commons Attribution No Derivatives 1.0 Generic                      | [CC-BY-ND-1.0](https://spdx.org/licenses/CC-BY-ND-1.0.html)                                                 |      |     |
+| Creative Commons Attribution No Derivatives 2.0 Generic                      | [CC-BY-ND-2.0](https://spdx.org/licenses/CC-BY-ND-2.0.html)                                                 |      |     |
+| Creative Commons Attribution No Derivatives 2.5 Generic                      | [CC-BY-ND-2.5](https://spdx.org/licenses/CC-BY-ND-2.5.html)                                                 |      |     |
+| Creative Commons Attribution No Derivatives 3.0 Unported                     | [CC-BY-ND-3.0](https://spdx.org/licenses/CC-BY-ND-3.0.html)                                                 |      |     |
+| Creative Commons Attribution No Derivatives 3.0 Germany                      | [CC-BY-ND-3.0-DE](https://spdx.org/licenses/CC-BY-ND-3.0-DE.html)                                           |      |     |
+| Creative Commons Attribution No Derivatives 4.0 International                | [CC-BY-ND-4.0](https://spdx.org/licenses/CC-BY-ND-4.0.html)                                                 |      |     |
+| Creative Commons Attribution Share Alike 1.0 Generic                         | [CC-BY-SA-1.0](https://spdx.org/licenses/CC-BY-SA-1.0.html)                                                 |      |     |
+| Creative Commons Attribution Share Alike 2.0 Generic                         | [CC-BY-SA-2.0](https://spdx.org/licenses/CC-BY-SA-2.0.html)                                                 |      |     |
+| Creative Commons Attribution Share Alike 2.0 England and Wales               | [CC-BY-SA-2.1-UK](https://spdx.org/licenses/CC-BY-SA-2.0-UK.html)                                           |      |     |
+| Creative Commons Attribution Share Alike 2.1 Japan                           | [CC-BY-SA-2.1-JP](https://spdx.org/licenses/CC-BY-SA-2.1-JP.html)                                           |      |     |
+| Creative Commons Attribution Share Alike 2.5 Generic                         | [CC-BY-SA-2.5](https://spdx.org/licenses/CC-BY-SA-2.5.html)                                                 |      |     |
+| Creative Commons Attribution Share Alike 3.0 Unported                        | [CC-BY-SA-3.0](https://spdx.org/licenses/CC-BY-SA-3.0.html)                                                 |      |     |
+| Creative Commons Attribution Share Alike 3.0 Austria                         | [CC-BY-SA-3.0-AT](https://spdx.org/licenses/CC-BY-SA-3.0-AT.html)                                           |      |     |
+| Creative Commons Attribution Share Alike 3.0 Germany                         | [CC-BY-SA-3.0-DE](https://spdx.org/licenses/CC-BY-SA-3.0-DE.html)                                           |      |     |
+| Creative Commons Attribution Share Alike 4.0 International                   | [CC-BY-SA-4.0](https://spdx.org/licenses/CC-BY-SA-4.0.html)                                                 | Y    |     |
+| Creative Commons Public Domain Dedication and Certification                  | [CC-PDDC](https://spdx.org/licenses/CC-PDDC.html)                                                           |      |     |
+| Creative Commons Zero v1.0 Universal                                         | [CC0-1.0](https://spdx.org/licenses/CC0-1.0.html)                                                           | Y    |     |
+| Common Development and Distribution License 1.0                              | [CDDL-1.0](https://spdx.org/licenses/CDDL-1.0.html)                                                         | Y    | Y   |
+| Common Development and Distribution License 1.1                              | [CDDL-1.1](https://spdx.org/licenses/CDDL-1.1.html)                                                         |      |     |
+| Common Documentation License 1.0                                             | [CDL-1.0](https://spdx.org/licenses/CDL-1.0.html)                                                           |      |     |
+| Community Data License Agreement Permissive 1.0                              | [CDLA-Permissive-1.0](https://spdx.org/licenses/CDLA-Permissive-1.0.html)                                   |      |     |
+| Community Data License Agreement Permissive 2.0                              | [CDLA-Permissive-2.0](https://spdx.org/licenses/CDLA-Permissive-2.0.html)                                   |      |     |
+| Community Data License Agreement Sharing 1.0                                 | [CDLA-Sharing-1.0](https://spdx.org/licenses/CDLA-Sharing-1.0.html)                                         |      |     |
+| CeCILL Free Software License Agreement v1.0                                  | [CECILL-1.0](https://spdx.org/licenses/CECILL-1.0.html)                                                     |      |     |
+| CeCILL Free Software License Agreement v1.1                                  | [CECILL-1.1](https://spdx.org/licenses/CECILL-1.1.html)                                                     |      |     |
+| CeCILL Free Software License Agreement v2.0                                  | [CECILL-2.0](https://spdx.org/licenses/CECILL-2.0.html)                                                     | Y    |     |
+| CeCILL Free Software License Agreement v2.1                                  | [CECILL-2.1](https://spdx.org/licenses/CECILL-2.1.html)                                                     |      | Y   |
+| CeCILL-B Free Software License Agreement                                     | [CECILL-B](https://spdx.org/licenses/CECILL-B.html)                                                         | Y    |     |
+| CeCILL-C Free Software License Agreement                                     | [CECILL-C](https://spdx.org/licenses/CECILL-C.html)                                                         | Y    |     |
+| CERN Open Hardware Licence v1.1                                              | [CERN-OHL-1.1](https://spdx.org/licenses/CERN-OHL-1.1.html)                                                 |      |     |
+| CERN Open Hardware Licence v1.2                                              | [CERN-OHL-1.2](https://spdx.org/licenses/CERN-OHL-1.2.html)                                                 |      |     |
+| CERN Open Hardware Licence Version 2 - Permissive                            | [CERN-OHL-P-2.0](https://spdx.org/licenses/CERN-OHL-P-2.0.html)                                             |      | Y   |
+| CERN Open Hardware Licence Version 2 - Strongly Reciprocal                   | [CERN-OHL-S-2.0](https://spdx.org/licenses/CERN-OHL-S-2.0.html)                                             |      | Y   |
+| CERN Open Hardware Licence Version 2 - Weakly Reciprocal                     | [CERN-OHL-W-2.0](https://spdx.org/licenses/CERN-OHL-W-2.0.html)                                             |      | Y   |
+| Clarified Artistic License                                                   | [ClArtistic](https://spdx.org/licenses/ClArtistic.html)                                                     | Y    |     |
+| CNRI Jython License                                                          | [CNRI-Jython](https://spdx.org/licenses/CNRI-Jython.html)                                                   |      |     |
+| CNRI Python License                                                          | [CNRI-Python](https://spdx.org/licenses/CNRI-Python.html)                                                   |      | Y   |
+| CNRI Python Open Source GPL Compatible License Agreement                     | [CNRI-Python-GPL-Compatible](https://spdx.org/licenses/CNRI-Python-GPL-Compatible.html)                     |      |     |
+| Copyfree Open Innovation License                                             | [COIL-1.0](https://spdx.org/licenses/COIL-1.0.html)                                                         |      |     |
+| Community Specification License 1.0                                          | [Community-Spec-1.0](https://spdx.org/licenses/Community-Spec-1.0.html)                                     |      |     |
+| Condor Public License v1.1                                                   | [Condor-1.1](https://spdx.org/licenses/Condor-1.1.html)                                                     | Y    |     |
+| copyleft-next 0.3.0                                                          | [copyleft-next-0.3.0](https://spdx.org/licenses/copyleft-next-0.3.0.html)                                   |      |     |
+| copyleft-next 0.3.1                                                          | [copyleft-next-0.3.1](https://spdx.org/licenses/copyleft-next-0.3.1.html)                                   |      |     |
+| Common Public Attribution License 1.0                                        | [CPAL-1.0](https://spdx.org/licenses/CPAL-1.0.html)                                                         | Y    | Y   |
+| Common Public License 1.0                                                    | [CPL-1.0](https://spdx.org/licenses/CPL-1.0.html)                                                           | Y    | Y   |
+| Code Project Open License 1.02                                               | [CPOL-1.02](https://spdx.org/licenses/CPOL-1.02.html)                                                       |      |     |
+| Crossword License                                                            | [Crossword](https://spdx.org/licenses/Crossword.html)                                                       |      |     |
+| CrystalStacker License                                                       | [CrystalStacker](https://spdx.org/licenses/CrystalStacker.html)                                             |      |     |
+| CUA Office Public License v1.0                                               | [CUA-OPL-1.0](https://spdx.org/licenses/CUA-OPL-1.0.html)                                                   |      | Y   |
+| Cube License                                                                 | [Cube](https://spdx.org/licenses/Cube.html)                                                                 |      |     |
+| curl License                                                                 | [curl](https://spdx.org/licenses/curl.html)                                                                 |      |     |
+| Deutsche Freie Software Lizenz                                               | [D-FSL-1.0](https://spdx.org/licenses/D-FSL-1.0.html)                                                       |      |     |
+| diffmark license                                                             | [diffmark](https://spdx.org/licenses/diffmark.html)                                                         |      |     |
+| Data licence Germany – attribution – version 2.0                             | [DL-DE-BY-2.0](https://spdx.org/licenses/DL-DE-BY-2.0.html)                                                 |      |     |
+| DOC License                                                                  | [DOC](https://spdx.org/licenses/DOC.html)                                                                   |      |     |
+| Dotseqn License                                                              | [Dotseqn](https://spdx.org/licenses/Dotseqn.html)                                                           |      |     |
+| Detection Rule License 1.0                                                   | [DRL-1.0](https://spdx.org/licenses/DRL-1.0.html)                                                           |      |     |
+| DSDP License                                                                 | [DSDP](https://spdx.org/licenses/DSDP.html)                                                                 |      |     |
+| dvipdfm License                                                              | [dvipdfm](https://spdx.org/licenses/dvipdfm.html)                                                           |      |     |
+| Educational Community License v1.0                                           | [ECL-1.0](https://spdx.org/licenses/ECL-1.0.html)                                                           |      | Y   |
+| Educational Community License v2.0                                           | [ECL-2.0](https://spdx.org/licenses/ECL-2.0.html)                                                           | Y    | Y   |
+| Eiffel Forum License v1.0                                                    | [EFL-1.0](https://spdx.org/licenses/EFL-1.0.html)                                                           |      | Y   |
+| Eiffel Forum License v2.0                                                    | [EFL-2.0](https://spdx.org/licenses/EFL-2.0.html)                                                           | Y    | Y   |
+| eGenix.com Public License 1.1.0                                              | [eGenix](https://spdx.org/licenses/eGenix.html)                                                             |      |     |
+| Elastic License 2.0                                                          | [Elastic-2.0](https://spdx.org/licenses/Elastic-2.0.html)                                                   |      |     |
+| Entessa Public License v1.0                                                  | [Entessa](https://spdx.org/licenses/Entessa.html)                                                           |      | Y   |
+| EPICS Open License                                                           | [EPICS](https://spdx.org/licenses/EPICS.html)                                                               |      |     |
+| Eclipse Public License 1.0                                                   | [EPL-1.0](https://spdx.org/licenses/EPL-1.0.html)                                                           | Y    | Y   |
+| Eclipse Public License 2.0                                                   | [EPL-2.0](https://spdx.org/licenses/EPL-2.0.html)                                                           | Y    | Y   |
+| Erlang Public License v1.1                                                   | [ErlPL-1.1](https://spdx.org/licenses/ErlPL-1.1.html)                                                       |      |     |
+| Etalab Open License 2.0                                                      | [etalab-2.0](https://spdx.org/licenses/etalab-2.0.html)                                                     |      |     |
+| EU DataGrid Software License                                                 | [EUDatagrid](https://spdx.org/licenses/EUDatagrid.html)                                                     | Y    | Y   |
+| European Union Public License 1.0                                            | [EUPL-1.0](https://spdx.org/licenses/EUPL-1.0.html)                                                         |      |     |
+| European Union Public License 1.1                                            | [EUPL-1.1](https://spdx.org/licenses/EUPL-1.1.html)                                                         | Y    | Y   |
+| European Union Public License 1.2                                            | [EUPL-1.2](https://spdx.org/licenses/EUPL-1.2.html)                                                         | Y    | Y   |
+| Eurosym License                                                              | [Eurosym](https://spdx.org/licenses/Eurosym.html)                                                           |      |     |
+| Fair License                                                                 | [Fair](https://spdx.org/licenses/Fair.html)                                                                 |      | Y   |
+| Fraunhofer FDK AAC Codec Library                                             | [FDK-AAC](https://spdx.org/licenses/FDK-AAC.html)                                                           |      |     |
+| Frameworx Open License 1.0                                                   | [Frameworx-1.0](https://spdx.org/licenses/Frameworx-1.0.html)                                               |      | Y   |
+| FreeBSD Documentation License                                                | [FreeBSD-DOC](https://spdx.org/licenses/FreeBSD-DOC.html)                                                   |      |     |
+| FreeImage Public License v1.0                                                | [FreeImage](https://spdx.org/licenses/FreeImage.html)                                                       |      |     |
+| FSF All Permissive License                                                   | [FSFAP](https://spdx.org/licenses/FSFAP.html)                                                               | Y    |     |
+| FSF Unlimited License                                                        | [FSFUL](https://spdx.org/licenses/FSFUL.html)                                                               |      |     |
+| FSF Unlimited License (with License Retention)                               | [FSFULLR](https://spdx.org/licenses/FSFULLR.html)                                                           |      |     |
+| Freetype Project License                                                     | [FTL](https://spdx.org/licenses/FTL.html)                                                                   | Y    |     |
+| GD License                                                                   | [GD](https://spdx.org/licenses/GD.html)                                                                     |      |     |
+| GNU Free Documentation License v1.1 only - invariants                        | [GFDL-1.1-invariants-only](https://spdx.org/licenses/GFDL-1.1-invariants-only.html)                         |      |     |
+| GNU Free Documentation License v1.1 or later - invariants                    | [GFDL-1.1-invariants-or-later](https://spdx.org/licenses/GFDL-1.1-invariants-or-later.html)                 |      |     |
+| GNU Free Documentation License v1.1 only - no invariants                     | [GFDL-1.1-no-invariants-only](https://spdx.org/licenses/GFDL-1.1-no-invariants-only.html)                   |      |     |
+| GNU Free Documentation License v1.1 or later - no invariants                 | [GFDL-1.1-no-invariants-or-later](https://spdx.org/licenses/GFDL-1.1-no-invariants-or-later.html)           |      |     |
+| GNU Free Documentation License v1.1 only                                     | [GFDL-1.1-only](https://spdx.org/licenses/GFDL-1.1-only.html)                                               | Y    |     |
+| GNU Free Documentation License v1.1 or later                                 | [GFDL-1.1-or-later](https://spdx.org/licenses/GFDL-1.1-or-later.html)                                       | Y    |     |
+| GNU Free Documentation License v1.2 only - invariants                        | [GFDL-1.2-invariants-only](https://spdx.org/licenses/GFDL-1.2-invariants-only.html)                         |      |     |        
+| GNU Free Documentation License v1.2 or later - invariants                    | [GFDL-1.2-invariants-or-later](https://spdx.org/licenses/GFDL-1.2-invariants-or-later.html)                 |      |     |        
+| GNU Free Documentation License v1.2 only - no invariants                     | [GFDL-1.2-no-invariants-only](https://spdx.org/licenses/GFDL-1.2-no-invariants-only.html)                   |      |     |              
+| GNU Free Documentation License v1.2 or later - no invariants                 | [GFDL-1.2-no-invariants-or-later](https://spdx.org/licenses/GFDL-1.2-no-invariants-or-later.html)           |      |     |              
+| GNU Free Documentation License v1.2 only                                     | [GFDL-1.2-only](https://spdx.org/licenses/GFDL-1.2-only.html)                                               | Y    |     |
+| GNU Free Documentation License v1.2 or later                                 | [GFDL-1.2-or-later](https://spdx.org/licenses/GFDL-1.2-or-later.html)                                       | Y    |     |
+| GNU Free Documentation License v1.3 only - invariants                        | [GFDL-1.3-invariants-only](https://spdx.org/licenses/GFDL-1.3-invariants-only.html)                         |      |     |        
+| GNU Free Documentation License v1.3 or later - invariants                    | [GFDL-1.3-invariants-or-later](https://spdx.org/licenses/GFDL-1.3-invariants-or-later.html)                 |      |     |        
+| GNU Free Documentation License v1.3 only - no invariants                     | [GFDL-1.3-no-invariants-only](https://spdx.org/licenses/GFDL-1.3-no-invariants-only.html)                   |      |     |              
+| GNU Free Documentation License v1.3 or later - no invariants                 | [GFDL-1.3-no-invariants-or-later](https://spdx.org/licenses/GFDL-1.3-no-invariants-or-later.html)           |      |     |              
+| GNU Free Documentation License v1.3 only                                     | [GFDL-1.3-only](https://spdx.org/licenses/GFDL-1.3-only.html)                                               | Y    |     |
+| GNU Free Documentation License v1.3 or later                                 | [GFDL-1.3-or-later](https://spdx.org/licenses/GFDL-1.3-or-later.html)                                       | Y    |     |
+| Giftware License                                                             | [Giftware](https://spdx.org/licenses/Giftware.html)                                                         |      |     |
+| GL2PS License                                                                | [GL2PS](https://spdx.org/licenses/GL2PS.html)                                                               |      |     |
+| 3dfx Glide License                                                           | [Glide](https://spdx.org/licenses/Glide.html)                                                               |      |     |
+| Glulxe License                                                               | [Glulxe](https://spdx.org/licenses/Glulxe.html)                                                             |      |     |
+| Good Luck With That Public License                                           | [GLWTPL](https://spdx.org/licenses/GLWTPL.html)                                                             |      |     |
+| gnuplot License                                                              | [gnuplot](https://spdx.org/licenses/gnuplot.html)                                                           | Y    |     |
+| GNU General Public License v1.0 only                                         | [GPL-1.0-only](https://spdx.org/licenses/GPL-1.0-only.html)                                                 |      |     |
+| GNU General Public License v1.0 or later                                     | [GPL-1.0-or-later](https://spdx.org/licenses/GPL-1.0-or-later.html)                                         |      |     |
+| GNU General Public License v2.0 only                                         | [GPL-2.0-only](https://spdx.org/licenses/GPL-2.0-only.html)                                                 | Y    | Y   |
+| GNU General Public License v2.0 or later                                     | [GPL-2.0-or-later](https://spdx.org/licenses/GPL-2.0-or-later.html)                                         | Y    | Y   |
+| GNU General Public License v3.0 only                                         | [GPL-3.0-only](https://spdx.org/licenses/GPL-3.0-only.html)                                                 | Y    | Y   |
+| GNU General Public License v3.0 or later                                     | [GPL-3.0-or-later](https://spdx.org/licenses/GPL-3.0-or-later.html)                                         | Y    | Y   |
+| gSOAP Public License v1.3b                                                   | [gSOAP-1.3b](https://spdx.org/licenses/gSOAP-1.3b.html)                                                     |      |     |
+| Haskell Language Report License                                              | [HaskellReport](https://spdx.org/licenses/HaskellReport.html)                                               |      |     |
+| Hippocratic License 2.1                                                      | [Hippocratic-2.1](https://spdx.org/licenses/Hippocratic-2.1)                                                |      |     |
+| Historical Permission Notice and Disclaimer                                  | [HPND](https://spdx.org/licenses/HPND.html)                                                                 | Y    | Y   |
+| Historical Permission Notice and Disclaimer - sell variant                   | [HPND-sell-variant](https://spdx.org/licenses/HPND-sell-variant.html)                                       |      |     |
+| HTML Tidy License                                                            | [HTMLTIDY](https://spdx.org/licenses/HTMLTIDY.html)                                                         |      |     |
+| IBM PowerPC Initialization and Boot Software                                 | [IBM-pibs](https://spdx.org/licenses/IBM-pibs.html)                                                         |      |     |
+| ICU License                                                                  | [ICU](https://spdx.org/licenses/ICU.html)                                                                   |      |     |
+| Independent JPEG Group License                                               | [IJG](https://spdx.org/licenses/IJG.html)                                                                   | Y    |     |
+| ImageMagick License                                                          | [ImageMagick](https://spdx.org/licenses/ImageMagick.html)                                                   |      |     |
+| iMatix Standard Function Library Agreement                                   | [iMatix](https://spdx.org/licenses/iMatix.html)                                                             | Y    |     |
+| Imlib2 License                                                               | [Imlib2](https://spdx.org/licenses/Imlib2.html)                                                             | Y    |     |
+| Info-ZIP License                                                             | [Info-ZIP](https://spdx.org/licenses/Info-ZIP.html)                                                         |      |     |
+| Intel Open Source License                                                    | [Intel](https://spdx.org/licenses/Intel.html)                                                               | Y    | Y   |
+| Intel ACPI Software License Agreement                                        | [Intel-ACPI](https://spdx.org/licenses/Intel-ACPI.html)                                                     |      |     |
+| Interbase Public License v1.0                                                | [Interbase-1.0](https://spdx.org/licenses/Interbase-1.0.html)                                               |      |     |
+| IPA Font License                                                             | [IPA](https://spdx.org/licenses/IPA.html)                                                                   | Y    | Y   |
+| IBM Public License v1.0                                                      | [IPL-1.0](https://spdx.org/licenses/IPL-1.0.html)                                                           | Y    | Y   |
+| ISC License                                                                  | [ISC](https://spdx.org/licenses/ISC.html)                                                                   | Y    | Y   |
+| Jam License                                                                  | [Jam](https://spdx.org/licenses/Jam.html)                                                                   |      | Y   |
+| JasPer License                                                               | [JasPer-2.0](https://spdx.org/licenses/JasPer-2.0.html)                                                     |      |     |
+| Japan Network Information Center License                                     | [JPNIC](https://spdx.org/licenses/JPNIC.html)                                                               |      |     |
+| JSON License                                                                 | [JSON](https://spdx.org/licenses/JSON.html)                                                                 |      |     |
+| KiCad Libraries Exception                                                    | [KiCad-libraries-exception](https://spdx.org/licenses/KiCad-libraries-exception.html)                       |      |     |
+| Licence Art Libre 1.2                                                        | [LAL-1.2](https://spdx.org/licenses/LAL-1.2.html)                                                           |      |     |
+| Licence Art Libre 1.3                                                        | [LAL-1.3](https://spdx.org/licenses/LAL-1.3.html)                                                           |      |     |
+| Latex2e License                                                              | [Latex2e](https://spdx.org/licenses/Latex2e.html)                                                           |      |     |
+| Leptonica License                                                            | [Leptonica](https://spdx.org/licenses/Leptonica.html)                                                       |      |     |
+| GNU Library General Public License v2 only                                   | [LGPL-2.0-only](https://spdx.org/licenses/LGPL-2.0-only.html)                                               |      | Y   |
+| GNU Library General Public License v2 or later                               | [LGPL-2.0-or-later](https://spdx.org/licenses/LGPL-2.0-or-later.html)                                       |      | Y   |
+| GNU Lesser General Public License v2.1 only                                  | [LGPL-2.1-only](https://spdx.org/licenses/LGPL-2.1-only.html)                                               | Y    | Y   |
+| GNU Lesser General Public License v2.1 or later                              | [LGPL-2.1-or-later](https://spdx.org/licenses/LGPL-2.1-or-later.html)                                       | Y    | Y   |
+| GNU Lesser General Public License v3.0 only                                  | [LGPL-3.0-only](https://spdx.org/licenses/LGPL-3.0-only.html)                                               | Y    | Y   |
+| GNU Lesser General Public License v3.0 or later                              | [LGPL-3.0-or-later](https://spdx.org/licenses/LGPL-3.0-or-later.html)                                       | Y    | Y   |
+| Lesser General Public License For Linguistic Resources                       | [LGPLLR](https://spdx.org/licenses/LGPLLR.html)                                                             |      |     |
+| libpng License                                                               | [Libpng](https://spdx.org/licenses/Libpng.html)                                                             |      |     |
+| PNG Reference Library version 2                                              | [libpng-2.0](https://spdx.org/licenses/libpng-2.0.html)                                                     |      |     |
+| libselinux public domain notice                                              | [libselinux-1.0](https://spdx.org/licenses/libselinux-1.0.html)                                             |      |     |
+| libtiff License                                                              | [libtiff](https://spdx.org/licenses/libtiff.html)                                                           |      |     |
+| Licence Libre du Québec – Permissive version 1.1                             | [LiLiQ-P-1.1](https://spdx.org/licenses/LiLiQ-P-1.1.html)                                                   | Y    | Y   |
+| Licence Libre du Québec – Réciprocité version 1.1                            | [LiLiQ-R-1.1](https://spdx.org/licenses/LiLiQ-R-1.1.html)                                                   | Y    | Y   |
+| Licence Libre du Québec – Réciprocité forte version 1.1                      | [LiLiQ-Rplus-1.1](https://spdx.org/licenses/LiLiQ-Rplus-1.1.html)                                           | Y    | Y   |
+| Linux man-pages Copyleft                                                     | [Linux-man-pages-copyleft](https://spdx.org/licenses/Linux-man-pages-copyleft.html)                         |      |     |
+| Linux Kernel Variant of OpenIB.org license                                   | [Linux-OpenIB](https://spdx.org/licenses/Linux-OpenIB.html)                                                 |      |     |
+| Lucent Public License Version 1.0                                            | [LPL-1.0](https://spdx.org/licenses/LPL-1.0.html)                                                           |      | Y   |
+| Lucent Public License v1.02                                                  | [LPL-1.02](https://spdx.org/licenses/LPL-1.02.html)                                                         | Y    | Y   |
+| LaTeX Project Public License v1.0                                            | [LPPL-1.0](https://spdx.org/licenses/LPPL-1.0.html)                                                         |      |     |
+| LaTeX Project Public License v1.1                                            | [LPPL-1.1](https://spdx.org/licenses/LPPL-1.1.html)                                                         |      |     |
+| LaTeX Project Public License v1.2                                            | [LPPL-1.2](https://spdx.org/licenses/LPPL-1.2.html)                                                         | Y    |     |
+| LaTeX Project Public License v1.3a                                           | [LPPL-1.3a](https://spdx.org/licenses/LPPL-1.3a.html)                                                       | Y    |     |
+| LaTeX Project Public License v1.3c                                           | [LPPL-1.3c](https://spdx.org/licenses/LPPL-1.3c.html)                                                       |      | Y   |
+| MakeIndex License                                                            | [MakeIndex](https://spdx.org/licenses/MakeIndex.html)                                                       |      |     |
+| The MirOS Licence                                                            | [MirOS](https://spdx.org/licenses/MirOS.html)                                                               |      | Y   |
+| MIT License                                                                  | [MIT](https://spdx.org/licenses/MIT.html)                                                                   | Y    | Y   |
+| MIT No Attribution                                                           | [MIT-0](https://spdx.org/licenses/MIT-0.html)                                                               |      | Y   |
+| Enlightenment License (e16)                                                  | [MIT-advertising](https://spdx.org/licenses/MIT-advertising.html)                                           |      |     |
+| CMU License                                                                  | [MIT-CMU](https://spdx.org/licenses/MIT-CMU.html)                                                           |      |     |
+| enna License                                                                 | [MIT-enna](https://spdx.org/licenses/MIT-enna.html)                                                         |      |     |
+| feh License                                                                  | [MIT-feh](https://spdx.org/licenses/MIT-feh.html)                                                           |      |     |
+| MIT License Modern Variant                                                   | [MIT-Modern-Variant](https://spdx.org/licenses/MIT-Modern-Variant.html)                                     |      | Y   |
+| MIT Open Group variant                                                       | [MIT-open-group](https://spdx.org/licenses/MIT-open-group.html)                                             |      |     |
+| MIT +no-false-attribs license                                                | [MITNFA](https://spdx.org/licenses/MITNFA.html)                                                             |      |     |
+| Motosoto License                                                             | [Motosoto](https://spdx.org/licenses/Motosoto.html)                                                         |      | Y   |
+| mpich2 License                                                               | [mpich2](https://spdx.org/licenses/mpich2.html)                                                             |      |     |
+| Mozilla Public License 1.0                                                   | [MPL-1.0](https://spdx.org/licenses/MPL-1.0.html)                                                           |      | Y   |
+| Mozilla Public License 1.1                                                   | [MPL-1.1](https://spdx.org/licenses/MPL-1.1.html)                                                           | Y    | Y   |
+| Mozilla Public License 2.0                                                   | [MPL-2.0](https://spdx.org/licenses/MPL-2.0.html)                                                           | Y    | Y   |
+| Mozilla Public License 2.0 (no copyleft exception)                           | [MPL-2.0-no-copyleft-exception](https://spdx.org/licenses/MPL-2.0-no-copyleft-exception.html)               |      | Y   |
+| mplus Font License                                                           | [mplus](https://spdx.org/licenses/mplus.html)                                                               |      |     |
+| Microsoft Public License                                                     | [MS-PL](https://spdx.org/licenses/MS-PL.html)                                                               | Y    | Y   |
+| Microsoft Reciprocal License                                                 | [MS-RL](https://spdx.org/licenses/MS-RL.html)                                                               | Y    | Y   |
+| Matrix Template Library License                                              | [MTLL](https://spdx.org/licenses/MTLL.html)                                                                 |      |     |
+| Mulan Permissive Software License, Version 1                                 | [MulanPSL-1.0](https://spdx.org/licenses/MulanPSL-1.0.html)                                                 |      |     |
+| Mulan Permissive Software License, Version 2                                 | [MulanPSL-2.0](https://spdx.org/licenses/MulanPSL-2.0.html)                                                 |      | Y   |
+| Multics License                                                              | [Multics](https://spdx.org/licenses/Multics.html)                                                           |      | Y   |
+| Mup License                                                                  | [Mup](https://spdx.org/licenses/Mup.html)                                                                   |      |     |
+| Nara Institute of Science and Technology License (2003)                      | [NAIST-2003](https://spdx.org/licenses/NAIST-2003.html)                                                     |      |     |
+| NASA Open Source Agreement 1.3                                               | [NASA-1.3](https://spdx.org/licenses/NASA-1.3.html)                                                         |      | Y   |
+| Naumen Public License                                                        | [Naumen](https://spdx.org/licenses/Naumen.html)                                                             |      | Y   |
+| Net Boolean Public License v1                                                | [NBPL-1.0](https://spdx.org/licenses/NBPL-1.0.html)                                                         |      |     |
+| Non-Commercial Government Licence                                            | [NCGL-UK-2.0](https://spdx.org/licenses/NCGL-UK-2.0.html)                                                   |      |     |
+| University of Illinois/NCSA Open Source License                              | [NCSA](https://spdx.org/licenses/NCSA.html)                                                                 | Y    | Y   |
+| Net-SNMP License                                                             | [Net-SNMP](https://spdx.org/licenses/Net-SNMP.html)                                                         |      |     |
+| NetCDF license                                                               | [NetCDF](https://spdx.org/licenses/NetCDF.html)                                                             |      |     |
+| Newsletr License                                                             | [Newsletr](https://spdx.org/licenses/Newsletr.html)                                                         |      |     |
+| Nethack General Public License                                               | [NGPL](https://spdx.org/licenses/NGPL.html)                                                                 |      | Y   |
+| NIST Public Domain Notice                                                    | [NIST-PD](https://spdx.org/licenes/NIST-PD.html)                                                            |      |     |
+| NIST Public Domain Notice with license fallback                              | [NIST-PD-fallback](https//spdx.org/licenes/NIST-PD-fallback.html)                                           |      |     |
+| Norwegian Licence for Open Government Data (NLOD) 1.0                        | [NLOD-1.0](https://spdx.org/licenses/NLOD-1.0.html)                                                         |      |     |
+| Norwegian Licence for Open Government Data (NLOD) 2.0                        | [NLOD-2.0](https://spdx.org/licenses/NLOD-2.0.html)                                                         |      |     |
+| No Limit Public License                                                      | [NLPL](https://spdx.org/licenses/NLPL.html)                                                                 |      |     |
+| Nokia Open Source License                                                    | [Nokia](https://spdx.org/licenses/Nokia.html)                                                               | Y    | Y   |
+| Netizen Open Source License                                                  | [NOSL](https://spdx.org/licenses/NOSL.html)                                                                 | Y    |     |
+| Noweb License                                                                | [Noweb](https://spdx.org/licenses/Noweb.html)                                                               |      |     |
+| Netscape Public License v1.0                                                 | [NPL-1.0](https://spdx.org/licenses/NPL-1.0.html)                                                           | Y    |     |
+| Netscape Public License v1.1                                                 | [NPL-1.1](https://spdx.org/licenses/NPL-1.1.html)                                                           | Y    |     |
+| Non-Profit Open Software License 3.0                                         | [NPOSL-3.0](https://spdx.org/licenses/NPOSL-3.0.html)                                                       |      | Y   |
+| NRL License                                                                  | [NRL](https://spdx.org/licenses/NRL.html)                                                                   |      |     |
+| NTP License                                                                  | [NTP](https://spdx.org/licenses/NTP.html)                                                                   |      | Y   |
+| NTP No Attribution                                                           | [NTP-0](https://spdx.org/licenses/NTP-0.html)                                                               |      |     |
+| Open Use of Data Agreement v1.0                                              | [O-UDA-1.0](https://spdx.org/licenses/O-UDA-1.0.html)                                                       |      |     |
+| Open CASCADE Technology Public License                                       | [OCCT-PL](https://spdx.org/licenses/OCCT-PL.html)                                                           |      |     |
+| OCLC Research Public License 2.0                                             | [OCLC-2.0](https://spdx.org/licenses/OCLC-2.0.html)                                                         |      | Y   |
+| ODC Open Database License v1.0                                               | [ODbL-1.0](https://spdx.org/licenses/ODbL-1.0.html)                                                         | Y    |     |
+| Open Data Commons Attribution License v1.0                                   | [ODC-By-1.0](https://spdx.org/licenses/ODC-By-1.0.html)                                                     |      |     |
+| SIL Open Font License 1.0                                                    | [OFL-1.0](https://spdx.org/licenses/OFL-1.0.html)                                                           | Y    |     |
+| SIL Open Font License 1.0 with no Reserved Font Name                         | [OFL-1.0-no-RFN](https://spdx.org/licenses/OFL-1.0-no-RFN.html)                                             |      |     |
+| SIL Open Font License 1.0 with Reserved Font Name                            | [OFL-1.0-RFN](https://spdx.org/licenses/OFL-1.0-RFN.html)                                                   |      |     |
+| SIL Open Font License 1.1                                                    | [OFL-1.1](https://spdx.org/licenses/OFL-1.1.html)                                                           | Y    | Y   |
+| SIL Open Font License 1.1 with no Reserved Font Name                         | [OFL-1.1-no-RFN](https://spdx.org/licenses/OFL-1.1-no-RFN.html)                                             |      | Y   |
+| SIL Open Font License 1.1 with Reserved Font Name                            | [OFL-1.1-RFN](https://spdx.org/licenses/OFL-1.1-RFN.html)                                                   |      | Y   |
+| Taiwan Open Government Data Licence, version 1.0                             | [OGDL-Taiwan-1.0](https://spdx.org/licenses/OGDL-Taiwan-1.0.html)                                           |      |     |
+| Open Government Licence - Canada                                             | [OGL-Canada-2.0](https://spdx.org/licenses/OGL-Canada-2.0.html)                                             |      |     |
+| Open Government Licence v1.0                                                 | [OGL-UK-1.0](https://spdx.org/licenses/OGL-UK-1.0.html)                                                     |      |     |
+| Open Government Licence v2.0                                                 | [OGL-UK-2.0](https://spdx.org/licenses/OGL-UK-2.0.html)                                                     |      |     |
+| Open Government Licence v3.0                                                 | [OGL-UK-3.0](https://spdx.org/licenses/OGL-UK-3.0.html)                                                     |      |     |
+| Open Group Test Suite License                                                | [OGTSL](https://spdx.org/licenses/OGTSL.html)                                                               | Y    | Y   |
+| Open LDAP Public License v1.1                                                | [OLDAP-1.1](https://spdx.org/licenses/OLDAP-1.1.html)                                                       |      |     |
+| Open LDAP Public License v1.2                                                | [OLDAP-1.2](https://spdx.org/licenses/OLDAP-1.2.html)                                                       |      |     |
+| Open LDAP Public License v1.3                                                | [OLDAP-1.3](https://spdx.org/licenses/OLDAP-1.3.html)                                                       |      |     |
+| Open LDAP Public License v1.4                                                | [OLDAP-1.4](https://spdx.org/licenses/OLDAP-1.4.html)                                                       |      |     |
+| Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)                    | [OLDAP-2.0](https://spdx.org/licenses/OLDAP-2.0.html)                                                       |      |     |
+| Open LDAP Public License v2.0.1                                              | [OLDAP-2.0.1](https://spdx.org/licenses/OLDAP-2.0.1.html)                                                   |      |     |
+| Open LDAP Public License v2.1                                                | [OLDAP-2.1](https://spdx.org/licenses/OLDAP-2.1.html)                                                       |      |     |
+| Open LDAP Public License v2.2                                                | [OLDAP-2.2](https://spdx.org/licenses/OLDAP-2.2.html)                                                       |      |     |
+| Open LDAP Public License v2.2.1                                              | [OLDAP-2.2.1](https://spdx.org/licenses/OLDAP-2.2.1.html)                                                   |      |     |
+| Open LDAP Public License 2.2.2                                               | [OLDAP-2.2.2](https://spdx.org/licenses/OLDAP-2.2.2.html)                                                   |      |     |
+| Open LDAP Public License v2.3                                                | [OLDAP-2.3](https://spdx.org/licenses/OLDAP-2.3.html)                                                       | Y    |     |
+| Open LDAP Public License v2.4                                                | [OLDAP-2.4](https://spdx.org/licenses/OLDAP-2.4.html)                                                       |      |     |
+| Open LDAP Public License v2.5                                                | [OLDAP-2.5](https://spdx.org/licenses/OLDAP-2.5.html)                                                       |      |     |
+| Open LDAP Public License v2.6                                                | [OLDAP-2.6](https://spdx.org/licenses/OLDAP-2.6.html)                                                       |      |     |
+| Open LDAP Public License v2.7                                                | [OLDAP-2.7](https://spdx.org/licenses/OLDAP-2.7.html)                                                       | Y    |     |
+| Open LDAP Public License v2.8                                                | [OLDAP-2.8](https://spdx.org/licenses/OLDAP-2.8.html)                                                       |      | Y   |
+| Open Market License                                                          | [OML](https://spdx.org/licenses/OML.html)                                                                   |      |     |
+| OpenSSL License                                                              | [OpenSSL](https://spdx.org/licenses/OpenSSL.html)                                                           | Y    |     |
+| Open Public License v1.0                                                     | [OPL-1.0](https://spdx.org/licenses/OPL-1.0.html)                                                           |      |     |
+| Open Publication License v1.0                                                | [OPBL-1.0](https://spdx.org/licenses/OPBL-1.0.html)                                                         |      |     |
+| OSET Public License version 2.1                                              | [OSET-PL-2.1](https://spdx.org/licenses/OSET-PL-2.1.html)                                                   |      | Y   |
+| Open Software License 1.0                                                    | [OSL-1.0](https://spdx.org/licenses/OSL-1.0.html)                                                           | Y    | Y   |
+| Open Software License 1.1                                                    | [OSL-1.1](https://spdx.org/licenses/OSL-1.1.html)                                                           | Y    |     |
+| Open Software License 2.0                                                    | [OSL-2.0](https://spdx.org/licenses/OSL-2.0.html)                                                           | Y    | Y   |
+| Open Software License 2.1                                                    | [OSL-2.1](https://spdx.org/licenses/OSL-2.1.html)                                                           | Y    | Y   |
+| Open Software License 3.0                                                    | [OSL-3.0](https://spdx.org/licenses/OSL-3.0.html)                                                           | Y    | Y   |
+| The Parity Public License 6.0.0                                              | [Parity-6.0.0](https://spdx.org/licenses/Parity-6.0.0.html)                                                 |      |     |
+| The Parity Public License 7.0.0                                              | [Parity-7.0.0](https://spdx.org/licenses/Parity-7.0.0.html)                                                 |      |     |
+| ODC Public Domain Dedication & License 1.0                                   | [PDDL-1.0](https://spdx.org/licenses/PDDL-1.0.html)                                                         |      |     |
+| PHP License v3.0                                                             | [PHP-3.0](https://spdx.org/licenses/PHP-3.0.html)                                                           |      | Y   |
+| PHP License v3.01                                                            | [PHP-3.01](https://spdx.org/licenses/PHP-3.01.html)                                                         | Y    | Y   |
+| Plexus Classworlds License                                                   | [Plexus](https://spdx.org/licenses/Plexus.html)                                                             |      |     |
+| PolyForm Noncommercial License 1.0.0                                         | [PolyForm-Noncommercial-1.0.0](https://spdx.org/licenses/PolyForm-Noncommercial-1.0.0.html)                 |      |     |
+| PolyForm Small Business License 1.0.0                                        | [PolyForm-Small-Business-1.0.0](https://spdx.org/licenses/PolyForm-Small-Business-1.0.0.html)               |      |     |
+| PostgreSQL License                                                           | [PostgreSQL](https://spdx.org/licenses/PostgreSQL.html)                                                     |      | Y   |
+| Python Software Foundation License 2.0                                       | [PSF-2.0](https://spdx.org/licenses/PSF-2.0.html)                                                           |      |     |
+| psfrag License                                                               | [psfrag](https://spdx.org/licenses/psfrag.html)                                                             |      |     |
+| psutils License                                                              | [psutils](https://spdx.org/licenses/psutils.html)                                                           |      |     |
+| Python License 2.0                                                           | [Python-2.0](https://spdx.org/licenses/Python-2.0.html)                                                     | Y    | Y   |
+| Qhull License                                                                | [Qhull](https://spdx.org/licenses/Qhull.html)                                                               |      |     |
+| Q Public License 1.0                                                         | [QPL-1.0](https://spdx.org/licenses/QPL-1.0.html)                                                           | Y    | Y   |
+| Rdisc License                                                                | [Rdisc](https://spdx.org/licenses/Rdisc.html)                                                               |      |     |
+| Red Hat eCos Public License v1.1                                             | [RHeCos-1.1](https://spdx.org/licenses/RHeCos-1.1.html)                                                     |      |     |
+| Reciprocal Public License 1.1                                                | [RPL-1.1](https://spdx.org/licenses/RPL-1.1.html)                                                           |      | Y   |
+| Reciprocal Public License 1.5                                                | [RPL-1.5](https://spdx.org/licenses/RPL-1.5.html)                                                           |      | Y   |
+| RealNetworks Public Source License v1.0                                      | [RPSL-1.0](https://spdx.org/licenses/RPSL-1.0.html)                                                         | Y    | Y   |
+| RSA Message-Digest License                                                   | [RSA-MD](https://spdx.org/licenses/RSA-MD.html)                                                             |      |     |
+| Ricoh Source Code Public License                                             | [RSCPL](https://spdx.org/licenses/RSCPL.html)                                                               |      | Y   |
+| Ruby License                                                                 | [Ruby](https://spdx.org/licenses/Ruby.html)                                                                 | Y    |     |
+| Sax Public Domain Notice                                                     | [SAX-PD](https://spdx.org/licenses/SAX-PD.html)                                                             |      |     |
+| Saxpath License                                                              | [Saxpath](https://spdx.org/licenses/Saxpath.html)                                                           |      |     |
+| SCEA Shared Source License                                                   | [SCEA](https://spdx.org/licenses/SCEA.html)                                                                 |      |     |
+| Scheme Language Report License                                               | [SchemeReport](https://spdx.org/licenses/SchemeReport.html)                                                 |      |     |
+| Sendmail License                                                             | [Sendmail](https://spdx.org/licenses/Sendmail.html)                                                         |      |     |
+| Sendmail License 8.23                                                        | [Sendmail-8.23](https://spdx.org/licenses/Sendmail-8.23.html)                                               |      |     |
+| SGI Free Software License B v1.0                                             | [SGI-B-1.0](https://spdx.org/licenses/SGI-B-1.0.html)                                                       |      |     |
+| SGI Free Software License B v1.1                                             | [SGI-B-1.1](https://spdx.org/licenses/SGI-B-1.1.html)                                                       |      |     |
+| SGI Free Software License B v2.0                                             | [SGI-B-2.0](https://spdx.org/licenses/SGI-B-2.0.html)                                                       | Y    |     |
+| Solderpad Hardware License v0.5                                              | [SHL-0.5](https://spdx.org/licenses/SHL-0.5.html)                                                           |      |     |
+| Solderpad Hardware License, Version 0.51                                     | [SHL-0.51](https://spdx.org/licenses/SHL-0.51.html)                                                         |      |     |
+| Simple Public License 2.0                                                    | [SimPL-2.0](https://spdx.org/licenses/SimPL-2.0.html)                                                       |      | Y   |
+| Sun Industry Standards Source License v1.1                                   | [SISSL](https://spdx.org/licenses/SISSL.html)                                                               | Y    | Y   |
+| Sun Industry Standards Source License v1.2                                   | [SISSL-1.2](https://spdx.org/licenses/SISSL-1.2.html)                                                       |      |     |
+| Sleepycat License                                                            | [Sleepycat](https://spdx.org/licenses/Sleepycat.html)                                                       | Y    | Y   |
+| Standard ML of New Jersey License                                            | [SMLNJ](https://spdx.org/licenses/SMLNJ.html)                                                               | Y    |     |
+| Secure Messaging Protocol Public License                                     | [SMPPL](https://spdx.org/licenses/SMPPL.html)                                                               |      |     |
+| SNIA Public License 1.1                                                      | [SNIA](https://spdx.org/licenses/SNIA.html)                                                                 |      |     |
+| Spencer License 86                                                           | [Spencer-86](https://spdx.org/licenses/Spencer-86.html)                                                     |      |     |
+| Spencer License 94                                                           | [Spencer-94](https://spdx.org/licenses/Spencer-94.html)                                                     |      |     |
+| Spencer License 99                                                           | [Spencer-99](https://spdx.org/licenses/Spencer-99.html)                                                     |      |     |
+| Sun Public License v1.0                                                      | [SPL-1.0](https://spdx.org/licenses/SPL-1.0.html)                                                           | Y    | Y   |
+| SSH OpenSSH license                                                          | [SSH-OpenSSH](https://spdx.org/licenses/SSH-OpenSSH.html)                                                   |      |     |
+| SSH short notice                                                             | [SSH-short](https://spdx.org/licenses/SSH-short.html)                                                       |      |     |
+| Server Side Public License, v 1                                              | [SSPL-1.0](https://spdx.org/licenses/SSPL-1.0.html)                                                         |      |     |
+| SugarCRM Public License v1.1.3                                               | [SugarCRM-1.1.3](https://spdx.org/licenses/SugarCRM-1.1.3.html)                                             |      |     |
+| Scheme Widget Library (SWL) Software License Agreement                       | [SWL](https://spdx.org/licenses/SWL.html)                                                                   |      |     |
+| TAPR Open Hardware License v1.0                                              | [TAPR-OHL-1.0](https://spdx.org/licenses/TAPR-OHL-1.0.html)                                                 |      |     |
+| TCL/TK License                                                               | [TCL](https://spdx.org/licenses/TCL.html)                                                                   |      |     |
+| TCP Wrappers License                                                         | [TCP-wrappers](https://spdx.org/licenses/TCP-wrappers.html)                                                 |      |     |
+| TMate Open Source License                                                    | [TMate](https://spdx.org/licenses/TMate.html)                                                               |      |     |
+| TORQUE v2.5+ Software License v1.1                                           | [TORQUE-1.1](https://spdx.org/licenses/TORQUE-1.1.html)                                                     |      |     |
+| Trusster Open Source License                                                 | [TOSL](https://spdx.org/licenses/TOSL.html)                                                                 |      |     |
+| Technische Universitaet Berlin License 1.0                                   | [TU-Berlin-1.0](https://spdx.org/licenses/TU-Berlin-1.0.html)                                               |      |     |
+| Technische Universitaet Berlin License 2.0                                   | [TU-Berlin-2.0](https://spdx.org/licenses/TU-Berlin-2.0.html)                                               |      |     |
+| Upstream Compatibility License v1.0                                          | [UCL-1.0](https://spdx.org/licenses/UCL-1.0.html)                                                           |      | Y   |
+| Unicode License Agreement - Data Files and Software (2015)                   | [Unicode-DFS-2015](https://spdx.org/licenses/Unicode-DFS-2015.html)                                         |      |     |
+| Unicode License Agreement - Data Files and Software (2016)                   | [Unicode-DFS-2016](https://spdx.org/licenses/Unicode-DFS-2016.html)                                         |      |     |
+| Unicode Terms of Use                                                         | [Unicode-TOU](https://spdx.org/licenses/Unicode-TOU.html)                                                   |      |     |
+| The Unlicense                                                                | [Unlicense](https://spdx.org/licenses/Unlicense.html)                                                       | Y    | Y   |
+| Universal Permissive License v1.0                                            | [UPL-1.0](https://spdx.org/licenses/UPL-1.0.html)                                                           | Y    | Y   |
+| Vim License                                                                  | [Vim](https://spdx.org/licenses/Vim.html)                                                                   | Y    |     |
+| VOSTROM Public License for Open Source                                       | [VOSTROM](https://spdx.org/licenses/VOSTROM.html)                                                           |      |     |
+| Vovida Software License v1.0                                                 | [VSL-1.0](https://spdx.org/licenses/VSL-1.0.html)                                                           | Y    | Y   |
+| W3C Software Notice and License (2002-12-31)                                 | [W3C](https://spdx.org/licenses/W3C.html)                                                                   | Y    | Y   |
+| W3C Software Notice and License (1998-07-20)                                 | [W3C-19980720](https://spdx.org/licenses/W3C-19980720.html)                                                 |      |     |
+| W3C Software Notice and Document License (2015-05-13)                        | [W3C-20150513](https://spdx.org/licenses/W3C-20150513.html)                                                 |      |     |
+| Sybase Open Watcom Public License 1.0                                        | [Watcom-1.0](https://spdx.org/licenses/Watcom-1.0.html)                                                     |      | Y   |
+| Wsuipa License                                                               | [Wsuipa](https://spdx.org/licenses/Wsuipa.html)                                                             |      |     |
+| Do What The F\*ck You Want To Public License                                  | [WTFPL](https://spdx.org/licenses/WTFPL.html)                                                               | Y    |     |
+| X11 License                                                                  | [X11](https://spdx.org/licenses/X11.html)                                                                   | Y    |     |
+| X11 License Distribution Modification Variant                                | [X11-distribute-modifications-variant](https://spdx.org/licenses/X11-distribute-modifciations-variant.html) |      |     |
+| Xerox License                                                                | [Xerox](https://spdx.org/licenses/Xerox.html)                                                               |      |     |
+| XFree86 License 1.1                                                          | [XFree86-1.1](https://spdx.org/licenses/XFree86-1.1.html)                                                   | Y    |     |
+| xinetd License                                                               | [xinetd](https://spdx.org/licenses/xinetd.html)                                                             | Y    |     |
+| X.Net License                                                                | [Xnet](https://spdx.org/licenses/Xnet.html)                                                                 |      | Y   |
+| XPP License                                                                  | [xpp](https://spdx.org/licenses/xpp.html)                                                                   |      |     |
+| XSkat License                                                                | [XSkat](https://spdx.org/licenses/XSkat.html)                                                               |      |     |
+| Yahoo! Public License v1.0                                                   | [YPL-1.0](https://spdx.org/licenses/YPL-1.0.html)                                                           |      |     |
+| Yahoo! Public License v1.1                                                   | [YPL-1.1](https://spdx.org/licenses/YPL-1.1.html)                                                           | Y    |     |
+| Zed License                                                                  | [Zed](https://spdx.org/licenses/Zed.html)                                                                   |      |     |
+| Zend License v2.0                                                            | [Zend-2.0](https://spdx.org/licenses/Zend-2.0.html)                                                         | Y    |     |
+| Zimbra Public License v1.3                                                   | [Zimbra-1.3](https://spdx.org/licenses/Zimbra-1.3.html)                                                     | Y    |     |
+| Zimbra Public License v1.4                                                   | [Zimbra-1.4](https://spdx.org/licenses/Zimbra-1.4.html)                                                     |      |     |
+| zlib License                                                                 | [Zlib](https://spdx.org/licenses/Zlib.html)                                                                 | Y    | Y   |
+| zlib/libpng License with Acknowledgement                                     | [zlib-acknowledgement](https://spdx.org/licenses/zlib-acknowledgement.html)                                 |      |     |
+| Zope Public License 1.1                                                      | [ZPL-1.1](https://spdx.org/licenses/ZPL-1.1.html)                                                           |      |     |
+| Zope Public License 2.0                                                      | [ZPL-2.0](https://spdx.org/licenses/ZPL-2.0.html)                                                           | Y    | Y   |
+| Zope Public License 2.1                                                      | [ZPL-2.1](https://spdx.org/licenses/ZPL-2.1.html)                                                           | Y    | Y   |
 
 ## A.2 Exceptions list <a name="A.2"></a>
+
+The SPDX License List includes a list of exceptions. These exceptions grant an exception to a license condition or additional permissions beyond those granted in a license; they are not stand-alone licenses. Exceptions are added to a license using the License Expression operator, "WITH".
 
 **Table A.2 — Exception names and license links**
 
@@ -432,6 +511,7 @@ The OSI column in Table A.1 refers to Open Source Initiative licenses [see Refer
 | GPL-3.0 Linking Exception (with Corresponding Source) | [GPL-3.0-linking-source-exception](https://spdx.org/licenses/GPL-3.0-linking-source-exception.html)   |
 | GPL Cooperation Commitment 1.0                        | [GPL-CC-1.0](https://spdx.org/licenses/GPL-CC-1.0.html)                                               |
 | i2p GPL+Java Exception                                | [i2p-gpl-java-exception](https://spdx.org/licenses/i2p-gpl-java-exception.html)                       |
+| LGPL-3.0 Linking Exception                            | [LGPL-3.0-linking-exception](https://spdx.org/licenses/LGPL-3.0-linking-exception.html)               |
 | Libtool Exception                                     | [Libtool-exception](https://spdx.org/licenses/Libtool-exception.html)                                 |
 | Linux Syscall Note                                    | [Linux-syscall-note](https://spdx.org/licenses/Linux-syscall-note.html)                               |
 | LLVM Exception                                        | [LLVM-exception](https://spdx.org/licenses/LLVM-exception.html)                                       |
@@ -445,6 +525,8 @@ The OSI column in Table A.1 refers to Open Source Initiative licenses [see Refer
 | Qt GPL exception 1.0                                  | [Qt-GPL-exception-1.0](https://spdx.org/licenses/Qt-GPL-exception-1.0.html)                           |
 | Qt LGPL exception 1.1                                 | [Qt-LGPL-exception-1.1](https://spdx.org/licenses/Qt-LGPL-exception-1.1.html)                         |
 | Qwt exception 1.0                                     | [Qwt-exception-1.0](https://spdx.org/licenses/Qwt-exception-1.0.html)                                 |
+| Solderpad Hardware License v2.0                       | [SHL-2.0](https://spdx.org/licenses/SHL-2.0.html)                                                     |
+| Solderpad Hardware License v2.1                       | [SHL-2.1](https://spdx.org/licenses/SHL-2.1.html)                                                     |
 | Swift Exception                                       | [Swift-exception](https://spdx.org/licenses/Swift-exception.html)                                     |
 | U-Boot exception 2.0                                  | [u-boot-exception-2.0](https://spdx.org/licenses/u-boot-exception-2.0.html)                           |
 | Universal FOSS Exception, Version 1.0                 | [Universal-FOSS-exception-1.0](https://spdx.org/licenses/Universal-FOSS-exception-1.0.html)           |
@@ -452,12 +534,17 @@ The OSI column in Table A.1 refers to Open Source Initiative licenses [see Refer
 
 ## A.3 Deprecated licenses <a name="A.3"></a>
 
+SPDX endeavors to never change the SPDX license identifiers. However, sometimes there has been a compelling reason to deprecate a license identifier, such as to accommodate improved SPDX license expressions or when we have found a duplicate license. When a license identifier is "deprecated" on the SPDX License List, it effectively means that there is an updated license identifier and the deprecated license identifier, while remaining valid, should no longer be used. The URL to each deprecated license is retained and those license pages are updated to note the deprecation. 
+
 **Table A.3 — Deprecated license short identifiers**
 
 | Full Name of License                                            | Deprecated SDPX Short Identifier                                                                    |
 |-----------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
 | Affero General Public License v1.0                              | [AGPL-1.0](https://spdx.org/licenses/AGPL-1.0.html)                                                 |
 | GNU Affero General Public License v3.0                          | [AGPL-3.0](https://spdx.org/licenses/AGPL-3.0.html)                                                 |
+| BSD 2-Clause FreeBSD License                                    | [BSD-2-Clause-FreeBSD](https://spdx.org/licenses/BSD-2-Clause-FreeBSD.html)                         |
+| BSD 2-Clause NetBSD License                                     | [BSD-2-Clause-NetBSD](https://spdx.org/licenses/BSD-2-Clause-NetBSD.html)                           |
+| bzip2 and libbzip2 License v1.0.5                               | [bzip2-1.0.5](https://spdx.org/licenses/bzip2-1.0.5.html)                                           |
 | eCos license version 2.0                                        | [eCos-2.0](https://spdx.org/licenses/eCos-2.0.html)                                                 |
 | GNU Free Documentation License v1.1                             | [GFDL-1.1](https://spdx.org/licenses/GFDL-1.1.html)                                                 |
 | GNU Free Documentation License v1.2                             | [GFDL-1.2](https://spdx.org/licenses/GFDL-1.2.html)                                                 |


### PR DESCRIPTION
Added new licenses since v. 3.8.   
Added FSF column
Reworked intro text to closer match current web pages
Added in new introduced execptions in the last 2 years
Added in 3 deprecated licenses since v 3.8

Signed-off-by: Kate Stewart <kate.stewart@att.net>