### PR TITLE
[2.3.1] Fix $schema identifier in JSON Schema

### DIFF
--- a/schemas/spdx-schema.json
+++ b/schemas/spdx-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema" : "https://json-schema.org/draft/2019-09/schema#",
+  "$schema" : "https://json-schema.org/draft/2019-09/schema",
   "$id" : "http://spdx.org/rdf/terms/2.3",
   "title" : "SPDX 2.3",
   "type" : "object",


### PR DESCRIPTION
While pre-2019 JSON Schema drafts had a trailing `#`, the 2019-09 draft does not:

> The identifier for Draft 2019-09 is `https://json-schema.org/draft/2019-09/schema`.
>
> https://json-schema.org/understanding-json-schema/reference/schema

Many validators locally store rules for the different schemas and match them by simple string comparison rather than fetching the remote schema, so the trailing `#` was causing issues here.

This issue is specific to the 2.3.1 branch - the identifier in 2.3.0 is correct.