### PR TITLE
Specify that licenses found can be expressions.

### DIFF
--- a/chapters/file-information.md
+++ b/chapters/file-information.md
@@ -91,7 +91,7 @@ This field provides information about the type of file identified. File Type is 
 * `BINARY` if the file is a compiled object, target image or binary executable (.o, .a, etc.);
 * `ARCHIVE` if the file represents an archive (.tar, .jar, etc.);
 * `APPLICATION` if the file is associated with a specific application type (MIME type of application/\*);
-* `AUDIO` if the file is associated with an audio file (MIME type of audio/* , e.g. .mp3);
+* `AUDIO` if the file is associated with an audio file (MIME type of audio/\* , e.g. .mp3);
 * `IMAGE` if the file is associated with a picture image file (MIME type of image/\*, e.g., .jpg, .gif);
 * `TEXT` if the file is human readable text file (MIME type of text/\*);
 * `VIDEO` if the file is associated with a video file type (MIME type of video/\*);
@@ -106,7 +106,7 @@ The metadata for the file type field is shown in Table 38.
 | Attribute | Value |
 | --------- | ----- |
 | Required | No |
-| Cardinality | 0..* |
+| Cardinality | 0..\* |
 | Format | `SOURCE` \| `BINARY` \| `ARCHIVE` \| `APPLICATION` \| `AUDIO` \| `IMAGE` \| `TEXT` \| `VIDEO` \| `DOCUMENTATION` \| `SPDX` \| `OTHER` |
 
 ### 8.3.2 Intent
@@ -171,7 +171,7 @@ The metadata for the file checksum field is shown in Table 39.
 | Attribute | Value |
 | --------- | ----- |
 | Required | Yes |
-| Cardinality | 1..1 for the [`SHA1`][SHA-1] algorithm, 0..* for all other algorithms |
+| Cardinality | 1..1 for the [`SHA1`][SHA-1] algorithm, 0..\* for all other algorithms |
 | Algorithm | [`SHA1`][SHA-1] is to be used on the file. Other algorithms that can be provided optionally include [`SHA224`][SHA-224], [`SHA256`][SHA-256], [`SHA384`][SHA-384], [`SHA512`][SHA-512], [`SHA3-256`][SHA3-256], [`SHA3-384`][SHA3-384], [`SHA3-512`][SHA3-512], [`BLAKE2b-256`][BLAKE2b-256], [`BLAKE2b-384`][BLAKE2b-384], [`BLAKE2b-512`][BLAKE2b-512], [`BLAKE3`][BLAKE3], [`MD2`][MD2], [`MD4`][MD4], [`MD5`][MD5], [`MD6`][MD6], [`ADLER32`][ADLER32] |
 | Format | In `tag:value` there are three components, an algorithm identifier (SHA1), a separator (“:”) and a checksum value. The RDF shall also contain an algorithm identifier and a checksum value. For example, when the algorithm identifier is SHA1, the checksum value should be a 160-bit value represented as 40 lowercase hexadecimal digits. For other algorithms, an appropriate number of hexadecimal digits is expected. |
 
@@ -231,17 +231,13 @@ This field contains the license the SPDX document creator has concluded as gover
 
 The options to populate this field are limited to:
 
-A valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions.md);
+* A valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions.md);
+* `NONE`, if the SPDX document creator concludes there is no license available for this file; or
+* `NOASSERTION`, if:
 
-`NONE`, if the SPDX document creator concludes there is no license available for this file; or
-
-`NOASSERTION`, if:
-
-- the SPDX document creator has attempted to, but cannot reach a reasonable objective determination;
-
-- the SPDX document creator has made no attempt to determine this field; or
-
-- the SPDX document creator has intentionally provided no information (no meaning should be implied by doing so).
+    - the SPDX document creator has attempted to, but cannot reach a reasonable objective determination;
+    - the SPDX document creator has made no attempt to determine this field; or
+    - the SPDX document creator has intentionally provided no information (no meaning should be implied by doing so).
 
 If the Concluded License is not the same as the License Information in File, a written explanation should be provided in the Comments on License field ([8.7](#8.7)). With respect to `NOASSERTION`, a written explanation in the Comments on License field ([8.7](#8.7)) is preferred. If the Concluded License field is not present for a file, it implies an equivalent meaning to `NOASSERTION`. The metadata for the concluded license field is shown in Table 40.
 
@@ -297,16 +293,12 @@ This field contains the license information actually found in the file, if any. 
 
 The options to populate this field are limited to:
 
-The SPDX License List short form identifier, if the license is on the SPDX License List;
-A reference to the license, denoted by LicenseRef-`[idstring]`, if the license is not on the SPDX License List;
+* A valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions.md);
+* `NONE`, if the file contains no license information whatsoever; or
+* `NOASSERTION`, if:
 
-`NONE`, if the file contains no license information whatsoever; or
-
-`NOASSERTION`, if:
-
-- the SPDX document creator has made no attempt to determine this field; or
-
-- the SPDX document creator has intentionally provided no information (no meaning should be implied by doing so).
+    - the SPDX document creator has made no attempt to determine this field; or
+    - the SPDX document creator has intentionally provided no information (no meaning should be implied by doing so).
 
 If license information for more than one license is contained in the file or if the license information offers the package recipient a choice of licenses, then each of the choices should be listed as a separate entry. If the License Information in File field is not present for a file, it implies an equivalent meaning to `NOASSERTION`. The metadata for the license information in file field is shown in Table 41.
 
@@ -315,8 +307,8 @@ If license information for more than one license is contained in the file or if 
 | Attribute | Value |
 | --------- | ----- |
 | Required | No |
-| Cardinality | 0..* |
-| Format | `<SPDX License Expression>` \|<br>["DocumentRef-"`[idstring]`":"]"LicenseRef-"`[idstring]` \|<br>\| `NONE` \| `NOASSERTION`<br>where:<br>`<SPDX License Expression>` is a valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions.md).<br>"DocumentRef-"`[idstring]`: is an optional reference to an external SPDX document as described in [6.6](document-creation-information.md#6.6)<br>`[idstring]` is a unique string containing letters, numbers, `.` and/or `-` |
+| Cardinality | 0..\* |
+| Format | `<SPDX License Expression>` \| `NONE` \| `NOASSERTION`<br>where:<br>`<SPDX License Expression>` is a valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions.md). |
 
 ### 8.6.2 Intent
 

--- a/chapters/package-information.md
+++ b/chapters/package-information.md
@@ -920,13 +920,11 @@ This field is to contain a list of all licenses found in the package. The relati
 
 The options to populate this field are limited to:
 
-* The SPDX License List short form identifier, if a detected license is on the SPDX License List;
-* A user defined license reference denoted by `LicenseRef-<idstring>` (for a license not on the SPDX License List);
+* A valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions.md);
 * `NONE`, if no license information is detected in any of the files; or
 * `NOASSERTION`, if:
 
     - the SPDX document creator has made no attempt to determine this field; or
-
     - the SPDX document creator has intentionally provided no information (no meaning should be implied by doing so).
 
 If the All Licenses Information from Files field is not present for a package and `FilesAnalyzed` field ([7.8](#7.8)) for that same pacakge is `true` or omitted, it implies an equivalent meaning to `NOASSERTION`. The metadata for all license information from files field is shown in Table 26.
@@ -936,8 +934,8 @@ If the All Licenses Information from Files field is not present for a package an
 | Attribute | Value |
 | --------- | ----- |
 | Required | No |
-| Cardinality | 0..* (optional) if `FilesAnalyzed` ([7.8](#7.8)) is `true` or omitted, 0..0 (must be omitted) if `FilesAnalyzed` is `false`. |
-| Format | `<shortIdentifier>` ([Annex A](SPDX-license-list.md#A.1)) \| ["DocumentRef-"`[idstring]`:]"LicenseRef-"`[idstring]` \| `NONE` \| `NOASSERTION`<br>where:<br><ul><li> "DocumentRef-"`[idstring]` is an optional reference to an external SPDX document as described in [6.6](document-creation-information.md#6.6).</li><li>`[idstring]` is a unique string containing letters, numbers, `.`, or `-`. </li></ul> |
+| Cardinality | 0..\* (optional) if `FilesAnalyzed` ([7.8](#7.8)) is `true` or omitted, 0..0 (must be omitted) if `FilesAnalyzed` is `false`. |
+| Format | `<SPDX License Expression>` \| `NONE` \| `NOASSERTION`<br>where:<br>`<SPDX License Expression>` is a valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions.md). |
 
 ### 7.14.2 Intent
 

--- a/chapters/snippet-information.md
+++ b/chapters/snippet-information.md
@@ -229,19 +229,14 @@ Supported classes from the pointer method vocabulary are `StartEndPointer` and `
 
 This field contains the license the SPDX document creator has concluded as governing the snippet or alternative values if the governing license cannot be determined. The options to populate this field are limited to:
 
-A valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions.md).
+* A valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions.md).
+* `NONE` should be used if there is no licensing information from which to conclude a license for the snippet.
+* `NOASSERTION` should be used if for the snippet:
 
-`NONE` should be used if there is no licensing information from which to conclude a license for the snippet.
-
-`NOASSERTION` should be used if for the snippet:
-
-- the SPDX document creator has attempted to, but cannot reach a reasonable objective determination of the Concluded License;
-
-- the SPDX document creator is uncomfortable concluding a license, despite some license information being available;
-
-- the SPDX document creator has made no attempt to determine a Concluded License;
-
-- the SPDX document creator has intentionally provided no information (no meaning should be implied by doing so).
+    - the SPDX document creator has attempted to, but cannot reach a reasonable objective determination of the Concluded License;
+    - the SPDX document creator is uncomfortable concluding a license, despite some license information being available;
+    - the SPDX document creator has made no attempt to determine a Concluded License;
+    - the SPDX document creator has intentionally provided no information (no meaning should be implied by doing so).
 
 If the Concluded License is not the same as the License Information in Snippet, a written explanation should be provided in the Comments on License field (see [9.7](#9.7)). With respect to `NOASSERTION`, a written explanation in the Comments on License field (see [9.7](#9.7)) is preferred. If the Snippet Concluded License field is not present for a snippet, it implies an equivalent meaning to `NOASSERTION`. The metadata for the snippet concluded license field is shown in Table 56.
 
@@ -299,16 +294,12 @@ This field contains the license information actually found in the snippet, if an
 
 The options to populate this field are limited to:
 
-The SPDX License List short form identifier, if the license is on the SPDX License List;
-A reference to the license, denoted by LicenseRef-`[idstring]`, if the license is not on the SPDX License List;
+* A valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions.md).
+* `NONE`, if the snippet contains no license information whatsoever; or
+* `NOASSERTION`, if:
 
-`NONE`, if the snippet contains no license information whatsoever; or
-
-`NOASSERTION`, if:
-
-- the SPDX document creator has made no attempt to determine this field; or
-
-- the SPDX document creator has intentionally provided no information (no meaning should be implied by doing so).
+    - the SPDX document creator has made no attempt to determine this field; or
+    - the SPDX document creator has intentionally provided no information (no meaning should be implied by doing so).
 
 If license information for more than one license is contained in the snippet or if the license information offers a choice of licenses, then each of the choices should be listed as a separate entry. If the License Information in Snippet field is not present for a snippet, it implies an equivalent meaning to `NOASSERTION`. The metadata for the license information in snippet field is shown in Table 57.
 
@@ -317,8 +308,8 @@ If license information for more than one license is contained in the snippet or 
 | Attribute | Value |
 | --------- | ----- |
 | Required | No |
-| Cardinality | 0..* |
-| Format | `<SPDX License Expression>` \|<br>["DocumentRef-"`[idstring]`:"]"LicenseRef-"[idstring] \|<br>\| `NONE` \| `NOASSERTION`<br>where:<br>`<SPDX License Expression>` is a valid SPDX License Expression<br>as defined in Annex [D](SPDX-license-expressions.md).<br>DocumentRef-"`[idstring]`: is an optional reference to an external SPDX<br>document as described in [6.6](document-creation-information.md#6.6)<br>`[idstring]` is a unique string containing letters, numbers, `.` and/or `-`. |
+| Cardinality | 0..\* |
+| Format | `<SPDX License Expression>` \| `NONE` \| `NOASSERTION`<br>where:<br>`<SPDX License Expression>` is a valid SPDX License Expression as defined in Annex [D](SPDX-license-expressions.md). |
 
 ### 9.6.2 Intent
 


### PR DESCRIPTION
In all cases of Package, File, or Snippet, the information about
licenses found can be License Expressions, instead of single licenses.

Signed-off-by: Alexios Zavras <github@zvr.gr>
