### PR TITLE
Remove "License Information in File" from License List Matching guidelines

### DIFF
--- a/docs/annexes/license-matching-guidelines-and-templates.md
+++ b/docs/annexes/license-matching-guidelines-and-templates.md
@@ -10,7 +10,10 @@ As noted here, some of the matching guidelines are implemented in the XML files 
 
 ### Purpose
 
-To ensure consistent results by different SPDX document creators when matching license information that will be included in the License Information in File field. SPDX document creators or tools may match on the license or exception text itself, the official license header, or the SPDX License List short identifier.
+To ensure consistent results by different SPDX document creators when matching
+license information that will be included in SPDX data.
+SPDX document creators or tools may match on the license or exception text
+itself, the official license header, or the SPDX License List short identifier.
 
 ### Guideline: official license headers
 


### PR DESCRIPTION
"License Information in File" field is no longer exist in SPDX 3.0.

Remove it from the matching guidelines, using a language suggested in https://github.com/spdx/spdx-spec/issues/1125#issuecomment-2378760932

From:
> To ensure consistent results by different SPDX document creators when matching license information that will be included in **the License Information in File field**.

To:
> To ensure consistent results by different SPDX document creators when matching license information that will be included in **SPDX data**.

To fix #1125