### PR TITLE
Attempt to fix CI failures related to PyYAML.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ json-schema-for-humans==0.47
 mkdocs-pdf-export-plugin==0.5.10
 mike==1.1.2
 shacl2code==0.0.9
+PyYAML>=6.0.1


### PR DESCRIPTION
Due to a build incompatibility between PyYAML and Cython 3.0.0, builds of PyYAML from source to satisfy a dependency will fail without a workaround introduced in PyYAML 6.0.1.  Therefore, we should insist on installing at least that version.

Fixes #867.