### PR TITLE
fix: Correct cardinality of Primary Package Purpose field

### DIFF
--- a/chapters/package-information.md
+++ b/chapters/package-information.md
@@ -1445,7 +1445,7 @@ The metadata for the Primary Package Purpose field is shown in Table 36.
 | Attribute | Value |
 | --------- | ----- |
 | Required | No |
-| Cardinality | 0..* |
+| Cardinality | 0..1 |
 | Format | `APPLICATION` \| `FRAMEWORK` \| `LIBRARY` \| `CONTAINER` \| `OPERATING-SYSTEM` \| `DEVICE` \| `FIRMWARE` \| `SOURCE` \| `ARCHIVE` \| `FILE` \| `INSTALL` \| `OTHER` \|
 
 ### 7.24.2 Intent


### PR DESCRIPTION
This PR corrects the cardinality of the Primary Package Purpose.

It seems this was not updated in the spec, after agreement on https://github.com/spdx/spdx-spec/issues/720

Fixes: #794 