### PR TITLE
Add "Profile" to Terms and defintions

### DIFF
--- a/docs/terms-and-definitions.md
+++ b/docs/terms-and-definitions.md
@@ -7,3 +7,11 @@ at the following addresses:
   [https://www.iso.org/obp](https://www.iso.org/obp)
 - IEC Electropedia: available at
   [http://www.electropedia.org/](http://www.electropedia.org/)
+
+## Profile
+
+A scope of usage for SPDX targeting support for particular use cases and
+scenarios (e.g., software, licensing, security, etc.).
+
+A profile identifies which particular SPDX namespaces, classes, and properties
+it leverages, along with any custom constraints unique to its use.

--- a/docs/terms-and-definitions.md
+++ b/docs/terms-and-definitions.md
@@ -8,7 +8,7 @@ at the following addresses:
 - IEC Electropedia: available at
   [http://www.electropedia.org/](http://www.electropedia.org/)
 
-## Profile
+** profile **
 
 A scope of usage for SPDX targeting support for particular use cases and
 scenarios (e.g., software, licensing, security, etc.).

--- a/docs/terms-and-definitions.md
+++ b/docs/terms-and-definitions.md
@@ -8,10 +8,9 @@ at the following addresses:
 - IEC Electropedia: available at
   [http://www.electropedia.org/](http://www.electropedia.org/)
 
-** profile **
+**profile**
 
 A scope of usage for SPDX targeting support for particular use cases and
 scenarios (e.g., software, licensing, security, etc.).
-
 A profile identifies which particular SPDX namespaces, classes, and properties
 it leverages, along with any custom constraints unique to its use.


### PR DESCRIPTION
Will resolve #1088

Please suggest style/format of the definition list.

--

Currently, it put terms as a H2 heading, with definition as following paragraphs.

As a result, terms will also showing in the side navigation bar.

<img width="935" alt="Screenshot 2024-08-27 at 20 18 08" src="https://github.com/user-attachments/assets/9739fd84-406d-4ccb-9621-b6fc89f66911">


--

Alternatively, it is also possible in MkDocs to use a Markdown syntax to generate standard HTML tags for a definition list (\<dl\> for list, \<dt\> for term, and \<dd\> for description), which in general will work better with a screen reader:
- https://www.markdownguide.org/extended-syntax/#definition-lists
- https://python-markdown.github.io/extensions/definition_lists/

This code:
```text
Profile

:   A scope of usage for SPDX targeting support for particular use cases and scenarios (e.g., software, licensing, security, etc.).

    A profile identifies which particular SPDX namespaces, classes, and properties it leverages, along with any custom constraints unique to its use.

Test

:   Test test
```

will generate

<img width="915" alt="Screenshot 2024-08-27 at 20 18 56" src="https://github.com/user-attachments/assets/7d4a7024-07f6-4f03-9d56-d6a5272a81f0">

--

Which one we prefer?

With the compatibility with our current PDF generation in mind.
