### PR TITLE
CI update for spec-parser 2.5.0

### DIFF
--- a/.github/workflows/publish_v3.yml
+++ b/.github/workflows/publish_v3.yml
@@ -28,6 +28,7 @@ jobs:
       MKDOCS_FULL_YML: "__mkdocs-full.yml"  # MkDocs configuration combined with model list
       REDIRECT_MAP_PATH: "etc/redirect-map.csv"             # redirect map
       REDIRECT_TEMPLATE_PATH: "etc/redirect-template.html"  # redirect HTML template
+      PANDOC_DEB_URL: "https://github.com/jgm/pandoc/releases/download/3.3/pandoc-3.3-1-amd64.deb"  # pandoc Debian package
     steps:
       - name: Checkout spdx-spec
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  #v4.1.7
@@ -51,10 +52,13 @@ jobs:
         run: pip install -r spdx-spec/requirements.txt
       - name: Install pre-requisites for spec-parser
         run: pip install -r spec-parser/requirements.txt
-      - name: Build model files
+      - name: Install pandoc (required by spec-parser to generate Tex)
         run: |
-          python3 spec-parser/main.py spdx-3-model/model $PARSER_OUT_BASE_DIR
-          tree $PARSER_OUT_BASE_DIR
+          wget -q -O __pandoc.deb $PANDOC_DEB_URL
+          dpkg --no-triggers -i __pandoc.deb
+          rm __pandoc.deb
+      - name: Build model files
+        run: python3 spec-parser/main.py spdx-3-model/model $PARSER_OUT_BASE_DIR
       - name: Create directories for model (MkDocs) and RDF files
         run: |
           mkdir spdx-spec/docs/rdf
@@ -75,11 +79,7 @@ jobs:
           ls $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR
           echo "===================="
           cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-context.jsonld spdx-spec/docs/rdf/
-          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-model.dot spdx-spec/docs/rdf/
-          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-model.json-ld spdx-spec/docs/rdf/
-          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-model.pretty-xml spdx-spec/docs/rdf/
-          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-model.ttl spdx-spec/docs/rdf/
-          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-model.xml spdx-spec/docs/rdf/
+          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-model.* spdx-spec/docs/rdf/
           cp spdx-spec/docs/rdf/spdx-model.json-ld spdx-spec/docs/rdf/spdx-model.jsonld
           echo "===================="
           echo "Target (after copy): spdx-spec/docs/rdf"
@@ -87,11 +87,7 @@ jobs:
           ls spdx-spec/docs/rdf
           echo "===================="
           cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-context.jsonld spdx-spec/docs/model/
-          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-model.dot spdx-spec/docs/model/
-          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-model.json-ld spdx-spec/docs/model/
-          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-model.pretty-xml spdx-spec/docs/model/
-          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-model.ttl spdx-spec/docs/model/
-          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-model.xml spdx-spec/docs/model/
+          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-model.* spdx-spec/docs/model/
           cp spdx-spec/docs/model/spdx-model.json-ld spdx-spec/docs/model/spdx-model.jsonld
           echo "===================="
           echo "Target (after copy): spdx-spec/docs/model"
@@ -109,7 +105,7 @@ jobs:
             jsonschema \
             --output spdx-spec/docs/rdf/schema.json
           cp spdx-spec/docs/rdf/schema.json spdx-spec/docs/model/schema.json
-      - name: Copy model files and file list for MkDocs
+      - name: Copy model Markdown files and a model file list for MkDocs
         # Will be available at https://spdx.github.io/spdx-spec/v3.0.x/model/*
         run: |
           cp -R $PARSER_OUT_BASE_DIR/$PARSER_OUT_MKDOCS_DIR/* spdx-spec/docs/model

--- a/.github/workflows/publish_v3.yml
+++ b/.github/workflows/publish_v3.yml
@@ -21,9 +21,9 @@ jobs:
       GIT_USER_NAME: "ci-bot"               # for gh-pages commit
       GIT_USER_EMAIL: "ci-bot@spdx.dev"     # for gh-pages commit
       PARSER_OUTPUT_DIR: "__parser_output"  # temp dir for output from spec-parser
-      RDF_BASE_DIR: ""                      # change to "rdf" in new spec-parser output dir structure
-      MKDOCS_BASE_DIR: ""                   # change to "mkdocs" in new spec-parser output dir structure
-      MKDOCS_MODEL_YML: "mkdocs-files.yml"  # contains list of model Markdown files
+      RDF_BASE_DIR: "rdf"                   # spec-parser output dir: contains JSON-LD context, RDFs, and JSON schema
+      MKDOCS_BASE_DIR: "mkdocs"             # spec-parser output dir: contains model Markdown files for MkDocs
+      MKDOCS_MODEL_YML: "model-files.yml"   # contains list of model Markdown files
       MKDOCS_BASE_YML: "mkdocs.yml"         # initial MkDocs configuration
       MKDOCS_FULL_YML: "__mkdocs-full.yml"  # MkDocs configuration combined with model list
       REDIRECT_MAP_PATH: "etc/redirect-map.csv"             # redirect map

--- a/.github/workflows/publish_v3.yml
+++ b/.github/workflows/publish_v3.yml
@@ -20,7 +20,7 @@ jobs:
       VERSION_ALIASES: "latest v3.0 v3.0.1-draft v3-draft v3.0-RC1 v3.0-RC2"  # aliases for VERSION
       GIT_USER_NAME: "ci-bot"               # for gh-pages commit
       GIT_USER_EMAIL: "ci-bot@spdx.dev"     # for gh-pages commit
-      PARSER_OUT_BASE_DIR: "__parser_output"  # spec-parser output directory
+      PARSER_OUT_BASE_DIR: "__parser_output"  # temp dir for output from spec-parser
       PARSER_OUT_RDF_DIR: "rdf"               # contains JSON-LD context, RDFs, and JSON schema. Relative to PARSER_OUT_BASE_DIR.
       PARSER_OUT_MKDOCS_DIR: "mkdocs"         # contains model Markdown files for MkDocs. Relative to PARSER_OUT_BASE_DIR.
       MKDOCS_MODEL_YML: "model-files.yml"   # contains list of model Markdown files
@@ -60,14 +60,14 @@ jobs:
           mkdir spdx-spec/docs/rdf
           mkdir spdx-spec/docs/model
       - name: Copy JSON annotations
-        # Will be redirected from https://spdx.org/rdf/3.0.0/spdx-json-serialize-annotations.ttl
-        # and available at https://spdx.github.io/spdx-spec/v3.0/rdf/jsonld-annotations.ttl
+        # Will be redirected from https://spdx.org/rdf/3.0.x/spdx-json-serialize-annotations.ttl
+        # and available at https://spdx.github.io/spdx-spec/v3.0.x/rdf/jsonld-annotations.ttl
         run: |
           cp spdx-spec/serialization/jsonld/annotations.ttl spdx-spec/docs/rdf/jsonld-annotations.ttl
           cp spdx-spec/serialization/jsonld/annotations.ttl spdx-spec/docs/model/jsonld-annotations.ttl
       - name: Copy JSON-LD context and RDFs
-        # Will be redirected from https://spdx.org/rdf/3.0.0/spdx-context.jsonld, spdx-model.ttl, etc.
-        # and available at https://spdx.github.io/spdx-spec/v3.0/rdf/spdx-context.jsonld
+        # Will be redirected from https://spdx.org/rdf/3.0.x/spdx-context.jsonld, spdx-model.ttl, etc.
+        # and available at https://spdx.github.io/spdx-spec/v3.0.x/rdf/spdx-context.jsonld
         run: |
           echo "===================="
           echo "Source: $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR"
@@ -99,8 +99,8 @@ jobs:
           ls spdx-spec/docs/model
           echo "===================="
       - name: Generate JSON schema
-        # Will be redirected from https://spdx.org/schema/3.0.0/spdx-json-schema.json
-        # and available at https://spdx.github.io/spdx-spec/v3.0/rdf/schema.json
+        # Will be redirected from https://spdx.org/schema/3.0.x/spdx-json-schema.json
+        # and available at https://spdx.github.io/spdx-spec/v3.0.x/rdf/schema.json
         run: |
           shacl2code generate \
             --input spdx-spec/docs/rdf/spdx-model.ttl \
@@ -110,7 +110,7 @@ jobs:
             --output spdx-spec/docs/rdf/schema.json
           cp spdx-spec/docs/rdf/schema.json spdx-spec/docs/model/schema.json
       - name: Copy model files and file list for MkDocs
-        # Will be available at https://spdx.github.io/spdx-spec/v3.0/model/*
+        # Will be available at https://spdx.github.io/spdx-spec/v3.0.x/model/*
         run: |
           cp -R $PARSER_OUT_BASE_DIR/$PARSER_OUT_MKDOCS_DIR/* spdx-spec/docs/model
           cp $PARSER_OUT_BASE_DIR/$MKDOCS_MODEL_YML spdx-spec

--- a/.github/workflows/publish_v3.yml
+++ b/.github/workflows/publish_v3.yml
@@ -20,9 +20,9 @@ jobs:
       VERSION_ALIASES: "latest v3.0 v3.0.1-draft v3-draft v3.0-RC1 v3.0-RC2"  # aliases for VERSION
       GIT_USER_NAME: "ci-bot"               # for gh-pages commit
       GIT_USER_EMAIL: "ci-bot@spdx.dev"     # for gh-pages commit
-      PARSER_OUTPUT_DIR: "__parser_output"  # temp dir for output from spec-parser
-      RDF_BASE_DIR: "rdf"                   # spec-parser output dir: contains JSON-LD context, RDFs, and JSON schema
-      MKDOCS_BASE_DIR: "mkdocs"             # spec-parser output dir: contains model Markdown files for MkDocs
+      PARSER_OUT_BASE_DIR: "__parser_output"  # spec-parser output directory
+      PARSER_OUT_RDF_DIR: "rdf"               # contains JSON-LD context, RDFs, and JSON schema. Relative to PARSER_OUT_BASE_DIR.
+      PARSER_OUT_MKDOCS_DIR: "mkdocs"         # contains model Markdown files for MkDocs. Relative to PARSER_OUT_BASE_DIR.
       MKDOCS_MODEL_YML: "model-files.yml"   # contains list of model Markdown files
       MKDOCS_BASE_YML: "mkdocs.yml"         # initial MkDocs configuration
       MKDOCS_FULL_YML: "__mkdocs-full.yml"  # MkDocs configuration combined with model list
@@ -52,7 +52,9 @@ jobs:
       - name: Install pre-requisites for spec-parser
         run: pip install -r spec-parser/requirements.txt
       - name: Build model files
-        run: python3 spec-parser/main.py spdx-3-model/model $PARSER_OUTPUT_DIR
+        run: |
+          python3 spec-parser/main.py spdx-3-model/model $PARSER_OUT_BASE_DIR
+          tree $PARSER_OUT_BASE_DIR
       - name: Create directories for model (MkDocs) and RDF files
         run: |
           mkdir spdx-spec/docs/rdf
@@ -68,28 +70,28 @@ jobs:
         # and available at https://spdx.github.io/spdx-spec/v3.0/rdf/spdx-context.jsonld
         run: |
           echo "===================="
-          echo "Source: $PARSER_OUTPUT_DIR/$RDF_BASE_DIR"
+          echo "Source: $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR"
           echo "--------------------"
-          ls $PARSER_OUTPUT_DIR/$RDF_BASE_DIR
+          ls $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR
           echo "===================="
-          cp $PARSER_OUTPUT_DIR/$RDF_BASE_DIR/spdx-context.jsonld spdx-spec/docs/rdf/
-          cp $PARSER_OUTPUT_DIR/$RDF_BASE_DIR/spdx-model.dot spdx-spec/docs/rdf/
-          cp $PARSER_OUTPUT_DIR/$RDF_BASE_DIR/spdx-model.json-ld spdx-spec/docs/rdf/
-          cp $PARSER_OUTPUT_DIR/$RDF_BASE_DIR/spdx-model.pretty-xml spdx-spec/docs/rdf/
-          cp $PARSER_OUTPUT_DIR/$RDF_BASE_DIR/spdx-model.ttl spdx-spec/docs/rdf/
-          cp $PARSER_OUTPUT_DIR/$RDF_BASE_DIR/spdx-model.xml spdx-spec/docs/rdf/
+          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-context.jsonld spdx-spec/docs/rdf/
+          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-model.dot spdx-spec/docs/rdf/
+          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-model.json-ld spdx-spec/docs/rdf/
+          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-model.pretty-xml spdx-spec/docs/rdf/
+          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-model.ttl spdx-spec/docs/rdf/
+          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-model.xml spdx-spec/docs/rdf/
           cp spdx-spec/docs/rdf/spdx-model.json-ld spdx-spec/docs/rdf/spdx-model.jsonld
           echo "===================="
           echo "Target (after copy): spdx-spec/docs/rdf"
           echo "--------------------"
           ls spdx-spec/docs/rdf
           echo "===================="
-          cp $PARSER_OUTPUT_DIR/$RDF_BASE_DIR/spdx-context.jsonld spdx-spec/docs/model/
-          cp $PARSER_OUTPUT_DIR/$RDF_BASE_DIR/spdx-model.dot spdx-spec/docs/model/
-          cp $PARSER_OUTPUT_DIR/$RDF_BASE_DIR/spdx-model.json-ld spdx-spec/docs/model/
-          cp $PARSER_OUTPUT_DIR/$RDF_BASE_DIR/spdx-model.pretty-xml spdx-spec/docs/model/
-          cp $PARSER_OUTPUT_DIR/$RDF_BASE_DIR/spdx-model.ttl spdx-spec/docs/model/
-          cp $PARSER_OUTPUT_DIR/$RDF_BASE_DIR/spdx-model.xml spdx-spec/docs/model/
+          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-context.jsonld spdx-spec/docs/model/
+          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-model.dot spdx-spec/docs/model/
+          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-model.json-ld spdx-spec/docs/model/
+          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-model.pretty-xml spdx-spec/docs/model/
+          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-model.ttl spdx-spec/docs/model/
+          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-model.xml spdx-spec/docs/model/
           cp spdx-spec/docs/model/spdx-model.json-ld spdx-spec/docs/model/spdx-model.jsonld
           echo "===================="
           echo "Target (after copy): spdx-spec/docs/model"
@@ -110,12 +112,12 @@ jobs:
       - name: Copy model files and file list for MkDocs
         # Will be available at https://spdx.github.io/spdx-spec/v3.0/model/*
         run: |
-          cp -R $PARSER_OUTPUT_DIR/$MKDOCS_BASE_DIR/* spdx-spec/docs/model
-          cp $PARSER_OUTPUT_DIR/$MKDOCS_MODEL_YML spdx-spec
+          cp -R $PARSER_OUT_BASE_DIR/$PARSER_OUT_MKDOCS_DIR/* spdx-spec/docs/model
+          cp $PARSER_OUT_BASE_DIR/$MKDOCS_MODEL_YML spdx-spec
         # mkdir -p spdx-spec/docs/diagram
-        # cp $PARSER_OUTPUT_DIR/diagram/model.plantuml spdx-spec/docs/diagram
+        # cp $PARSER_OUT_BASE_DIR/diagram/model.plantuml spdx-spec/docs/diagram
         # mkdir -p spdx-spec/docs/jsondump
-        # cp $PARSER_OUTPUT_DIR/jsondump/model.json spdx-spec/docs/jsondump
+        # cp $PARSER_OUT_BASE_DIR/jsondump/model.json spdx-spec/docs/jsondump
       - name: Set Git identity
         working-directory: spdx-spec
         run: git config user.name $GIT_USER_NAME; git config user.email $GIT_USER_EMAIL

--- a/serialization/jsonld/annotations.ttl
+++ b/serialization/jsonld/annotations.ttl
@@ -1,4 +1,4 @@
-@base <https://spdx.org/rdf/3.0.0/terms/> .
+@base <https://spdx.org/rdf/3.0.1/terms/> .
 @prefix sh-to-code: <https://jpewdev.github.io/shacl2code/schema#> .
 
 <Core/Element> ;


### PR DESCRIPTION
- Update RDF and MkDocs Markdown directories to match spec-parser's new output directory structure
- Install pandoc (required by spec-parser for Tex files generation)
- 