### PR TITLE
Add Extension Profile diagram to Annex

### DIFF
--- a/docs/annexes/rdf-model.md
+++ b/docs/annexes/rdf-model.md
@@ -12,13 +12,13 @@ and is published in online at
 
 [![Core and Software Profiles diagram][fig_core_software]][fig_core_software]
 
-### Licensing Profile
-
-[![Licensing Profile diagram][fig_licensing]][fig_licensing]
-
 ### Security Profile
 
 [![Security Profile diagram][fig_security]][fig_security]
+
+### Licensing Profile
+
+[![Licensing Profile diagram][fig_licensing]][fig_licensing]
 
 ### Dataset Profile
 
@@ -32,9 +32,14 @@ and is published in online at
 
 [![Build Profile diagram][fig_build]][fig_build]
 
-[fig_core_software]: ../images/model-core-software.png "SPDX 3.0.1 Core and Software Profiles diagram"
+### Extension Profile
+
+[![Extension Profile diagram][fig_extension]][fig_extension]
+
 [fig_ai]: ../images/model-ai.png "SPDX 3.0.1 AI Profile diagram"
 [fig_build]: ../images/model-build.png "SPDX 3.0.1 Build Profile diagram"
+[fig_core_software]: ../images/model-core-software.png "SPDX 3.0.1 Core and Software Profiles diagram"
 [fig_dataset]: ../images/model-dataset.png "SPDX 3.0.1 Dataset Profile diagram"
+[fig_extension]: ../images/model-extension.png "SPDX 3.0.1 Extension Profile diagram"
 [fig_licensing]: ../images/model-licensing.png "SPDX 3.0.1 Licensing Profile diagram"
 [fig_security]: ../images/model-security.png "SPDX 3.0.1 Security Profile diagram"


### PR DESCRIPTION
- Add Extension Profile diagram to [Annex A](https://spdx.github.io/spdx-spec/v3.0.1/annexes/rdf-model/) - 
to fix #1127
- Also sort diagrams according to the order in [Conformance](https://spdx.github.io/spdx-spec/v3.0.1/conformance/#introduction-to-profiles)
