### PR TITLE
Add serialization info + NamespaceMap info

### DIFF
--- a/docs/serializations.md
+++ b/docs/serializations.md
@@ -9,6 +9,7 @@ The data may be serialized in a variety of formats for storage and transmission.
 ## 4.2 RDF Serialization
 
 Since the data model is based on RDF, any SPDX data can be serialized in any of the multiple RDF serialization formats, including but not limited to:
+
 - JSON-LD format as defined in [JSON-LD 1.1](https://www.w3.org/TR/json-ld11/);
 - Turtle (Terse RDF Triple Language) format as defined in [RDF 1.1 Turtle](https://www.w3.org/TR/turtle/);
 - N-Triples format as defined in [RDF 1.1 N-Triples](https://www.w3.org/TR/n-triples/); and
@@ -34,3 +35,27 @@ Canonical serialization is in JSON format, as defined in RFC 8259 (IETF STD 90),
 - strings: UTF-8 representation without specific canonicalisation. A string begins and ends with quotation marks (%x22). Any Unicode characters may be placed within the quotation marks, except for the two characters that MUST be escaped by a reverse solidus: quotation mark, reverse solidus, and the control characters (U+0000 through U+001F).
 - arrays: An array structure is represented as square brackets surrounding zero or more items. Items are separated by commas.
 - objects: An object structure is represented as a pair of curly brackets surrounding zero or more name/value pairs (or members). A name is a string containing only ASCII characters (0x21-0x7F). The names within an object must be unique. A single colon comes after each name, separating the name from the value. A single comma separates a value from a following name. The name/value pairs are ordered by name.
+
+## 4.4 Serialization information
+
+A collection of elements may be serialized in multiple formats.
+
+An SpdxDocument element represents the common properties of a collection of
+elements across all serialization data formats within the model.
+
+The actual serialized bytes is represented by an Artifact element within the
+model.
+
+A Relationship of type `serializedInArtifact` links an SpdxDocument to one or
+more serialized forms of itself.
+
+When serializing an SpdxDocument, properties of the logical element that can be
+represented using native mechanisms of the specific serialization format
+(e.g., @context prefixes in JSON-LD in place of namespaceMap) shall use these
+mechanisms. Remaining properties shall be serialized within the “XCollection”
+element.
+
+A serialization shall contain at most one SpdxDocument.
+
+A given instance of serialization shall define at most one SpdxDocument
+element.


### PR DESCRIPTION
- This is a step to fix https://github.com/spdx/spdx-3-model/pull/796#issuecomment-2258760629
  - Once this PR is merged and v3.0.1 is published: we can use this URL: https://spdx.github.io/spdx-spec/v3.0.1/serializations/ as a ref in NamespaceMap model description (instead of using a repo URL, which is not allowed in ISO doc)
- Add a new subsection "4.4 Serialization information" to the chapter ["Model and serializations"](https://spdx.github.io/spdx-spec/v3.0.1-draft/serializations/)
  - Use serialization and NamespaceMap content from https://github.com/spdx/spdx-3-model/blob/main/serialization/README.md and revise it with standard terms like "may", "shall".
- Still need to be done
  - Confirm if `serializedInArtifact` a correct relationship type for this paragraph:
    > A Relationship of type serializedInArtifact can be used to relate an SpdxDocument to one more serialized for of the SpdxDocument.
  - Figure out what is "XCollection" in:
    > When serializing the physical SpdxDocument, any properties of the logical element which can be represented using native mechanisms in the specific serialization format (e.g. @context prefixes in JSON-LD in place of the namespaceMap) should use these mechanisms and the remaining properties should be serialized within the “XCollection” element itself.
  - See https://github.com/spdx/spdx-3-model/pull/802#issuecomment-2260241027 