### PR TITLE
Remove ref to SLSA v0.2

### DIFF
--- a/docs/references.md
+++ b/docs/references.md
@@ -141,11 +141,8 @@ Internet Engineering Task Force,
 Tom Preston-Werner and SemVer contributors,
 [https://semver.org](https://semver.org).
 
-*SLSA Provenance v0.2*, The Linux Foundation,
-[https://slsa.dev/provenance/v0.2](https://slsa.dev/provenance/v0.2).
-
 SoftWare Heritage persistent IDentifiers (SWHIDs), in
-Draft International Standard 
+Draft International Standard
 *ISO/IEC DIS 18670 Information technology — SoftWare Hash IDentifier (SWHID) Specification V1.2*[https://www.iso.org/standard/89985.html](https://www.iso.org/standard/89985.html),
 also available at
 [https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html](https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html)


### PR DESCRIPTION
With the merge of https://github.com/spdx/spdx-3-model/pull/862 the SPDX 3.0.1 model is no longer made a reference to SLSA v0.2 document.

There's also no other reference to SLSA within the chapters and annexes.
