### PR TITLE
Update SPDX schema URL in Conformance chapter

### DIFF
--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -263,7 +263,7 @@ following constraints:
     see:
     [ECMA-404](https://ecma-international.org/publications-and-standards/standards/ecma-404/)
     - The JSON Schema for SPDX can be found in the
-      [SPDX specification GitHub pages](https://spdx.github.io/spdx-spec/v3.0.1/model/schema.json)
+      [SPDX specification GitHub pages](https://spdx.github.io/spdx-spec/v3.0.1/rdf/schema.json)
   - **Resource Description Framework** (RDF, also referred to as RDF/XML)
     see:
     [RDF 1.1 XML Syntax](https://www.w3.org/TR/rdf-syntax-grammar/)

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -263,7 +263,7 @@ following constraints:
     see:
     [ECMA-404](https://ecma-international.org/publications-and-standards/standards/ecma-404/)
     - The JSON Schema for SPDX can be found in the
-      [SPDX specification Git repository schemas directory](https://github.com/spdx/spdx-spec/blob/master/schemas/spdx-schema.json)
+      [SPDX specification Git repository schemas directory](https://spdx.github.io/spdx-spec/v3.0/model/schema.json)
   - **Resource Description Framework** (RDF, also referred to as RDF/XML)
     see:
     [RDF 1.1 XML Syntax](https://www.w3.org/TR/rdf-syntax-grammar/)

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -263,7 +263,7 @@ following constraints:
     see:
     [ECMA-404](https://ecma-international.org/publications-and-standards/standards/ecma-404/)
     - The JSON Schema for SPDX can be found in the
-      [SPDX specification Git repository schemas directory](https://spdx.github.io/spdx-spec/v3.0/model/schema.json)
+      [SPDX specification GitHub pages](https://spdx.github.io/spdx-spec/v3.0.1/model/schema.json)
   - **Resource Description Framework** (RDF, also referred to as RDF/XML)
     see:
     [RDF 1.1 XML Syntax](https://www.w3.org/TR/rdf-syntax-grammar/)


### PR DESCRIPTION
To fix #1042, also update to v3.0.1 URL

--> <s>https://spdx.github.io/spdx-spec/v3.0.1/model/schema.json</s> https://spdx.github.io/spdx-spec/v3.0.1/rdf/schema.json

The text label of the URL is taken from @goneall's https://github.com/spdx/spdx-spec/commit/8db91b24653a0275483649ba8ac706179d018198

Noted that the location is no longer in model/ as the spec-parser is now put the RDF thing in rdf/
