### PR TITLE
Add <del> (~~strikethrough~~) support

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,7 +12,8 @@ extra_css:
 - css/style.css
 markdown_extensions:
 - codehilite:
-   guess_lang: false
+    guess_lang: false
+- pymdownx.tilde
 nav:
 - 'Copyright': index.md
 - 'Introduction': introduction.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mkdocs-pdf-export-plugin==0.5.10
 mike==1.1.2
 shacl2code==0.0.10
 PyYAML>=6.0.1
+pymdown-extensions==10.8.1


### PR DESCRIPTION
Python Markdown that mkdocs use doesn't support the rendering of `~~text~~` to ~~text~~ (strikethrough). Need to call an extension to support that.

- Adding [pymdownx.tilde](https://facelessuser.github.io/pymdown-extensions/extensions/tilde/) extension to mkdocs.yml config
- Adding [pymdown-extensions](https://pypi.org/project/pymdown-extensions/) module to requirements.txt dependencies

This will fix #929

Before fix:
![Screenshot 2024-07-23 at 00 54 34](https://github.com/user-attachments/assets/51a9ffd7-8d6f-4aa9-9d69-f74b27dec409)

After fix:
![Screenshot 2024-07-23 at 00 53 36](https://github.com/user-attachments/assets/b69aaa79-6602-4737-8b0c-7b994ddaa798)
