### PR TITLE
[2.3] Use H2 for headings in Annex I (diff from prev editions) to fix nav bar issue

### DIFF
--- a/chapters/diffs-from-previous-editions.md
+++ b/chapters/diffs-from-previous-editions.md
@@ -1,6 +1,6 @@
 # Annex I Differences from previous editions (Informative)
 
-# I.1 Differences between V2.3 and V2.2.2  <a name="I.1"></a>
+## I.1 Differences between V2.3 and V2.2.2  <a name="I.1"></a>
 
 V2.3 has added new fields to improve the ability to capture security related information and to improve interoperabiility with other SBOM formats.  
 
@@ -24,9 +24,7 @@ Key changes include:
 
 * Added Annex K ( How To Use SPDX in Different Scenarios ) to illustrate linking to external security information, and illustrate how the NTIA SBOM mandatory minimum elements map to SPDX fields.
 
-
-
-# I.2 Differences between V2.2.2 and V2.2.1 <a name="I.2"></a>
+## I.2 Differences between V2.2.2 and V2.2.1 <a name="I.2"></a>
 
 V2.2.2 fixed formatting, grammatical and spelling issues found since ISO/IEC 5962:2021 SPDX v2.2.1 was published.   No new fields were added.
 
@@ -53,7 +51,7 @@ Creative Commons Attribution License 3.0 Unported | Annex G    | [omitted] | Ann
 
 *_This edition featured inconsistent lettering._
 
-# I.3 Differences between V2.2.1 and V2.2 <a name="I.3"></a>
+## I.3 Differences between V2.2.1 and V2.2 <a name="I.3"></a>
 
 There were no technical differences; V2.2.1 is V2.2 reformatted for submission to ISO via the PAS process. As a result, new clauses were added causing the previous clause-numbering sequence to change. Also, Annexes went from having Roman numbers to Latin letters. Here is the translation between numbering in V2.2.1 and the version that came before it:
 
@@ -85,10 +83,9 @@ SPDX Lite                                         | Appendix VIII | Annex H/G* |
 SPDX File Tags                                    | Appendix IX   | Annex I/H* | Annex H
 Differences from Earlier SPDX Versions            | N/A           | Annex J/I* | Annex I
 
-
 *_This edition featured inconsistent lettering._
 
-# I.4 Differences from V2.2 and V2.1 <a name="I.4"></a>
+## I.4 Differences from V2.2 and V2.1 <a name="I.4"></a>
 
 * JSON, YAML, and a development version of XML have been added as supported file formats.
 
@@ -100,7 +97,7 @@ Differences from Earlier SPDX Versions            | N/A           | Annex J/I* |
 
 * Miscellaneous bug fixes and non-breaking improvements as reported on the mailing list and reported as issues on the spdx-spec GitHub repository.
 
-# I.5 Differences between V2.1 and V2.0 <a name="I.5"></a>
+## I.5 Differences between V2.1 and V2.0 <a name="I.5"></a>
 
 * Snippets have been added to allow a portion of a file to be identified as having different properties from the file it resides in.  The use of snippets is completely optional and it is not mandatory for snippets to be identified. See section 5 Snippet Information for further details on the fields available to describe snippets.
 
@@ -115,7 +112,7 @@ more information.
 
 * Miscellaneous bug fixes.
 
-# I.6 Differences between V2.0 and V1.2 <a name="I.6"></a>
+## I.6 Differences between V2.0 and V1.2 <a name="I.6"></a>
 
 * Abstraction has been applied to the underlying model with the inclusion of SPDX elements. With SPDX 2.0, the concept of an SPDX element is introduced (see Appendix III). This includes SPDX documents, SPDX files, and SPDX packages, each of which gets associated with an SPDX identifier which is denoted by “SPDXRef-”.
 


### PR DESCRIPTION
To allow readthedocs to generate proper heading items in the navigation bar.

Currently when a user clicked on the page https://spdx.github.io/spdx-spec/v2.3/diffs-from-previous-editions/ ,
the nav bar on the left will not expanding the subheadings. This is behavior is different from other chapters/annexes.

The reason is, in Markdown, H1 is reserved for the title.
mkdocs's readthedocs theme will read only H2 headings to generate expandable items in the nav bar.

This fix add one level to all headings in the doc (H1 -> H2), except the title.

There is no change in the content.

See screenshot of a similar fix (for 3.0) in #988