### PR TITLE
Build and deploy the v3.0 spec on changes.

### DIFF
--- a/.github/workflows/publish_v3.yml
+++ b/.github/workflows/publish_v3.yml
@@ -16,7 +16,6 @@ jobs:
           ref: development/v3.0
           path: spdx-spec
           fetch-depth: 0 # Because we will be pushing the gh-pages branch
-          token: ${{ secrets.ACTIONS_DEPLOY_KEY }}
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           repository: spdx/spec-parser

--- a/.github/workflows/publish_v3.yml
+++ b/.github/workflows/publish_v3.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Build model
         run: python3 spec-parser/main.py spdx-3-model/model spdx-spec/docs/model
       - name: Build docs
-        run: mike deploy v3.0 v3-draft
+        run: GIT_COMMITTER_NAME=ci-bot GIT_COMMITTER_EMAIL=ci-bot@spdx.dev mike deploy v3.0 v3-draft
         working-directory: spdx-spec

--- a/.github/workflows/publish_v3.yml
+++ b/.github/workflows/publish_v3.yml
@@ -36,5 +36,5 @@ jobs:
         run: git config user.name ci-bot; git config user.email ci-bot@spdx.dev
         working-directory: spdx-spec
       - name: Build docs
-        run: mike deploy v3.0 v3-draft
+        run: mike deploy v3.0 v3-draft -b gh-pages -p
         working-directory: spdx-spec

--- a/.github/workflows/publish_v3.yml
+++ b/.github/workflows/publish_v3.yml
@@ -32,6 +32,8 @@ jobs:
         run: pip install -r spec-parser/requirements.txt
       - name: Build model
         run: python3 spec-parser/main.py spdx-3-model/model spdx-spec/docs/model
+      - name: Set git identity
+        run: git config user.name ci-bot; git config user.email ci-bot@spdx.dev
       - name: Build docs
-        run: GIT_COMMITTER_NAME=ci-bot GIT_COMMITTER_EMAIL=ci-bot@spdx.dev mike deploy v3.0 v3-draft
+        run: mike deploy v3.0 v3-draft
         working-directory: spdx-spec

--- a/.github/workflows/publish_v3.yml
+++ b/.github/workflows/publish_v3.yml
@@ -34,6 +34,7 @@ jobs:
         run: python3 spec-parser/main.py spdx-3-model/model spdx-spec/docs/model
       - name: Set git identity
         run: git config user.name ci-bot; git config user.email ci-bot@spdx.dev
+        working-directory: spdx-spec
       - name: Build docs
         run: mike deploy v3.0 v3-draft
         working-directory: spdx-spec

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,10 @@ site_name: SPDX v3 Specification
 copyright: DRAFT version generated from d25ae89 (model) by 85e8d65 (parser)
 use_directory_urls: true
 theme: readthedocs
+plugins:
+- search
+- pdf-export:
+    combined: true
 extra_css:
 - css/style.css
 markdown_extensions:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mkdocs==1.5.3
 json-schema-for-humans==0.47
+mkdocs-pdf-export-plugin==0.5.10
 mike==1.1.2


### PR DESCRIPTION
Rebuild the spec using GitHub Actions on changes to the 3.0 branch, and deploy to the spec website with a new version (v3.0, aliased to v3-draft).  The build can also be triggered from external repository changes and manually.