### PR TITLE
[2.3.1] bugfix: remove unnecessary field 'name' in snippets

### DIFF
--- a/schemas/spdx-schema.json
+++ b/schemas/spdx-schema.json
@@ -713,7 +713,7 @@
             "type" : "string"
           }
         },
-        "required" : [ "SPDXID", "name", "ranges", "snippetFromFile" ],
+        "required" : [ "SPDXID", "ranges", "snippetFromFile" ],
         "additionalProperties" : false
       }
     },


### PR DESCRIPTION
  remove unnecessary field 'name' in snippets according to official spdx website.  By the link below, 'name' is not required in the specification [link](https://spdx.github.io/spdx-spec/v2.2.2/snippet-information/#910-snippet-name-field) however it is required in json schema.