### PR TITLE
fix: add correct referenceCategory values to the 2.2 JSON schema

### DIFF
--- a/schemas/spdx-schema.json
+++ b/schemas/spdx-schema.json
@@ -317,7 +317,7 @@
                 "referenceCategory" : {
                   "description" : "Category for the external reference",
                   "type" : "string",
-                  "enum" : [ "OTHER", "PERSISTENT_ID", "SECURITY", "PACKAGE_MANAGER" ]
+                  "enum" : [ "OTHER", "PERSISTENT-ID", "PERSISTENT_ID", "SECURITY", "PACKAGE-MANAGER", "PACKAGE_MANAGER" ]
                 },
                 "referenceLocator" : {
                   "description" : "The unique string with no spaces necessary to access the package-specific information, metadata, or content within the target location. The format of the locator is subject to constraints defined by the <type>.",


### PR DESCRIPTION
This PR adds `PERSISTENT-ID` and `PACKAGE-MANAGER` as valid values for `referenceCategory` to the v2.2 JSON schema, which aligns more correctly with the SPDX spec and the 2.3 schema.

I'm not sure if this is the correct base branch to target -- please let me know if this should be changed!

This may fix #798 