### PR TITLE
Fix typos in 3.0.1 spec

### DIFF
--- a/docs/annexes/spdx-license-expressions.md
+++ b/docs/annexes/spdx-license-expressions.md
@@ -144,7 +144,7 @@ Sometimes license texts are found with additional text, which might or might not
 
 In this case, use the binary "WITH" operator to construct a new license expression to represent the special situation. A valid `<license-expression>` is where the left operand is a `<simple-expression>` value and the right operand is a `<addition-expression>` that represents the additional text.
 
-The `<addition-expression>` can be either a `<license-exception-id>` from the SPDX License List, or a user defined addition reference in the form ["DocumentRef-"(idstring)":"]"AdditonRef-"(idstring)
+The `<addition-expression>` can be either a `<license-exception-id>` from the SPDX License List, or a user defined addition reference in the form ["DocumentRef-"(idstring)":"]"AdditionRef-"(idstring)
 
 For example, when the Bison exception is to be applied to GPL-2.0-or-later, the expression would be:
 

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -26,7 +26,7 @@ the SPDX community, it has been preserved in this specification.
 
 Profile is the term for a compliance point within the SPDX community across The
 Linux Foundation and OMG. The System Package Data Exchange (SPDX) specification
-defines the following six compliance points, defined as “Profiles”:
+defines the following nine compliance points, defined as “Profiles”:
 
 - Core and Software Profiles
 - Security Profile

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -30,7 +30,7 @@ defines the following six compliance points, defined as “Profiles”:
 
 - Core and Software Profiles
 - Security Profile
-- Licencing Profile
+- Licensing Profile
 - Dataset Profile
 - AI Profile
 - Build Profile
@@ -69,7 +69,7 @@ conform with one of the SPDX serialization formats defined SPDX serialization
 formats.
 
 Conformance to the Software Profile compliance point does not entail support
-for the Licencing, Dataset, AI, Build, Lite, or Extension profiles of the
+for the Licensing, Dataset, AI, Build, Lite, or Extension profiles of the
 SPDX.
 
 This compliance point, in combination with the Core Profile compliance point,
@@ -91,17 +91,17 @@ mechanism to express how a vulnerability may affect a specific software element
 including if a fix is available.
 
 Conformance to the Security Profile compliance point does not entail support
-for the Licencing, Dataset, AI, Build, Lite, or Extension profiles of the
+for the Licensing, Dataset, AI, Build, Lite, or Extension profiles of the
 SPDX.
 
 This compliance point facilitates interchange of the security information
 produced by tools supporting SPDX.
 
-## Licencing Profile compliance point <a name="5.6"></a>
+## Licensing Profile compliance point <a name="5.6"></a>
 
 The Licensing Profile includes capturing details relevant to software licensing
 and intellectual property information when producing or consuming SPDX content.
-Specifically, software that conforms to the SPDX specification at the Licencing
+Specifically, software that conforms to the SPDX specification at the Licensing
 profile compliance point shall be able to import and export serialized
 documents that conform with one of the SPDX serialization formats defined SPDX
 serialization formats, including the classes and fields that comprise the SPDX
@@ -113,11 +113,11 @@ and the ExpandedLicensing profiles.
 Both allow expression of the same information,
 albeit in different ways.
 
-Conformance to the Licencing Profile compliance point does not entail support
+Conformance to the Licensing Profile compliance point does not entail support
 for the Software, Security, Dataset, AI, Build, Lite, or Extension profiles of
 the SPDX.
 
-This compliance point facilitates interchange of the licencing documents
+This compliance point facilitates interchange of the licensing documents
 expressing which licenses and copyright notices are determined by persons or
 automated tooling to apply to distributions of software that are produced by
 tools supporting SPDX.
@@ -139,7 +139,7 @@ and properties of a dataset, helping users understand and analyze the data more
 effectively.
 
 Conformance to the Dataset Profile compliance point does not entail support
-for the Software, Licencing, Security, AI, Build, Lite, or Extension profiles
+for the Software, Licensing, Security, AI, Build, Lite, or Extension profiles
 of the SPDX.
 
 This compliance point facilitates interchange of the information about
@@ -162,7 +162,7 @@ information about their versions, licenses, and useful security references
 including ethical and security information.
 
 Conformance to the AI Profile compliance point does not entail support for the
-Software, Licencing, Security, Dataset, Build, Lite, or Extension profiles of
+Software, Licensing, Security, Dataset, Build, Lite, or Extension profiles of
 the SPDX.
 
 This compliance point facilitates interchange of the AI model related
@@ -182,7 +182,7 @@ procedures/instructions, environments and actors from the build process along
 with the associated evidence.
 
 Conformance to the Build Profile compliance point does not entail support for
-the Software, Licencing, Security, Dataset, AI, Lite, or Extension profiles of
+the Software, Licensing, Security, Dataset, AI, Lite, or Extension profiles of
 the SPDX.
 
 This compliance point facilitates interchange of the build information produced
@@ -201,10 +201,10 @@ formats, including creation of the SBOM, package lists with licensing and other
 related items, and their relationships.
 
 Conformance to the Lite Profile compliance point does not entail support for
-the Software, Licencing, Security, Dataset, AI, Build, or Extension profiles
+the Software, Licensing, Security, Dataset, AI, Build, or Extension profiles
 of the SPDX.
 
-This compliance point facilitates interchange of minimal licencing information
+This compliance point facilitates interchange of minimal licensing information
 when produced by tools supporting SPDX.
 
 ## Extension Profile compliance point <a name="5.11"></a>
@@ -242,7 +242,7 @@ formats, including the abstract Extension class serving as the base for all
 defined Extension subclasses.
 
 Conformance to the Extension Profile compliance point does not entail support
-for the Licencing, Security, Dataset, AI, Build, or profiles of the SPDX but
+for the Licensing, Security, Dataset, AI, Build, or profiles of the SPDX but
 is expected to be used in combination with the other profiles to extend them.
 
 This compliance point facilitates interchange of extended information that goes

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -28,7 +28,8 @@ Profile is the term for a compliance point within the SPDX community across The
 Linux Foundation and OMG. The System Package Data Exchange (SPDX) specification
 defines the following nine compliance points, defined as “Profiles”:
 
-- Core and Software Profiles
+- Core Profile
+- Software Profile
 - Security Profile
 - Licensing Profile
 - Dataset Profile

--- a/docs/symbols.md
+++ b/docs/symbols.md
@@ -35,7 +35,7 @@ List of symbols/abbreviations.
 | SHACL | Shapes Constraint Language |
 | SPDX | System Package Data Exchange (previously Software Package Data Exchange) |
 | SSVC | Stakeholder-Specific Vulnerability Categorization |
-| SWHID | SoftWare Hash IDentifiers |
+| SWHID | SoftWare Hash IDentifier |
 | URI | Uniform Resource Identifier |
 | URL | Uniform Resource Locator |
 | VEX | Vulnerability Exploitability eXchange |

--- a/docs/symbols.md
+++ b/docs/symbols.md
@@ -4,38 +4,39 @@ List of symbols/abbreviations.
 
 | | |
 |-|-|
-| 3T-SBOM | Tool-to-Tool Software Bill of Material |
+| 3T-SBOM | Tool-to-Tool Software Bill of Materials Exchange |
 | ABNF | Augmented Backus–Naur form |
-| AI | Artificial Intelligence |
+| AI | Artificial intelligence |
 | BNF | Backus–Naur form |
-| BOM | Bill of Material |
-| CISA | Cybersecurity and Information Security Agency |
-| CISQ | Center for Information and Security Quality |
-| CPE | Common Package Enumeration |
-| CVE | Common Vulnerabilies and Exposures |
+| BOM | Bill of materials |
+| CISA | Cybersecurity and Infrastructure Security Agency |
+| CISQ | Consortium for Information & Software Quality |
+| CPE | Common Platform Enumeration |
+| CVE | Common Vulnerabilities and Exposures |
 | CVSS | Common Vulnerability Scoring System |
 | EPSS | Exploit Prediction Scoring System |
 | ISO | International Organization for Standardization |
-| JSON-LD | JavaScript Object Notation for Linked Data |
+| JSON-LD | JavaScript Object Notation for Linking Data |
 | KEV | Known Exploited Vulnerabilities |
-| ML | Machine Learning |
-| NISTIR | National Institute of Standards and Technology Internal/Interagency Reports |
+| ML | Machine learning |
+| NIST | National Institute of Standards and Technology |
+| NISTIR | NIST Internal or Interagency Report |
 | NTIA | National Telecommunications and Information Administration |
 | OSI | Open Source Initiative |
 | OWL | Web Ontology Language |
 | PAS | Publicly Available Specification |
 | POSIX | Portable Operating System Interface |
 | PTF | Platform Task Force |
-| PURL | Package Uniform Resource Identifier |
+| PURL | Package URL |
 | RDF | Resource Description Framework |
-| RFC | Request For Comment |
-| SBOM | Software Bill of Material |
+| RFC | Request For Comments |
+| SBOM | Software bill of materials |
 | SHA | Secure Hash Algorithms |
 | SHACL | Shapes Constraint Language |
 | SPDX | System Package Data Exchange (previously Software Package Data Exchange) |
-| SSVC | Stakeholder- Specific Vulnerability Categorization |
-| SWHID | SoftWare Heritage persistent IDentifiers |
+| SSVC | Stakeholder-Specific Vulnerability Categorization |
+| SWHID | SoftWare Hash IDentifiers |
 | URI | Uniform Resource Identifier |
 | URL | Uniform Resource Locator |
-| VEX | Vulnerability Exploitable eXchange |
+| VEX | Vulnerability Exploitability eXchange |
 | XML | Extensible Markup Language |

--- a/docs/symbols.md
+++ b/docs/symbols.md
@@ -6,9 +6,9 @@ List of symbols/abbreviations.
 |-|-|
 | 3T-SBOM | Tool-to-Tool Software Bill of Materials Exchange |
 | ABNF | Augmented Backus–Naur form |
-| AI | Artificial intelligence |
+| AI | Artificial Intelligence |
 | BNF | Backus–Naur form |
-| BOM | Bill of materials |
+| BOM | Bill of Materials |
 | CISA | Cybersecurity and Infrastructure Security Agency |
 | CISQ | Consortium for Information & Software Quality |
 | CPE | Common Platform Enumeration |
@@ -18,7 +18,7 @@ List of symbols/abbreviations.
 | ISO | International Organization for Standardization |
 | JSON-LD | JavaScript Object Notation for Linking Data |
 | KEV | Known Exploited Vulnerabilities |
-| ML | Machine learning |
+| ML | Machine Learning |
 | NIST | National Institute of Standards and Technology |
 | NISTIR | NIST Internal or Interagency Report |
 | NTIA | National Telecommunications and Information Administration |
@@ -30,7 +30,7 @@ List of symbols/abbreviations.
 | PURL | Package URL |
 | RDF | Resource Description Framework |
 | RFC | Request For Comments |
-| SBOM | Software bill of materials |
+| SBOM | Software Bill of Materials |
 | SHA | Secure Hash Algorithms |
 | SHACL | Shapes Constraint Language |
 | SPDX | System Package Data Exchange (previously Software Package Data Exchange) |


### PR DESCRIPTION
### SPDX license expressions annex

Fix typo in SPDX license expressions annex as reported by @brokenjpl
- AdditonRef -> AdditionRef
- will fix #1086

### Conformance chapter

Fix typos in Conformance chapter as reported by @vargenau
- Profile counts: six compliance points -> nine compliance points
  - Will fix #1081
- Profile name: Licensing -> Licensing
  - Will fix #1082

### Symbols chapter

Fix typos in the Symbols chapter as reported by @vargenau + additional typos

- 3T-SBOM
  - Tool-to-Tool Software Bill of Material --> Tool-to-Tool Software Bill of Materials Exchange
  - ref: https://www.it-cisq.org/software-bill-of-materials/
- BOM / SBOM
  - Bill of Material --> Bill of materials
  - Software Bill of Material -> Software bill of materials
  - will fix #1079
- CISA
  - Cybersecurity and Information Security Agency --> Cybersecurity and Infrastructure Security Agency
  - ref: https://www.cisa.gov/
- CISQ
  - Center for Information and Security Quality --> Consortium for Information & Software Quality
  - ref: https://www.it-cisq.org/
- CPE
  - Common Package Enumeration --> Common Platform Enumeration
  - ref: https://nvd.nist.gov/products/cpe
- CVE
  - Common Vulnerabilies and Exposures --> Common Vulnerabilities and Exposures
- JSON-LD
  - JavaScript Object Notation for Linked Data --> JSON-LD | JavaScript Object Notation for Linking Data
  - ref: https://github.com/json-ld/json-ld.org, https://json-ld.org/
  - note: [JSON-LD 1.1](https://www.w3.org/TR/json-ld11/) spec has a subtitle "A JSON-based Serialization for Linked Data" but has not specified what JSON-LD stands for.
- NISTIR
  - National Institute of Standards and Technology Internal/Interagency Reports -> NIST Internal or Interagency Report
  - ref: https://csrc.nist.rip/publications/PubsNISTIRs.html
  - note: It is a singular term referring to a particular numbered report (NISTIR 8259, NISTIR 8286, etc). Plural is NISTIRs. / NIST | National Institute of Standards and Technology is also added, as NIST is mentioned elsewhere in the spec but not yet in the Symbols table.
- PURL
  - Package Uniform Resource Identifier -> Package URL
  - ref: https://spdx.github.io/spdx-spec/v3.0.1-draft/annexes/pkg-url-specification/
  - will fix #1083
- RFC
  - Request for Comment --> Request For Comments
  - ref: https://www.ietf.org/process/rfcs/
- SSVC 
  - Stakeholder- Specific Vulnerability Categorization --> Stakeholder-Specific Vulnerability Categorization (without space between '-' and 'Specific')
- SWHID
  - SoftWare Heritage persistent IDentifiers --> SoftWare Hash IDentifiers
  - ref: https://www.swhid.org/
  - will fix #1080
- VEX
  - Vulnerability Exploitable eXchange --> Vulnerability Exploitability eXchange
  - ref: https://www.ntia.gov/files/ntia/publications/vex_one-page_summary.pdf
  - note: the NTIA document uses both "Vulnerability Exploitability eXchange" and "Vulnerability-Exploitability eXchange"
