### PR TITLE
Update license expression syntax references to license list

### DIFF
--- a/docs/annexes/SPDX-license-expressions.md
+++ b/docs/annexes/SPDX-license-expressions.md
@@ -13,7 +13,7 @@ idstring = 1*(ALPHA / DIGIT / "-" / "." )
 
 license-id = <short form license identifier from SPDX License List>
 
-license-exception-id = <short form license exception identifier from SPDX License Exceptions list (spdx.org/licenses/exception-index.html)>
+license-exception-id = <short form license exception identifier from SPDX License List>
 
 license-ref = ["DocumentRef-"(idstring)":"]"LicenseRef-"(idstring)
 

--- a/docs/annexes/SPDX-license-expressions.md
+++ b/docs/annexes/SPDX-license-expressions.md
@@ -11,7 +11,7 @@ The exact syntax of license expressions is described below in [ABNF](http://tool
 ```text
 idstring = 1*(ALPHA / DIGIT / "-" / "." )
 
-license-id = <short form license identifier from SPDX License list (spdx.org/licenses)>
+license-id = <short form license identifier from SPDX License List>
 
 license-exception-id = <short form license exception identifier from SPDX License Exceptions list (spdx.org/licenses/exception-index.html)>
 

--- a/docs/annexes/SPDX-license-expressions.md
+++ b/docs/annexes/SPDX-license-expressions.md
@@ -11,9 +11,9 @@ The exact syntax of license expressions is described below in [ABNF](http://tool
 ```text
 idstring = 1*(ALPHA / DIGIT / "-" / "." )
 
-license-id = <short form license identifier in Annex A.1>
+license-id = <short form license identifier from SPDX License list (spdx.org/licenses)>
 
-license-exception-id = <short form license exception identifier in Annex A.2>
+license-exception-id = <short form license exception identifier from SPDX License Exceptions list (spdx.org/licenses/exception-index.html)>
 
 license-ref = ["DocumentRef-"(idstring)":"]"LicenseRef-"(idstring)
 


### PR DESCRIPTION
In SPDX v3 `license-id` and `license-exception-id` can no longer be defined by referencing Annex A (which previously included the license list).
Instead reference the SPDX License list and License Exceptions list directly.