### PR TITLE
fix: fix typo (definined to defined)

### DIFF
--- a/ontology/SPDX-2.2-ontology.html
+++ b/ontology/SPDX-2.2-ontology.html
@@ -1201,7 +1201,7 @@
         <h3>reference type<sup title="object property" class="type-op">op</sup><span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a></span></h3>
         <p><strong>IRI:</strong> http://spdx.org/rdf/terms#referenceType</p>
         <div class="comment">
-          <p>Type of the external reference. These are definined in an appendix in the SPDX specification.</p>
+          <p>Type of the external reference. These are defined in an appendix in the SPDX specification.</p>
         </div>
         <div class="description">
           <dl>

--- a/ontology/SPDX-2.3-ontology.html
+++ b/ontology/SPDX-2.3-ontology.html
@@ -1203,7 +1203,7 @@
         <a name="http://spdx.org/rdf/terms#referenceType"></a>
         <h3>reference type<sup title="object property" class="type-op">op</sup><span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a></span></h3>
         <p><strong>IRI:</strong> http://spdx.org/rdf/terms#referenceType</p>
-        <div class="comment"><span class="markdown">Type of the external reference. These are definined in an appendix in the SPDX specification.</span></div>
+        <div class="comment"><span class="markdown">Type of the external reference. These are defined in an appendix in the SPDX specification.</span></div>
         <div class="description">
           <dl>
             <dt>has domain</dt>

--- a/ontology/spdx-ontology.owl.ttl
+++ b/ontology/spdx-ontology.owl.ttl
@@ -337,7 +337,7 @@ If the licenseInfoInSnippet field is not present for a snippet, it implies an eq
 :referenceType rdf:type owl:ObjectProperty ;
                rdfs:domain :ExternalRef ;
                rdfs:range :ReferenceType ;
-               rdfs:comment "Type of the external reference. These are definined in an appendix in the SPDX specification."@en ;
+               rdfs:comment "Type of the external reference. These are defined in an appendix in the SPDX specification."@en ;
                ns:term_status "stable"@en .
 
 

--- a/ontology/spdx-ontology.owl.xml
+++ b/ontology/spdx-ontology.owl.xml
@@ -472,7 +472,7 @@ If the licenseInfoInSnippet field is not present for a snippet, it implies an eq
     <owl:ObjectProperty rdf:about="http://spdx.org/rdf/terms#referenceType">
         <rdfs:domain rdf:resource="http://spdx.org/rdf/terms#ExternalRef"/>
         <rdfs:range rdf:resource="http://spdx.org/rdf/terms#ReferenceType"/>
-        <rdfs:comment xml:lang="en">Type of the external reference. These are definined in an appendix in the SPDX specification.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Type of the external reference. These are defined in an appendix in the SPDX specification.</rdfs:comment>
         <ns:term_status xml:lang="en">stable</ns:term_status>
     </owl:ObjectProperty>
     

--- a/schemas/spdx-schema.json
+++ b/schemas/spdx-schema.json
@@ -329,7 +329,7 @@
                   "type" : "string"
                 },
                 "referenceType" : {
-                  "description" : "Type of the external reference. These are definined in an appendix in the SPDX specification.",
+                  "description" : "Type of the external reference. These are defined in an appendix in the SPDX specification.",
                   "type" : "string"
                 }
               },


### PR DESCRIPTION
Hello, thank you for creating & maintaining the standard!

I just noticed a typo in the JSON schema. (`definined`)
So let me create a PR to fix that.