### PR TITLE
mkdocs: Fix ref not found warnings

### DIFF
--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -4,11 +4,7 @@ TODO: update for SPDXv3
 
 ## 4.1 SPDX Current and Previous Versions <a name="4.1"></a>
 
-This edition has the version number 2.3 as part of its title. This is a follow on from [ISO/IEC 5962:2021 Information technology — SPDX® Specification V2.2.1](https://www.iso.org/standard/81870.html), and includes new fields.
-
-Earlier editions were published by the SPDX workgroup via the Linux Foundation. The SPDX Specification was subsequently transposed into the Joint Development Foundation. [Those earlier editions are: 1.0 (August 2011), 1.1 (August 2012), 1.2 (October 2013), 2.0 (May 2015), 2.1 (November 2016), and 2.2 (May 2020).]
-
-Differences between this edition and earlier ones are reported in [Annex J](annexes/diffs-from-previous-editions.md);
+This edition has the version number 2.3 as part of its title. This is a follow on from [ISO/IEC 5962:2021 Information technology — SPDX® Specification V2.2.1](https://www.iso.org/standard/81870.html), and includes new fields.  Earlier editions were published by the SPDX workgroup via the Linux Foundation. The SPDX Specification was subsequently transposed into the Joint Development Foundation. [Those earlier editions are: 1.0 (August 2011), 1.1 (August 2012), 1.2 (October 2013), 2.0 (May 2015), 2.1 (November 2016), and 2.2 (May 2020).] Differences between this edition and earlier ones are reported in [Annex J](annexes/diffs-from-previous-editions.md);
 see also [[1]](bibliography.md).
 
 ## 4.2 Obsolete features <a name="4.2"></a>

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -4,8 +4,8 @@ TODO: update for SPDXv3
 
 ## 4.1 SPDX Current and Previous Versions <a name="4.1"></a>
 
-This edition has the version number 2.3 as part of its title. This is a follow on from [ISO/IEC 5962:2021 Information technology — SPDX® Specification V2.2.1](https://www.iso.org/standard/81870.html), and includes new fields.  Earlier editions were published by the SPDX workgroup via the Linux Foundation. The SPDX Specification was subsequently transposed into the Joint Development Foundation. [Those earlier editions are: 1.0 (August 2011), 1.1 (August 2012), 1.2 (October 2013), 2.0 (May 2015), 2.1 (November 2016), and 2.2 (May 2020).] Differences between this edition and earlier ones are reported in [Annex J](annexes/diffs-from-previous-editions.md);
-see also [[1]](bibliography.md).
+This edition has the version number 2.3 as part of its title. This is a follow on from [ISO/IEC 5962:2021
+Information technology — SPDX® Specification V2.2.1](https://www.iso.org/standard/81870.html), and includes new fields.  Earlier editions were published by the SPDX workgroup via the Linux Foundation. The SPDX Specification was subsequently transposed into the Joint Development Foundation. [Those earlier editions are: 1.0 (August 2011), 1.1 (August 2012), 1.2 (October 2013), 2.0 (May 2015), 2.1 (November 2016), and 2.2 (May 2020).] Differences between this edition and earlier ones are reported in [Annex J](annexes/diffs-from-previous-editions.md); see also [[1]](bibliography.md).
 
 ## 4.2 Obsolete features <a name="4.2"></a>
 

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -4,8 +4,12 @@ TODO: update for SPDXv3
 
 ## 4.1 SPDX Current and Previous Versions <a name="4.1"></a>
 
-This edition has the version number 2.3 as part of its title. This is a follow on from [ISO/IEC 5962:2021
-Information technology — SPDX® Specification V2.2.1](https://www.iso.org/standard/81870.html), and includes new fields.  Earlier editions were published by the SPDX workgroup via the Linux Foundation. The SPDX Specification was subsequently transposed into the Joint Development Foundation. [Those earlier editions are: 1.0 (August 2011), 1.1 (August 2012), 1.2 (October 2013), 2.0 (May 2015), 2.1 (November 2016), and 2.2 (May 2020).] Differences between this edition and earlier ones are reported in [Annex J](diffs-from-previous-editions.md); see also [[1]](bibliography.md).
+This edition has the version number 2.3 as part of its title. This is a follow on from [ISO/IEC 5962:2021 Information technology — SPDX® Specification V2.2.1](https://www.iso.org/standard/81870.html), and includes new fields.
+
+Earlier editions were published by the SPDX workgroup via the Linux Foundation. The SPDX Specification was subsequently transposed into the Joint Development Foundation. [Those earlier editions are: 1.0 (August 2011), 1.1 (August 2012), 1.2 (October 2013), 2.0 (May 2015), 2.1 (November 2016), and 2.2 (May 2020).]
+
+Differences between this edition and earlier ones are reported in [Annex J](annexes/diffs-from-previous-editions.md);
+see also [[1]](bibliography.md).
 
 ## 4.2 Obsolete features <a name="4.2"></a>
 
@@ -80,4 +84,4 @@ The official copyright notice that shall be used with any non-verbatim reproduct
 
 ## 4.6 The SPDX Lite profile <a name="4.6"></a>
 
-Rather than conforming to this whole specification, an implementation may conform with SPDX Lite only, a profile that defines a subset of the SPDX specification. SPDX Lite aims at the balance between the SPDX standard and actual workflows in some industries. See [Annex G](SPDX-Lite.md) for more information.
+Rather than conforming to this whole specification, an implementation may conform with SPDX Lite only, a profile that defines a subset of the SPDX specification. SPDX Lite aims at the balance between the SPDX standard and actual workflows in some industries. See [Annex G](annexes/SPDX-Lite.md) for more information.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -144,7 +144,6 @@ nav:
       - model/Software/Properties/downloadLocation.md
       - model/Software/Properties/fileKind.md
       - model/Software/Properties/homePage.md
-      - model/Software/Properties/isDirectory.md
       - model/Software/Properties/lineRange.md
       - model/Software/Properties/packageUrl.md
       - model/Software/Properties/packageVersion.md
@@ -251,7 +250,6 @@ nav:
   - Dataset:
     - 'Description': model/Dataset/Dataset.md
     - Classes:
-      - model/Dataset/Classes/Dataset.md
       - model/Dataset/Classes/DatasetPackage.md
     - Properties:
       - model/Dataset/Properties/anonymizationMethodUsed.md
@@ -266,7 +264,6 @@ nav:
       - model/Dataset/Properties/hasSensitivePersonalInformation.md
       - model/Dataset/Properties/intendedUse.md
       - model/Dataset/Properties/knownBias.md
-      - model/Dataset/Properties/sensitivePersonalInformation.md
       - model/Dataset/Properties/sensor.md
     - Vocabularies:
       - model/Dataset/Vocabularies/ConfidentialityLevelType.md
@@ -295,7 +292,6 @@ nav:
       - model/AI/Properties/modelDataPreprocessing.md
       - model/AI/Properties/modelExplainability.md
       - model/AI/Properties/safetyRiskAssessment.md
-      - model/AI/Properties/sensitivePersonalInformation.md
       - model/AI/Properties/standardCompliance.md
       - model/AI/Properties/trainingEnergyConsumption.md
       - model/AI/Properties/typeOfModel.md


### PR DESCRIPTION
(A rework of #926 to fix unresolvable rebase/merge conflicts)

Fix ref/doc not found warnings during spec doc generation.

Currently, `mkdocs serve` and `mkdocs build` emit these warnings:

```
WARNING -  A reference to 'model/Software/Properties/isDirectory.md' is included in the 'nav' configuration, which is not
           found in the documentation files.
WARNING -  A reference to 'model/Dataset/Classes/Dataset.md' is included in the 'nav' configuration, which is not found
           in the documentation files.
WARNING -  A reference to 'model/Dataset/Properties/sensitivePersonalInformation.md' is included in the 'nav'
           configuration, which is not found in the documentation files.
WARNING -  A reference to 'model/AI/Properties/sensitivePersonalInformation.md' is included in the 'nav' configuration,
           which is not found in the documentation files.
WARNING -  Doc file 'conformance.md' contains a link 'diffs-from-previous-editions.md', but the target is not found among
           documentation files.
WARNING -  Doc file 'conformance.md' contains a link 'SPDX-Lite.md', but the target is not found among documentation
           files.
```

The first 4 warnings are responsible to the four erroneous `None` class/properties displaying in the left pane of https://spdx.github.io/spdx-spec/v3.0/ . They are all old property names. New property names are already included in the nav. Fixed by removing all 4 outdated references:

- `model/Software/Properties/isDirectory.md` is now `fileKind`
  - https://github.com/spdx/spdx-3-model/pull/666
- `model/Dataset/Classes/Dataset.md` is now `DatasetPackage`
  - https://github.com/spdx/spdx-3-model/pull/671
- `model/Dataset/Properties/sensitivePersonalInformation.md` is now `hasSensitivePersonalInformation`
- `model/AI/Properties/sensitivePersonalInformation.md` is now `useSensitivePersonalInformation`
  - https://github.com/spdx/spdx-3-model/pull/656

The remaining 2 warnings are fixed by add directory name to the targets in `conformance.md`:

- `diffs-from-previous-editions.md` and `SPDX-Lite.md` are in `annexes/` directory
- Note that `conformance.md` is not included yet in the 3.0 as the content is need to be updated for the version. So fixing these 2 warnings or not is not effecting what the public will see in the spec doc - yet, until we include the Conformance chapter to the spec.