### PR TITLE
Clarify that name is optional for extracted license info

### DIFF
--- a/chapters/other-licensing-information-detected.md
+++ b/chapters/other-licensing-information-detected.md
@@ -113,15 +113,15 @@ If indeed full text of license present in File:
 
 Provide a common name of the license that is not on the SPDX list.
 
-Use `NOASSERTION` If there is no common name or it is not known. The metadata for the license name field is shown in Table 65.
+The metadata for the license name field is shown in Table 65.
 
 **Table 65 — Metadata for the license name field**
 
 | Attribute | Value |
 | --------- | ----- |
-| Required | Conditional |
-| Cardinality | 0..1 conditional (Mandatory, one) if license is not on SPDX License List. |
-| Format | Single line of text | `NOASSERTION` |
+| Required | No |
+| Cardinality | 0..1 |
+| Format | Single line of text |
 
 ### 10.3.2 Intent
 

--- a/chapters/other-licensing-information-detected.md
+++ b/chapters/other-licensing-information-detected.md
@@ -111,8 +111,7 @@ If indeed full text of license present in File:
 
 ### 10.3.1 Description
 
-Provide a common name of the license that is not on the SPDX list.
-
+Provide a common name of the license that is not on the SPDX list.  If the License Name field is not present for a license, it implies an equivalent meaning to NOASSERTION.
 The metadata for the license name field is shown in Table 65.
 
 **Table 65 — Metadata for the license name field**
@@ -120,8 +119,9 @@ The metadata for the license name field is shown in Table 65.
 | Attribute | Value |
 | --------- | ----- |
 | Required | No |
-| Cardinality | 0..1 |
-| Format | Single line of text |
+| Cardinality | 0..1 conditional (optional, one) if license is not on SPDX License List. |
+| Format | Single line of text | `NOASSERTION` |
+
 
 ### 10.3.2 Intent
 


### PR DESCRIPTION
Fixes #506 

This PR makes the name field for the extracted license text name field to be optional rather than requiring a `NOASSERTION` value.  This is consistent with the other licensing related changes in the 2.3 release where we are making values optional rather than requiring `NOASSERTION` when the field is not known.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>