### PR TITLE
[2.2.2] bugfix: remove 'name' in snippets' required field and add 'documentNamespace' to doc's required field

### DIFF
--- a/schemas/spdx-schema.json
+++ b/schemas/spdx-schema.json
@@ -685,7 +685,7 @@
             "type" : "string"
           }
         },
-        "required" : [ "SPDXID", "copyrightText", "licenseConcluded", "name", "ranges", "snippetFromFile" ],
+        "required" : [ "SPDXID", "copyrightText", "licenseConcluded", "ranges", "snippetFromFile" ],
         "additionalProperties" : false
       }
     },
@@ -717,6 +717,6 @@
       }
     }
   },
-  "required" : [ "SPDXID", "creationInfo", "dataLicense", "name", "spdxVersion" ],
+  "required" : [ "SPDXID", "creationInfo", "dataLicense", "name", "spdxVersion", "documentNamespace" ],
   "additionalProperties" : false
 }


### PR DESCRIPTION
 remove 'name' in snippets' required field and add 'documentNamespace' to doc's required field according to official spdx website. By the link below,  'documentNamespace' is required in the specification [link](https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#65-spdx-document-namespace-field) however it not not required in json schema. And 'name' is not required in the specification [link](https://spdx.github.io/spdx-spec/v2.3/snippet-information/#910-snippet-name-field) however it is required in json schema.