### PR TITLE
chore: deprecate shorthand properties

### DIFF
--- a/schemas/spdx-schema.json
+++ b/schemas/spdx-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "$schema" : "https://json-schema.org/draft/2019-09/schema#",
   "$id" : "http://spdx.org/rdf/terms/2.3",
   "title" : "SPDX 2.3",
   "type" : "object",
@@ -217,7 +217,9 @@
       "description" : "The URI provides an unambiguous mechanism for other SPDX documents to reference SPDX elements within this SPDX document."
     },
     "documentDescribes" : {
-      "description" : "Packages, files and/or Snippets described by this SPDX document",
+      "description" : "DEPRECATED: use relationships instead of this field. Packages, files and/or Snippets described by this SPDX document",
+      "deprecated": true,
+      "$comment": "This field has been deprecated as it is a duplicate of using the SPDXRef-DOCUMENT DESCRIBES relationship",
       "type" : "array",
       "items" : {
         "type" : "string",
@@ -343,7 +345,9 @@
             "type" : "boolean"
           },
           "hasFiles" : {
-            "description" : "Indicates that a particular file belongs to a package.",
+            "description" : "DEPRECATED: use relationships instead of this field. Indicates that a particular file belongs to a package.",
+            "deprecated": true,
+            "$comment": "This field has been deprecated as it is a duplicate of using SPDXRef-<package-id> CONTAINS SPDXRef-<file-id> relationships",
             "type" : "array",
             "items" : {
               "description" : "SPDX ID for File.  Indicates that a particular file belongs to a package.",

--- a/schemas/spdx-schema.json
+++ b/schemas/spdx-schema.json
@@ -348,7 +348,7 @@
           "hasFiles" : {
             "description" : "DEPRECATED: use relationships instead of this field. Indicates that a particular file belongs to a package.",
             "deprecated": true,
-            "$comment": "This field has been deprecated as it is a duplicate of using SPDXRef-<package-id> CONTAINS SPDXRef-<file-id> relationships",
+            "$comment": "This field has been deprecated as it is a duplicate of using CONTAINS relationships from a package to files",
             "type" : "array",
             "items" : {
               "description" : "SPDX ID for File.  Indicates that a particular file belongs to a package.",

--- a/schemas/spdx-schema.json
+++ b/schemas/spdx-schema.json
@@ -187,6 +187,7 @@
     },
     "revieweds" : {
       "description" : "Reviewed",
+      "deprecated": true,
       "type" : "array",
       "items" : {
         "type" : "object",
@@ -535,6 +536,7 @@
           },
           "fileDependencies" : {
             "description" : "This field is deprecated since SPDX 2.0 in favor of using Section 7 which provides more granularity about relationships.",
+            "deprecated": true,
             "type" : "array",
             "items" : {
               "description" : "SPDX ID for File.  This field is deprecated since SPDX 2.0 in favor of using Section 7 which provides more granularity about relationships.",


### PR DESCRIPTION
This PR adds deprecation to the "shorthand" properties in the schema and marks previously deprecated fields as such with the `deprecated` property.

Based on the SPDX WG meeting 2023/02/28, these fields will not be included in SPDX 3.0 and we want to indicate they are deprecated in the latest SPDX 2.3 JSON schema.

cc: @goneall @lumjjb