### PR TITLE
Fix 7.21 violation (`PACKAGE_MANAGER`)

### DIFF
--- a/examples/SPDXJSONExample-v2.2.spdx.json
+++ b/examples/SPDXJSONExample-v2.2.spdx.json
@@ -122,7 +122,7 @@
     "copyrightText" : "NOASSERTION",
     "downloadLocation" : "https://search.maven.org/remotecontent?filepath=org/apache/jena/apache-jena/3.12.0/apache-jena-3.12.0.tar.gz",
     "externalRefs" : [ {
-      "referenceCategory" : "PACKAGE_MANAGER",
+      "referenceCategory" : "PACKAGE-MANAGER",
       "referenceLocator" : "pkg:maven/org.apache.jena/apache-jena@3.12.0",
       "referenceType" : "purl"
     } ],


### PR DESCRIPTION
According to [7.21 External reference field](https://spdx.github.io/spdx-spec/package-information/#721-external-reference-field), it should be `PACKAGE-MANAGER` and not `PACKAGE_MANAGER`.

The SPDX Online Tool agrees with this conclusion.

<img width="596" alt="image" src="https://user-images.githubusercontent.com/357872/184670926-64d93635-db25-4aaa-aa6f-e3cc5ae6181e.png">
