### PR TITLE
Remove ISO specific Forward from generated 2.3 release

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,6 @@ extra_css:
 use_directory_urls: true
 nav:
 - 'Copyright': index.md
-- 'Foreword': foreword.md
 - 'Introduction': introduction.md
 - 'Clause 1: Scope': scope.md
 - 'Clause 2: Normative references': normative-references.md


### PR DESCRIPTION
Given 2.3 is not going to be submitted to ISO ( it's a strict superset of the fields in ISO/IEC 5962:2021 ), remove the ISO specific Forward section from the text, but leave it in the repo for the submission in the 3.X timeframe.

Signed-off-by: Kate Stewart <kate.stewart@att.net>