### PR TITLE
New workflow for deploying the v3 spec to the site.

### DIFF
--- a/.github/workflows/publish_v3.yml
+++ b/.github/workflows/publish_v3.yml
@@ -1,0 +1,38 @@
+on:
+  push:
+    branches:
+      - development/v3.0
+  repository_dispatch:
+    types:
+      - publish_v3_spec
+  workflow_dispatch: {}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: python:3
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          ref: development/v3.0
+          path: spdx-spec
+          fetch-depth: 0 # Because we will be pushing the gh-pages branch
+          token: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          repository: spdx/spec-parser
+          ref: main
+          path: spec-parser
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          repository: spdx/spdx-3-model
+          ref: main
+          path: spdx-3-model
+      - name: Install pre-requisites
+        run: pip install -r spdx-spec/requirements.txt
+      - name: Install pre-requisites for spec-parser
+        run: pip install -r spec-parser/requirements.txt
+      - name: Build model
+        run: python3 spec-parser/main.py spdx-3-model/model spdx-spec/docs/model
+      - name: Build docs
+        run: mike deploy v3.0 v3-draft
+        working-directory: spdx-spec

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 mkdocs==1.5.3
 json-schema-for-humans==0.47
-
+mike==1.1.2


### PR DESCRIPTION
This workflow uses spec-parser and spdx-3-model to build and deploy the v3 spec into the main spec site, alongside the 2.x versions already deployed.

It is designed to be triggered by pushes to the development/v3.0 branch, via manual triggers, and via external triggers.  The latter can be used to build workflows to cause the spec to be rebuilt on changes to spec-parser or spdx-3-model.