### PR TITLE
Fix minor grammatical issue.

### DIFF
--- a/chapters/external-repository-identifiers.md
+++ b/chapters/external-repository-identifiers.md
@@ -264,7 +264,7 @@ External Reference Site: <https://gitbom.dev/>
 
 Documentation: 
 `gitoid` stands for Git Object ID. A `gitoid` of type` blob` is a unique hash of a software artifact. Git relies on a Merkle Tree to index stored objects. See <https://git-scm.com/book/en/v2/Git-Internals-Git-Objects>.
-GitBOM is an amalgam of the terms "Git" and "SBOM". GitBOM is minimalistic schema to describe software dependency graphs using a Merkle Tree, and is inspired by Git. A `gitoid` may refer to either the software artifact or its GitBOM document; this ambiguity exists because the GitBOM document is itself an artifact, and the `gitoid` of that artifact is its valid locator.
+GitBOM is an amalgam of the terms "Git" and "SBOM". GitBOM is a minimalistic schema to describe software dependency graphs using a Merkle Tree, and is inspired by Git. A `gitoid` may refer to either the software artifact or its GitBOM document; this ambiguity exists because the GitBOM document is itself an artifact, and the `gitoid` of that artifact is its valid locator.
 
 ## F.5 Other <a name="F.5"></a>
 


### PR DESCRIPTION
Missing the word "a" in a description of GitBOM.