### PR TITLE
[2.3.1] Fix/add missing link anchors in License matching guidelines

### DIFF
--- a/chapters/license-matching-guidelines-and-templates.md
+++ b/chapters/license-matching-guidelines-and-templates.md
@@ -73,11 +73,11 @@ XML files do not require specific markup to implement this guideline.
 
 ## B.5 Capitalization <a name="B.5"></a>
 
-### B.5.1  Purpose <a name="B.5.1"></a>
+### B.5.1 Purpose <a name="B.5.1"></a>
 
 To avoid the possibility of a non-match due to lowercase or uppercase letters in otherwise the same words.
 
-### B.5.2  Guideline <a name="B.5.2"></a>
+### B.5.2 Guideline <a name="B.5.2"></a>
 
 All uppercase and lowercase letters should be treated as lowercase letters. 
 
@@ -85,31 +85,31 @@ XML files do not require specific markup to implement this guideline.
 
 ## B.6 Punctuation <a name="B.6"></a>
 
-### B.6.1  Purpose <a name="B.6.1"></a>
+### B.6.1 Purpose <a name="B.6.1"></a>
 
 Because punctuation can change the meaning of a sentence, punctuation needs to be included in the matching process. 
 
 XML files do not require specific markup to implement this guideline. 
 
-### B.6.2  Guideline: punctuation <a name="B.6.2"></a>
+### B.6.2 Guideline: punctuation <a name="B.6.2"></a>
 
 Punctuation should be matched, unless otherwise stated in these guidelines.
 
-### B.6.3  Guideline: hyphens, dashes <a name="B.6.3"></a>
+### B.6.3 Guideline: hyphens, dashes <a name="B.6.3"></a>
 
 Any hyphen, dash, en dash, em dash, or other variation should be considered equivalent.
 
-### B.6.4 Guideline: Quotes
+### B.6.4 Guideline: Quotes <a name="B.6.4"></a>
 
 Any variation of quotations (single, double, curly, etc.) should be considered equivalent.
 
 ## B.7 Code Comment Indicators <a name="B.7"></a>
 
-### B.7.1  Purpose <a name="B.7.1"></a>
+### B.7.1 Purpose <a name="B.7.1"></a>
 
 To avoid the possibility of a non-match due to the existence or absence of code comment indicators placed within the license text, e.g. at the start of each line of text.
 
-### B.7.2  Guideline <a name="B.7.2"></a>
+### B.7.2 Guideline <a name="B.7.2"></a>
 
 Any kind of code comment indicator or prefix which occurs at the beginning of each line in a matchable section should be ignored for matching purposes. 
 
@@ -117,11 +117,11 @@ XML files do not require specific markup to implement this guideline.
 
 ## B.8 Bullets and numbering <a name="B.8"></a>
 
-### B.8.1  Purpose <a name="B.8.1"></a>
+### B.8.1 Purpose <a name="B.8.1"></a>
 
 To avoid the possibility of a non-match due to the otherwise same license using bullets instead of numbers, number instead of letter, or no bullets instead of bullet, etc., for a list of clauses.
 
-### B.8.2  Guideline <a name="B.8.2"></a>
+### B.8.2 Guideline <a name="B.8.2"></a>
 
 Where a line starts with a bullet, number, letter, or some form of a list item (determined where list item is followed by a space, then the text of the sentence), ignore the list item for matching purposes. 
 
@@ -131,11 +131,11 @@ For example: `<bullet>1.0</bullet>`
 
 ## B.9 Varietal word spelling <a name="B.9"></a>
 
-### B.9.1  Purpose <a name="B.9.1"></a>
+### B.9.1 Purpose <a name="B.9.1"></a>
 
 English uses different spelling for some words. By identifying the spelling variations for words found or likely to be found in licenses, we avoid the possibility of a non-match due to the same word being spelled differently. This list is not meant to be an exhaustive list of all spelling variations, but meant to capture the words most likely to be found in open source software licenses.
 
-### B.9.2  Guideline <a name="B.9.2"></a>
+### B.9.2 Guideline <a name="B.9.2"></a>
 
 The words in each line of the text file available at <https://spdx.org/licenses/equivalentwords.txt> are considered equivalent and interchangeable. 
 
@@ -211,11 +211,11 @@ XML files do not require specific markup to implement this guideline.
 
 The license XML can be accessed in the license-list-data repository under the license-list-XML directory.  Although the license list XML files can also be found in the [license-list-XML](https://github.com/spdx/license-list-XML) repo, users are encouraged to use the published versions in the [license-list-data](https://github.com/spdx/license-list-data) repository.  The license-list-data repository is tagged by release.  Only tagged released versions of the license list are considered stable.
 
-### B.15.2 License List XML format
+### B.15.2 License List XML format <a name="B.15.2"></a>
   
-A full schema for the License List XML can be found at https://github.com/spdx/license-list-XML/blob/master/schema/ListedLicense.xsd.
-  
-###  B.15.3 Legacy Text Template format <a name="B.15.2"></a>
+A full schema for the License List XML can be found at <https://github.com/spdx/license-list-XML/blob/master/schema/ListedLicense.xsd>.
+
+### B.15.3 Legacy Text Template format <a name="B.15.3"></a>
 
 Prior to the XML format, a text template was used to express variable and optional text in licenses.  This text template is still supported, however, users are encouraged to use the more expressive XML format.
   
@@ -226,16 +226,16 @@ A rule is a variable section of a license wrapped between double angle brackets 
 Rule fields:
 
 * type: indicates whether the text is replaceable or omittable as per Matching Guideline #2 (“Substantive Text”).
-    * Indicated by `<<var; . . . >>` or...
-    * Indicated by `<<beginOptional; . . .>>` and `<<endOptional>>` respectively.
-    * This field is the first field and is required.
+  * Indicated by `<<var; . . . >>` or...
+  * Indicated by `<<beginOptional; . . .>>` and `<<endOptional>>` respectively.
+  * This field is the first field and is required.
 * name: name of the field in the template.
-    * This field is unique within each license template.
-    * This field is required.
+  * This field is unique within each license template.
+  * This field is required.
 * original: the original text of the rule.
-    * This field is required for a rule type: `<<var; . . . >>`
+  * This field is required for a rule type: `<<var; . . . >>`
 * match: a POSIX extended regular expression (ERE).
-    * This field is required for a rule type: `<<var; . . . >>`
+  * This field is required for a rule type: `<<var; . . . >>`
 
 The [POSIX ERE]( http://pubs.opengroup.org/onlinepubs/9699919799/) in the match field has the following restrictions and extensions:
 


### PR DESCRIPTION
In Annex B License matching guidelines and templates

- Fix wrong anchor: B.15.2 -> B.15.2
- Add missing anchors: B.6.4, B.15.2
