### PR TITLE
Add build instruction and flow diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,17 +190,18 @@ Files intended for display and linking in the navigation bar should be
 included in the `nav:` section. The order of filenames in this section
 determines their order on the navigation bar.
 
-## Specifications on spdx.github.io/spdx-spec/
+## Specification versions on spdx.github.io/spdx-spec/
 
 The SPDX specifications on <https://spdx.github.io/spdx-spec/> are built
 by using a workflow in
 [`.github/workflows/publish_v3.yml`](/.github/workflows/publish_v3.yml).
-This workflow uses [mike](https://github.com/jimporter/mike) to deploy multiple
-versions of MkDocs-powered documentation.
+This workflow uses [mike](https://github.com/jimporter/mike) to publish
+multiple versions of MkDocs-powered documentation.
 
-Deployed versions, their titles, and their aliases, can be seen in the file
+The published versions, their titles, and aliases are listed in the file
 [versions.json](https://github.com/spdx/spdx-spec/blob/gh-pages/versions.json)
-in the `gh-pages` branch.
+located in the `gh-pages` branch. These versions populate the version selector
+dropdown on the website. The line `run: mike deploy` in the GitHub workflow
+file determines the title and alias.
 
-mike is not required for local testing of a specific version of the
-specification.
+mike is not needed for local testing of a specific spec version.

--- a/README.md
+++ b/README.md
@@ -189,6 +189,18 @@ Or building a static HTML site:
 mkdocs build
 ```
 
+To abort the build immediately when there is a warning, enables strict mode:
+
+```shell
+mkdocs build --strict
+```
+
+To get debug messages, enables verbose output:
+
+```shell
+mkdocs build --verbose
+```
+
 ## Configuring the website
 
 Inside `spdx-spec/` directory, there is a file `mkdocs.yml`. This is a

--- a/README.md
+++ b/README.md
@@ -1,33 +1,206 @@
 # The System Package Data Exchange (SPDX®) Specification
 
-The System Package Data Exchange (SPDX®) specification is an open standard capable of representing systems with software components in as SBOMs (Software Bill of Materials) and other AI, data and security references supporting a range of risk management use cases.
+The System Package Data Exchange (SPDX®) specification is an open standard
+capable of representing systems with software components in as SBOMs
+(Software Bill of Materials) and other AI, data and security references
+supporting a range of risk management use cases.
 
-The SPDX standard helps facilitate compliance with free and open source software licenses by standardizing the way license information is shared across the software supply chain. SPDX reduces redundant work by providing a common format for companies and communities to share important data about software licenses and copyrights, thereby streamlining and improving compliance.
+The SPDX standard helps facilitate compliance with free and open source
+software licenses by standardizing the way license information is shared across
+the software supply chain. SPDX reduces redundant work by providing a common
+format for companies and communities to share important data about software
+licenses and copyrights, thereby streamlining and improving compliance.
 
 This repository holds under active development version of the specification as:
 
-* [MarkDown](https://github.com/spdx/spdx-spec/tree/master/chapters) (`master` branch)
-* HTML (gh-pages branch, built on every commit to `master` and `development/` branches)
-  * [Current](https://spdx.github.io/spdx-spec/v3.0/)
+- Markdown:
+  [`development/v3.0.1`](https://github.com/spdx/spdx-spec/tree/development/v3.0.1/docs)
+  branch
+- HTML: `gh-pages` branch, built on every commit to the development branch,
+  see the workflow in
+  [`.github/workflows/publish_v3.yml`](/.github/workflows/publish_v3.yml)
+  - Current (3.0): <https://spdx.github.io/spdx-spec/v3.0/>
 
-See for the official [releases of the specification](https://spdx.org/specifications) or additional information also the [SPDX website](https://spdx.org).
+The model itself is under active development at
+[spdx/spdx-3-model](https://github.com/spdx/spdx-3-model/)
+repo (`main` branch).
 
-## Specification Structure
+See for the official
+[releases of the specification](https://spdx.org/specifications)
+or additional information also the SPDX website at <https://spdx.org>.
 
-The specification consists of a model which is generated from the [spdx-3-model](https://github.com/spdx/spdx-3-model) repository and additional information in the `docs` directory.
+## Specification structure
 
-The `examples` directory contains examples of various SPDX serializations for the current version of the spec.
+This repository consists of these files and directories:
 
-# Building the specification
+- `bin/` - Scripts for spec generation.
+- `docs/` - Specification content:
+  - `annexes/` - Annexes for the specification.
+  - `css/` - Style sheets for HTML.
+  - `images/` - Model diagrams. These image files are to be generated from a
+    diagram description file
+    [model.drawio](https://github.com/spdx/spdx-3-model/blob/main/model.drawio)
+    in `spdx/spdx-3-model` repo and manually copied here.
+  - `licenses/` - Licenses that used by the SPDX specifications.
+  - `model/` - Model files*. This subdirectory _is to be created_ by a script
+    from `spdx/spec-parser` repo, using model information from
+    `spdx/spdx-3-model` repo (see the build instructions below).
+- `examples/` - Examples of various SPDX serializations for the current version
+  of the spec.
+- `mkdocs.yml` - MkDocs recipe for the spec documentation generation. The
+  inclusion of model files and the order of chapters are defined here.
 
-## Prerequisites
+The specification consists of documents in the `docs/` directory from this
+`spdx/spdx-spec` repository and a model which is generated from Markdown files
+in the `spdx/spdx-3-model` repository.
 
-You have to [MkDocs](http://mkdocs.org) installed on your machine. If you don't have it yet installed please follow these [installation instructions](http://www.mkdocs.org/#installation).
+Note: The model Markdown files in the `spdx/spdx-3-model` repository use a
+constrained format. Only a limited set of headings are allowed for processing
+by the spec-parser.
 
-## Building HTML
+## Building the specification
 
-    # Execute built-in dev-server that lets you preview the specification
-    $ mkdocs serve
+The specification building flow looks like this:
 
-    # Building static HTML site
-    $ mkdocs build
+```text
+  +-------------------+
+  |[spdx-3-model]     |
+  | |                 |
+  | +- model/        ---- Constrained-Markdown files -+
+  | |                 |                               |
+  | +- model.drawio  -----------------+               |
+  +-------------------+               |               |
+                                      |               |
+                                      |               |
+  +-------------------+               v               |
+  |[spdx-spec]        |            draw.io            |
+  | |                 |            (manual)           |
+  | +- docs/          |               |               |
+  |    |              |               |               |
+  |    +- annexes/    |               |               v
+  |    |              |               |         spec-parser
+  |    +- images/  <---- PNG images --+               |
+  |    |              |                               |
+  |    +- licenses/   |                               |
+  |    |              |                               |
+  |    +- model/   <----- Processed Markdown files ---+
+  |    |              |
+  |    +- index.md    |
+  |    |              |
+  |    +- *.md        |
+  +-------------------+
+          |
+    mike & mkdocs
+          |
+          v
+  +-------------------+
+  |   HTML website    |
+  +-------------------+
+```
+
+### Prerequisites
+
+Apart from Git and Python, you have to have [MkDocs](http://mkdocs.org)
+installed on your machine. If you don't have it yet installed please follow
+these [installation instructions](http://www.mkdocs.org/#installation).
+
+[WeasyPrint](https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#installation)
+is also required for generating PDF files. To disable PDF generation, comment
+out the these lines in your `mkdocs.yml` configuration file:
+
+```yaml
+#- pdf-export:
+#    combined: true
+```
+
+### Preparing input files
+
+Next, you have to prepare the model files, the other specification files,
+and the model parser, by cloning these repositoriess:
+[`spdx/spdx-3-model`](https://github.com/spdx/spdx-3-model),
+[`spdx/spdx-spec`](https://github.com/spdx/spdx-spec), and
+[`spdx/spec-parser`](https://github.com/spdx/spec-parser)
+to these paths: `spdx-3-model`, `spdx-spec`, and `spec-parser`, respectively:
+
+```shell
+git clone https://github.com/spdx/spdx-3-model.git
+git clone https://github.com/spdx/spdx-spec.git
+git clone https://github.com/spdx/spec-parser.git
+```
+
+Install prerequisites for Python:
+
+```shell
+pip3 install -r spdx-spec/requirements.txt
+pip3 install -r spec-parser/requirements.txt
+```
+
+### Generating formatted Markdown files for MkDocs
+
+Model files in `spdx/spdx-3-model` repo are written in a specific format of
+Markdown, with a limited set of allowed headings. The `spec-parser` processes
+these model files to generate both ontology and final Markdown files suitable
+for MkDocs.
+
+The `spec-parser` also performs automatic formatting on the resulting Markdown
+files. For instance, it converts a list under the "Properties" heading into a
+table.
+
+To check the model files and generate formatted files for MkDocs, run the
+following command:
+
+```shell
+python3 spec-parser/main.py spdx-3-model/model spdx-spec/docs/model
+```
+
+This will create well-formatted model files in the `spdx-spec/docs/model/`
+directory. This directory contains two components:
+
+- Model ontology and diagram files: These files (`model.plantuml`,
+  `spdx-context.jsonld`, `spdx-model.dot`, `spdx-model.json-ld`,
+  `spdx-model.pretty-xml`, `spdx-model.ttl`, `spdx-model.xml`)
+  are ready for immediate use.
+- Formatted Makdown files: These files (`.md` extension) are located in various
+  subdirectories and are intended for processing by MkDocs in the next step.
+
+### Building HTML
+
+With all spec and model files prepared, we will use MkDocs to assemble them
+into a website.
+
+In side `spdx-spec/` directory, execute a built-in dev-server that let you
+preview the specification:
+
+```shell
+mkdocs serve
+```
+
+Or building a static HTML site:
+
+```shell
+mkdocs build
+```
+
+## Configuring the website
+
+Inside `spdx-spec/` directory, there is a file `mkdocs.yml`. This is a
+configuration file for MkDocs.
+
+Files intended for display and linking in the navigation bar should be
+included in the `nav:` section. The order of filenames in this section
+determines their order on the navigation bar.
+
+## Specifications on spdx.github.io/spdx-spec/
+
+The SPDX specifications on <https://spdx.github.io/spdx-spec/> are built
+by using a workflow in
+[`.github/workflows/publish_v3.yml`](/.github/workflows/publish_v3.yml).
+This workflow uses [mike](https://github.com/jimporter/mike) to deploy multiple
+versions of MkDocs-powered documentation.
+
+Deployed versions, their titles, and their aliases, can be seen in the file
+[versions.json](https://github.com/spdx/spdx-spec/blob/gh-pages/versions.json)
+in the `gh-pages` branch.
+
+mike is not required for local testing of a specific version of the
+specification.

--- a/README.md
+++ b/README.md
@@ -163,6 +163,14 @@ directory. This directory contains two components:
 - Formatted Makdown files: These files (`.md` extension) are located in various
   subdirectories and are intended for processing by MkDocs in the next step.
 
+If the output directory already exists, the `spec-parser` will not overwrite
+it. If you edited a model file and want to regenerate the formatted files, you
+have to delete the existing `spdx-spec/docs/model` directory first:
+
+```shell
+rm -rf spdx-spec/docs/model
+```
+
 ### Building HTML
 
 With all spec and model files prepared, we will use MkDocs to assemble them

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository holds under active development version of the specification as:
   branch
 - HTML: `gh-pages` branch, built on every commit to the development branch,
   see the workflow in
-  [`.github/workflows/publish_v3.yml`](/.github/workflows/publish_v3.yml)
+  [`.github/workflows/publish_v3.yml`](.github/workflows/publish_v3.yml)
   - Current (3.0): <https://spdx.github.io/spdx-spec/v3.0/>
 
 The model itself is under active development at
@@ -54,8 +54,8 @@ The specification consists of documents in the `docs/` directory from this
 `spdx/spdx-spec` repository and a model which is generated from Markdown files
 in the `spdx/spdx-3-model` repository.
 
-Note: The model Markdown files in the `spdx/spdx-3-model` repository use a
-constrained format. Only a limited set of headings are allowed for processing
+Note: The model files in the `spdx/spdx-3-model` repository use a constrained
+format of Markdown. Only a limited set of headings are allowed to be processed
 by the spec-parser.
 
 ## Building the specification
@@ -214,7 +214,7 @@ determines their order on the navigation bar.
 
 The SPDX specifications on <https://spdx.github.io/spdx-spec/> are built
 by using a workflow in
-[`.github/workflows/publish_v3.yml`](/.github/workflows/publish_v3.yml).
+[`.github/workflows/publish_v3.yml`](.github/workflows/publish_v3.yml).
 This workflow uses [mike](https://github.com/jimporter/mike) to publish
 multiple versions of MkDocs-powered documentation.
 

--- a/docs/annexes/SPDX-license-expressions.md
+++ b/docs/annexes/SPDX-license-expressions.md
@@ -6,7 +6,7 @@ Often a single license can be used to represent the licensing terms of a source 
 
 SPDX License Expressions provide a way for one to construct expressions that more accurately represent the licensing terms typically found in open source software source code. A license expression could be a single license identifier found on the SPDX License List; a user defined license reference denoted by the LicenseRef-`[idString]`; a license identifier combined with an SPDX exception; or some combination of license identifiers, license references and exceptions constructed using a small set of defined operators (e.g., `AND`, `OR`, `WITH` and `+`). We provide the definition of what constitutes a valid SPDX License Expression in this section.
 
-The exact syntax of license expressions is described below in [ABNF](http://tools.ietf.org/html/rfc5234).
+The exact syntax of license expressions is described below in ABNF, as defined in [RFC5234](http://tools.ietf.org/html/rfc5234) and expanded in [RFC7405](http://tools.ietf.org/html/rfc7405).
 
 ```text
 idstring = 1*(ALPHA / DIGIT / "-" / "." )
@@ -15,9 +15,9 @@ license-id = <short form license identifier in Annex A.1>
 
 license-exception-id = <short form license exception identifier in Annex A.2>
 
-license-ref = ["DocumentRef-"(idstring)":"]"LicenseRef-"(idstring)
+license-ref = [%s"DocumentRef-"(idstring)":"]%s"LicenseRef-"(idstring)
 
-addition-ref = ["DocumentRef-"(idstring)":"]"AdditionRef-"(idstring)
+addition-ref = [%s"DocumentRef-"(idstring)":"]%s"AdditionRef-"(idstring)
 
 simple-expression = license-id / license-id"+" / license-ref
 
@@ -25,11 +25,11 @@ addition-expression = license-exception-id / addition-ref
 
 compound-expression = (simple-expression /
 
-  simple-expression ( "WITH" / "with" ) addition-expression /
+  simple-expression ( %s"WITH" / %s"with" ) addition-expression /
 
-  compound-expression ( "AND" / "and" ) compound-expression /
+  compound-expression ( %s"AND" / %s"and" ) compound-expression /
 
-  compound-expression ( "OR" / "or" ) compound-expression /
+  compound-expression ( %s"OR" / %s"or" ) compound-expression /
 
   "(" compound-expression ")" )
 
@@ -74,8 +74,7 @@ LicenseRef-MIT-Style-1
 DocumentRef-spdx-tool-1.2:LicenseRef-MIT-Style-2
 ```
 
-The current set of valid license identifiers can be found in [spdx.org/licenses](https:/
-/spdx.org/licenses).
+The current set of valid license identifiers can be found in [spdx.org/licenses](https://spdx.org/licenses).
 
 ## D.4 Composite license expressions <a name="D.4"></a>
 


### PR DESCRIPTION
The intention of this PR is to allow more contributors to test the spec and spot issues early.
It will also allow more people to understand the build process which involved components across several spdx repos.

- Add info on repo structure (which directory is for what purpose)
- Update build instructions
  - Add a build flow diagram and instruction on using spdx-3-model, spdx-spec, and spec-parser together
  - Add info about MkDocs configuration
  - Add info about mike and GitHub workflow
- Update info about development branch and repo
  - Was pointing to https://github.com/spdx/spdx-spec/tree/master/chapters which is no longer exist

This is a rework of #946

Note: Once we are set on internationalization/localization, this will need to be updated again.