### PR TITLE
Fix strikethrough and typo in relationshipType translation table (Annex A)

### DIFF
--- a/docs/annexes/diffs-from-previous-editions.md
+++ b/docs/annexes/diffs-from-previous-editions.md
@@ -225,7 +225,7 @@ Relationship migration is being worked out in the relationships spreadsheet.  On
 | DEPENDENCY_OF | [removed] | | |
 | DEPENDS_ON | dependsOn | | various LifecycleScopeType |
 | DESCENDANT_OF | decendentOf | | |
-| *DESCRIBED_BY* | [removed] | | |
+| DESCRIBED_BY | [removed] | | |
 | DESCRIBES | describes | | |
 | DEV_DEPENDENCY_OF | dependsOn | | development |
 | DEV_TOOL_OF | usesTool | | development |
@@ -245,8 +245,8 @@ Relationship migration is being worked out in the relationships spreadsheet.  On
 | OPTIONAL_DEPENDENCY_OF | hasOptionalDependency | | lifecycle scope |
 | OTHER | other | | |
 | PACKAGE_OF | packagedBy | | |
-| *PATCH_FOR* | [removed] | | |
-| *PREREQUISITE_FOR* | [removed] | | |
+| PATCH_FOR | [removed] | | |
+| PREREQUISITE_FOR | [removed] | | |
 | PROVIDED_DEPENDENCY_OF | hasProvidedDependency | | lifecycle scope |
 | REQUIREMENT_DESCRIPTION_FOR | hasRequirement | | lifecycle scope |
 | RUNTIME_DEPENDENCY_OF | dependsOn | | runtime |

--- a/docs/annexes/diffs-from-previous-editions.md
+++ b/docs/annexes/diffs-from-previous-editions.md
@@ -222,7 +222,7 @@ Relationship migration is being worked out in the relationships spreadsheet.  On
 | COPY_OF | copiedTo | | |
 | DATA_FILE_OF | hasDataFile | | |
 | DEPENDENCY_MANIFEST_OF | hasDependencyManifest | | |
-| *DEPENDENCY_OF* | [removed] | | |
+| DEPENDENCY_OF | [removed] | | |
 | DEPENDS_ON | dependsOn | | various LifecycleScopeType |
 | DESCENDANT_OF | decendentOf | | |
 | *DESCRIBED_BY* | [removed] | | |

--- a/docs/annexes/diffs-from-previous-editions.md
+++ b/docs/annexes/diffs-from-previous-editions.md
@@ -222,10 +222,10 @@ Relationship migration is being worked out in the relationships spreadsheet.  On
 | COPY_OF | copiedTo | | |
 | DATA_FILE_OF | hasDataFile | | |
 | DEPENDENCY_MANIFEST_OF | hasDependencyManifest | | |
-| ~~DEPENDENCY_OF~~ | [removed] | | |
+| *DEPENDENCY_OF* | [removed] | | |
 | DEPENDS_ON | dependsOn | | various LifecycleScopeType |
 | DESCENDANT_OF | decendentOf | | |
-| ~~DESCRIBED_BY~~ | [removed] | | |
+| *DESCRIBED_BY* | [removed] | | |
 | DESCRIBES | describes | | |
 | DEV_DEPENDENCY_OF | dependsOn | | development |
 | DEV_TOOL_OF | usesTool | | development |
@@ -239,14 +239,14 @@ Relationship migration is being worked out in the relationships spreadsheet.  On
 | FILE_MODIFIED | modifiedBy | | |
 | GENERATED_FROM | generates | Y | |
 | GENERATES | generates | | |
-| HAS_PREREQUISITE | hasPrequisite | | lifecycle scope |
+| HAS_PREREQUISITE | hasPrerequisite | | lifecycle scope |
 | METAFILE_OF | hasMetadata | | |
 | OPTIONAL_COMPONENT_OF | hasOptionalComponent | | |
 | OPTIONAL_DEPENDENCY_OF | hasOptionalDependency | | lifecycle scope |
 | OTHER | other | | |
 | PACKAGE_OF | packagedBy | | |
-| ~~PATCH_FOR~~ | [removed] | | |
-| ~~PREREQUISITE_FOR~~ | [removed] | | |
+| *PATCH_FOR* | [removed] | | |
+| *PREREQUISITE_FOR* | [removed] | | |
 | PROVIDED_DEPENDENCY_OF | hasProvidedDependency | | lifecycle scope |
 | REQUIREMENT_DESCRIPTION_FOR | hasRequirement | | lifecycle scope |
 | RUNTIME_DEPENDENCY_OF | dependsOn | | runtime |


### PR DESCRIPTION
- Remove strikethrough formatting
- Fix typo: hasPrequisite -> hasPrerequisite

### Questions

1. Does this table complete?
    - A sentence before the table said:
      > Relationship migration is being worked out in the relationships spreadsheet. Once completed, the following table will reflect the translation for relationship types from SPDX 2.3 to SPDX 3.0:
1. What does "lifecycle scope" in the last column mean?
    - Other values in this column are types in LifecycleScopeType (for example, "build", "build, runtime", "test") or a string stating "various LifecycleScopeType".
    - Should this "lifecycle scope" string be replaced by "various LifecycleScopeType"?
1. The 3rd column ("Swap to and from?") probably not complete?
    - For example, 2.3 `DATA_FILE_OF` and 3.0 `hasDataFile` they are swapped in direction. But there's no "Y" marked in their column.
    - A (is a) `DATA_FILE_OF` B
    - B `hasDataFile` A
