### PR TITLE
Update shacl2code to 0.0.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ mike==2.1.3
 mkdocs==1.6.1
 mkdocs-pdf-export-plugin==0.5.10
 PyYAML==6.0.2
-shacl2code==0.0.13
+shacl2code==0.0.14


### PR DESCRIPTION
Currently, the example validation [failed for 3.0.1](https://github.com/spdx/spdx-spec/actions/runs/10797439542/job/29948703452?pr=1107).

> _WrappedReferencingError: PointerToNowhere: '/$defs/Artifact' does not exist ...

As discussed during tech call 2024-09-10,
this PR will upgrade shacl2code to fix it.