### PR TITLE
Update SPDX License List link to v3.25.0

### DIFF
--- a/docs/annexes/license-matching-guidelines-and-templates.md
+++ b/docs/annexes/license-matching-guidelines-and-templates.md
@@ -14,7 +14,7 @@ To ensure consistent results by different SPDX document creators when matching l
 
 ### Guideline: official license headers <a name="C.2.2"></a>
 
-The matching guidelines apply to license and exception text, as well as official license headers. Official license headers are defined by the SPDX License List as specific text specified within the license itself to be put in the header of files. (see [explanation of SPDX License List fields](https://github.com/spdx/license-list-XML/blob/v3.24.0/DOCS/license-fields.md) for more info).
+The matching guidelines apply to license and exception text, as well as official license headers. Official license headers are defined by the SPDX License List as specific text specified within the license itself to be put in the header of files. (see [explanation of SPDX License List fields](https://github.com/spdx/license-list-XML/blob/v3.25.0/DOCS/license-fields.md) for more info).
 
 The following XML tag is used to implement this guideline: `<standardLicenseHeader>`
 
@@ -241,7 +241,7 @@ Only tagged released versions of the license list are considered stable.
 ### License List XML format <a name="C.15.2"></a>
 
 A full schema for the License List XML can be found at
-[SPDX License List XML Schema](https://github.com/spdx/license-list-XML/blob/v3.24.0/schema/ListedLicense.xsd).
+[SPDX License List XML Schema](https://github.com/spdx/license-list-XML/blob/v3.25.0/schema/ListedLicense.xsd).
 
 ### Legacy Text Template format <a name="C.15.3"></a>
 

--- a/docs/annexes/license-matching-guidelines-and-templates.md
+++ b/docs/annexes/license-matching-guidelines-and-templates.md
@@ -14,7 +14,9 @@ To ensure consistent results by different SPDX document creators when matching l
 
 ### Guideline: official license headers <a name="C.2.2"></a>
 
-The matching guidelines apply to license and exception text, as well as official license headers. Official license headers are defined by the SPDX License List as specific text specified within the license itself to be put in the header of files. (see [explanation of SPDX License List fields](https://github.com/spdx/license-list-XML/blob/v3.25.0/DOCS/license-fields.md) for more info).
+The matching guidelines apply to license and exception text, as well as official license headers.
+Official license headers are defined by the SPDX License List as specific text specified within the license itself to be put in the header of files.
+(see [explanation of SPDX License List fields](https://github.com/spdx/license-list-XML/blob/v3.25.0/DOCS/license-fields.md) for more info).
 
 The following XML tag is used to implement this guideline: `<standardLicenseHeader>`
 


### PR DESCRIPTION
Update SPDX License List link to [v3.25.0](https://github.com/spdx/license-list-XML/releases/tag/v3.25.0)

- Similar PR in spdx-3-model: https://github.com/spdx/spdx-3-model/pull/863