### PR TITLE
feat: allow $schema entry in SPDX 2.3 JSON

### DIFF
--- a/schemas/spdx-schema.json
+++ b/schemas/spdx-schema.json
@@ -4,6 +4,10 @@
   "title" : "SPDX 2.3",
   "type" : "object",
   "properties" : {
+    "$schema": {
+      "type": "string",
+      "description": "Reference the SPDX 2.3 JSON schema."
+    },
     "SPDXID" : {
       "type" : "string",
       "description" : "Uniquely identify any element in an SPDX document which may be referenced by other elements."


### PR DESCRIPTION
This adds an allowed field `$schema` to the JSON schema, which can be used to reference the SPDX 2.3 JSON schema.
Ideally this would be an enum with a list of allowed locators, but since the schema is not hosted anywhere other than in GitHub (not to my knowledge), I left it as a free-form string.

Closes #864.