### PR TITLE
Validate only specific doc examples with SHACL in CI.

### DIFF
--- a/.github/workflows/validate_examples.yml
+++ b/.github/workflows/validate_examples.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Check documentation examples
         run: |
-          for f in $(grep -l '```json' docs/annexes/*.md); do
+          for f in docs/annexes/getting-started.md; do
             echo "Checking $f"
             cat $f | awk '/^```json/, $0=="```" {if ($0 !~ /^```.*/ ) print}' > temp.json
             check-jsonschema \


### PR DESCRIPTION
The check assumes that JSON example snippets are all parts of a single JSON document that needs validating, but not all files are written that way.  To avoid errors that have nothing to do with the correctness of the examples, we should only check files which meet the check's assumptions.

Fixes #912.