### PR TITLE
Add 3.0 and 2.3 changes to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@ All notable changes to this project will be documented in this file.
 
 ## 3.0
 
-See the [v3.0 GithHub release notes](https://github.com/spdx/spdx-spec/releases/tag/v3.0) for changes.
+See the [v3.0 GitHub release notes](https://github.com/spdx/spdx-spec/releases/tag/v3.0) for changes.
 
 ## 2.3
 
-See the [v2.3 GithHub release notes](https://github.com/spdx/spdx-spec/releases/tag/v2.3) for changes.
+See the [v2.3 GitHub release notes](https://github.com/spdx/spdx-spec/releases/tag/v2.3) for changes.
 
 ## 2.2 (2020-05-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## 3.0 (TBD)
+## 3.0
 
-* Refactored the build process and mkdocs process.
+See the [v3.0 GithHub release notes](https://github.com/spdx/spdx-spec/releases/tag/v3.0) for changes.
+
+## 2.3
+
+See the [v2.3 GithHub release notes](https://github.com/spdx/spdx-spec/releases/tag/v2.3) for changes.
 
 ## 2.2 (2020-05-02)
 


### PR DESCRIPTION
We switched over to using the GitHub release notes on version 2.3 and later.

This adds references to the GitHub release notes in the CHANGELOG.md

Fixes #919 