### PR TITLE
Extend support of exception to LicenseRef

### DIFF
--- a/chapters/SPDX-license-expressions.md
+++ b/chapters/SPDX-license-expressions.md
@@ -22,7 +22,7 @@ simple-expression = license-id / license-id"+" / license-ref
 compound-expression = (simple-expression /
 
 
-simple-expression "WITH" license-exception-id /
+simple-expression "WITH" (license-exception-id / license-ref) /
 
   compound-expression "AND" compound-expression /
 
@@ -127,7 +127,7 @@ LGPL-2.1-only AND MIT AND BSD-2-Clause
 
 ### D.4.4 Exception "WITH" operator <a name="D.4.4"></a>
 
-Sometimes a set of license terms apply except under special circumstances. In this case, use the binary "WITH" operator to construct a new license expression to represent the special exception situation. A valid `<license-expression>` is where the left operand is a `<simple-expression>` value and the right operand is a `<license-exception-id>` that represents the special exception terms.
+Sometimes a set of license terms apply except under special circumstances. In this case, use the binary "WITH" operator to construct a new license expression to represent the special exception situation. A valid `<license-expression>` is where the left operand is a `<simple-expression>` value and the right operand is a `<license-exception-id>` or a `<license-ref>` that represents the special exception terms.
 
 For example, when the Bison exception is to be applied to GPL-2.0-or-later, the expression would be:
 

--- a/chapters/SPDX-license-expressions.md
+++ b/chapters/SPDX-license-expressions.md
@@ -135,7 +135,13 @@ For example, when the Bison exception is to be applied to GPL-2.0-or-later, the 
 GPL-2.0-or-later WITH Bison-exception-2.2
 ```
 
-The current set of valid exceptions can be found in Annex [A.2](SPDX-license-list.md#A.2). For the most up to date set of exceptions please see [spdx.org/licenses](https://spdx.org/licenses). If the applicable exception is not found on the SPDX License Exception List, then use a single `<license-ref>` to represent the entire license terms (including the exception).
+The current set of valid exceptions can be found in Annex [A.2](SPDX-license-list.md#A.2). For the most up to date set of exceptions please see [spdx.org/licenses](https://spdx.org/licenses). If the applicable exception is not found on the SPDX License Exception List, then use a `<license-ref>` to represent the exception.
+
+For example, with a custom "FOOBAR" exception applied to GPL-2.0-or-later, the expression would be:
+
+```text
+GPL-2.0-or-later WITH LicenseRef-FOOBAR
+```
 
 ### D.4.5 Order of precedence and parentheses <a name="D.4.5"></a>
 


### PR DESCRIPTION
This PR extends the usage of LicenseRef in the right hand
side of a WITH license expression.

Reference: https://github.com/spdx/change-proposal/issues/4
Reference: https://github.com/spdx/spdx-spec/issues/153
Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>