### PR TITLE
Fix package typos

### DIFF
--- a/chapters/package-information.md
+++ b/chapters/package-information.md
@@ -927,7 +927,7 @@ The options to populate this field are limited to:
     - the SPDX document creator has made no attempt to determine this field; or
     - the SPDX document creator has intentionally provided no information (no meaning should be implied by doing so).
 
-If the All Licenses Information from Files field is not present for a package and `FilesAnalyzed` field ([7.8](#7.8)) for that same pacakge is `true` or omitted, it implies an equivalent meaning to `NOASSERTION`. The metadata for all license information from files field is shown in Table 26.
+If the All Licenses Information from Files field is not present for a package and `FilesAnalyzed` field ([7.8](#7.8)) for that same package is `true` or omitted, it implies an equivalent meaning to `NOASSERTION`. The metadata for all license information from files field is shown in Table 26.
 
 **Table 26 — Metadata for the all licenses information from files field**
 

--- a/ontology/SPDX-2.3-ontology.html
+++ b/ontology/SPDX-2.3-ontology.html
@@ -1069,7 +1069,7 @@
         <h3>license info from files<sup title="object property" class="type-op">op</sup><span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a></span></h3>
         <p><strong>IRI:</strong> http://spdx.org/rdf/terms#licenseInfoFromFiles</p>
         <div class="comment"><span class="markdown">The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.
-          If the licenseInfoFromFiles field is not present for a package and filesAnalyzed property for that same pacakge is true or omitted, it implies an equivalent meaning to NOASSERTION.</span>
+          If the licenseInfoFromFiles field is not present for a package and filesAnalyzed property for that same package is true or omitted, it implies an equivalent meaning to NOASSERTION.</span>
         </div>
         <div class="description">
           <dl>

--- a/ontology/spdx-ontology.owl.ttl
+++ b/ontology/spdx-ontology.owl.ttl
@@ -240,7 +240,7 @@ If the licenseConcluded field is not present for an SPDX Item, it implies an equ
                                  ] ;
                       rdfs:comment """The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.
 
-If the licenseInfoFromFiles field is not present for a package and filesAnalyzed property for that same pacakge is true or omitted, it implies an equivalent meaning to NOASSERTION."""@en ;
+If the licenseInfoFromFiles field is not present for a package and filesAnalyzed property for that same package is true or omitted, it implies an equivalent meaning to NOASSERTION."""@en ;
                       ns:term_status "stable"@en .
 
 

--- a/ontology/spdx-ontology.owl.xml
+++ b/ontology/spdx-ontology.owl.xml
@@ -342,7 +342,7 @@ If the licenseConcluded field is not present for an SPDX Item, it implies an equ
         </rdfs:range>
         <rdfs:comment xml:lang="en">The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.
 
-If the licenseInfoFromFiles field is not present for a package and filesAnalyzed property for that same pacakge is true or omitted, it implies an equivalent meaning to NOASSERTION.</rdfs:comment>
+If the licenseInfoFromFiles field is not present for a package and filesAnalyzed property for that same package is true or omitted, it implies an equivalent meaning to NOASSERTION.</rdfs:comment>
         <ns:term_status xml:lang="en">stable</ns:term_status>
     </owl:ObjectProperty>
     

--- a/schemas/spdx-schema.json
+++ b/schemas/spdx-schema.json
@@ -366,10 +366,10 @@
             "type" : "string"
           },
           "licenseInfoFromFiles" : {
-            "description" : "The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.\n\nIf the licenseInfoFromFiles field is not present for a package and filesAnalyzed property for that same pacakge is true or omitted, it implies an equivalent meaning to NOASSERTION.",
+            "description" : "The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.\n\nIf the licenseInfoFromFiles field is not present for a package and filesAnalyzed property for that same package is true or omitted, it implies an equivalent meaning to NOASSERTION.",
             "type" : "array",
             "items" : {
-              "description" : "License expression for licenseInfoFromFiles. See SPDX Annex D for the license expression syntax.  The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.\n\nIf the licenseInfoFromFiles field is not present for a package and filesAnalyzed property for that same pacakge is true or omitted, it implies an equivalent meaning to NOASSERTION.",
+              "description" : "License expression for licenseInfoFromFiles. See SPDX Annex D for the license expression syntax.  The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.\n\nIf the licenseInfoFromFiles field is not present for a package and filesAnalyzed property for that same package is true or omitted, it implies an equivalent meaning to NOASSERTION.",
               "type" : "string"
             }
           },


### PR DESCRIPTION
Stumbled across [this typo](https://spdx.github.io/spdx-spec/v2-draft/package-information/#72-package-spdx-identifier-field), figured I'd fix it up! 😄 

Let me know if any of these changes are unnecessary, I just searched for this typo and fixed it everywhere it appeared.