### PR TITLE
Remove RC versions from version selector

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,1 +1,20 @@
-[{"version": "v3.0", "title": "v3.0", "aliases": ["v3-draft"]}, {"version": "v3.0-RC2", "title": "v3.0-RC2", "aliases": []}, {"version": "v2.3", "title": "v2.3", "aliases": ["latest"]}, {"version": "v2.3-RC1", "title": "v2.3-RC1", "aliases": []}, {"version": "v2.2.2", "title": "v2.2.2", "aliases": []}]
+[
+    {
+        "version": "v3.0",
+        "title": "v3.0",
+        "aliases": [
+            "latest",
+            "v3-draft"
+        ]
+    },
+    {
+        "version": "v2.3",
+        "title": "v2.3",
+        "aliases": []
+    },
+    {
+        "version": "v2.2.2",
+        "title": "v2.2.2",
+        "aliases": []
+    }
+]

--- a/versions.json
+++ b/versions.json
@@ -3,14 +3,15 @@
         "version": "v3.0",
         "title": "v3.0",
         "aliases": [
-            "latest",
             "v3-draft"
         ]
     },
     {
         "version": "v2.3",
         "title": "v2.3",
-        "aliases": []
+        "aliases": [
+            "latest"
+        ]
     },
     {
         "version": "v2.2.2",


### PR DESCRIPTION
- Remove `v3.0-RC2` and `v2.3-RC1` from version selector  on the website
- `v3-draft` alias still point to `v3.0`, no change

This will close #952

Note that this will only remove RC versions from the version selector but the actual directories that contain HTML files of these drafts/RCs are still kept intact. So if people access directly to these URLs they can still see the content of that draft version:

- https://spdx.github.io/spdx-spec/v2-draft/ (has a content that shows "v2.2.2". This is a non-mike configuration, notice that it doesn't have the version selector)
- https://spdx.github.io/spdx-spec/v2.3-RC1/
- https://spdx.github.io/spdx-spec/v3.0-RC2/

