### PR TITLE
Fix cardinality of Primary Package Purpose

### DIFF
--- a/chapters/package-information.md
+++ b/chapters/package-information.md
@@ -1445,7 +1445,7 @@ The metadata for the Primary Package Purpose field is shown in Table 36.
 | Attribute | Value |
 | --------- | ----- |
 | Required | No |
-| Cardinality | 0..* |
+| Cardinality | 0..1 <br> _NOTE: The cardinality was incorrectly printed as 0..\* in the original publishing of the 2.3 specification_ |
 | Format | `APPLICATION` \| `FRAMEWORK` \| `LIBRARY` \| `CONTAINER` \| `OPERATING-SYSTEM` \| `DEVICE` \| `FIRMWARE` \| `SOURCE` \| `ARCHIVE` \| `FILE` \| `INSTALL` \| `OTHER` \|
 
 ### 7.24.2 Intent


### PR DESCRIPTION
It was brought to the attention of the group in the most recent SPDX DocFest that the Primary Package Purpose cardinality was incorrectly listed in the spec as 0..* despite the decision[1] that it should be 0..1. The cardinality was correct in the JSON schema and OWL ontology, however, so the consensus was to update the 2.3 specification text with a note noting the update.

[1] https://github.com/spdx/spdx-spec/issues/720

Signed-off-by: Rose Judge <rjudge@vmware.com>