### PR TITLE
Fix diagram filenames, make them display properly (rework)

### DIFF
--- a/docs/annexes/RDF-object-model-and-identifier-syntax.md
+++ b/docs/annexes/RDF-object-model-and-identifier-syntax.md
@@ -1,7 +1,5 @@
 # Annex B: RDF object model and identifier syntax (Normative)
 
-TODO: update for SPDXv3
-
 ## B.1 Introduction <a name="B.1"></a>
 
 SPDX ® Vocabulary Specification
@@ -10,14 +8,33 @@ SPDX ® Vocabulary Specification
 
 Version: 3.0.1
 
-![SPDX 3.0.1 Core and Software models diagram](../images/model Core+Software.png)
+### Core and Software Profiles
 
-![SPDX 3.0.1 Dataset model diagram](../images/model Dataset.png)
+![SPDX 3.0.1 Core and Software Profiles diagram][fig_Core_Software]
 
-![SPDX 3.0.1 AI model diagram](../images/model AI.png)
+### AI Profile
 
-![SPDX 3.0.1 Build model diagram](../images/model Build.png)
+![SPDX 3.0.1 AI Profile diagram][fig_AI]
 
-![SPDX 3.0.1 Licensing model diagram](../images/model Licensing.png)
+### Build Profile
 
-![SPDX 3.0.1 Security model diagram](../images/model Security.png)
+![SPDX 3.0.1 Build Profile diagram][fig_Build]
+
+### Dataset Profile
+
+![SPDX 3.0.1 Dataset Profile diagram][fig_Dataset]
+
+### Licensing Profile
+
+![SPDX 3.0.1 Licensing Profile diagram][fig_Licensing]
+
+### Security Profile
+
+![SPDX 3.0.1 Security Profile diagram][fig_Security]
+
+[fig_Core_Software]: ../images/model%20Core+Software.png "SPDX 3.0.1 Core and Software Profiles diagram"
+[fig_Dataset]: ../images/model%20Dataset.png "SPDX 3.0.1 Dataset Profile diagram"
+[fig_AI]: ../images/model%20AI.png "SPDX 3.0.1 AI Profile diagram"
+[fig_Build]: ../images/model%20Build.png "SPDX 3.0.1 Build Profile diagram"
+[fig_Licensing]: ../images/model%20Licensing.png "SPDX 3.0.1 Licensing Profile diagram"
+[fig_Security]: ../images/model%20Security.png "SPDX 3.0.1 Security Profile diagram"


### PR DESCRIPTION
- Currently diagram filenames have a space in the name. Have to replace a space with `%20` when make a link.
- If possible, it may be better to rename the image files. But for now, use them as they are.
- Also sort the diagrams by name
- This will fix #959

This is a rework of #989 (with approvals there)