### PR TITLE
Update JSON schema for dash and underscore enums

### DIFF
--- a/schemas/spdx-schema.json
+++ b/schemas/spdx-schema.json
@@ -322,7 +322,7 @@
                 "referenceCategory" : {
                   "description" : "Category for the external reference",
                   "type" : "string",
-                  "enum" : [ "OTHER", "PERSISTENT-ID", "SECURITY", "PACKAGE-MANAGER" ]
+                  "enum" : [ "OTHER", "PERSISTENT-ID", "PERSISTENT_ID", "SECURITY", "PACKAGE-MANAGER", "PACKAGE_MANAGER" ]
                 },
                 "referenceLocator" : {
                   "description" : "The unique string with no spaces necessary to access the package-specific information, metadata, or content within the target location. The format of the locator is subject to constraints defined by the <type>.",


### PR DESCRIPTION
Allow for both 'PACKAGE_MANAGER' and 'PACKAGE-MANAGER'. Also allows for both 'PERSISTENT-ID' and 'PERSISTENT_ID'.

Resolves #792

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>