### PR TITLE
[WEBSITE BROKEN] Fix 404 File Not Found for spec website homepage (root)

### DIFF
--- a/docs/front/copyright.md
+++ b/docs/front/copyright.md
@@ -1,0 +1,28 @@
+# Use of Specification - Terms, Conditions & Notices
+
+Copyright © 2010-2024, The Linux Foundation and its Contributors,
+including SPDX Model contributions from OMG and its Contributors.
+
+This work is licensed under the
+[Community Specification License 1.0](../licenses/Community-Spec-1.0.md)
+(Community-Spec-1.0).
+Pre-existing portions of this work from copyright holders who have not
+subsequently contributed under the Community-Spec-1.0 are provided under
+[Creative Commons Attribution License 3.0 Unported](../licenses/CC-BY-3.0.md)
+(CC-BY-3.0).
+Copies of these licenses are reproduced in their entirety herein.
+
+## Trademarks
+
+SPDX® is a registered trademark of The Linux Foundation.
+
+## Compliance
+
+Use of the SPDX trademarks is subject to the SPDX Trademark License,
+currently available at
+[SPDX Legal Notices page](https://spdx.dev/about/legal-notices/).
+
+Software developed under the terms of the licenses under which this
+specification is issued may claim compliance or conformance with this
+specification if and only if the software provider complies with the
+SPDX Trademark License given above.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,34 +3,6 @@
 Copyright © 2010-2024, The Linux Foundation and its Contributors,
 including SPDX Model contributions from OMG and its Contributors.
 
-## Use of Specification - Terms, Conditions & Notices
-
-This work is licensed under the
-[Community Specification License 1.0](../licenses/Community-Spec-1.0.md)
-(Community-Spec-1.0).
-Pre-existing portions of this work from copyright holders who have not
-subsequently contributed under the Community-Spec-1.0 are provided under
-[Creative Commons Attribution License 3.0 Unported](../licenses/CC-BY-3.0.md)
-(CC-BY-3.0).
-Copies of these licenses are reproduced in their entirety herein.
-
-### Trademarks
-
-SPDX® is a registered trademark of The Linux Foundation.
-
-### Compliance
-
-Use of the SPDX trademarks is subject to the SPDX Trademark License,
-currently available at
-[SPDX Legal Notices page](https://spdx.dev/about/legal-notices/).
-
-Software developed under the terms of the licenses under which this
-specification is issued may claim compliance or conformance with this
-specification if and only if the software provider complies with the
-SPDX Trademark License given above.
-
-## Thanks
-
 With thanks to
 Adam Cohn,
 Adolfo García Veytia,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,7 +32,8 @@ validation:
     absolute_links: warn
     unrecognized_links: warn
 nav:
-- 'Copyright': front/index.md
+- 'Home': index.md  # index.md, which will be publish as index.html, is needed for a website as a default home
+- 'Copyright': front/copyright.md
 - 'Introduction': front/introduction.md
 - '1. Scope': scope.md
 - '2. References': references.md


### PR DESCRIPTION
Currently https://spdx.github.io/spdx-spec/v3.0.1-draft/ returns 404 File Not Found,
as under a new directory structure there is no `index.md` in `docs/` directory (it is currently moved to `front/index.md`).

- Other pages does not effected. For example, https://bact.github.io/spdx-spec/v3.0.1/front/introduction/ still accessible 

This PR fixes it by adding the `index.md` back and rename `front/index.md` to `front/copyright.md`.

See more at https://github.com/spdx/spdx-spec/pull/1100#issuecomment-2326597294