### PR TITLE
Standardize RFC links to https://datatracker.ietf.org/doc/rfc...

### DIFF
--- a/docs/annexes/pkg-url-specification.md
+++ b/docs/annexes/pkg-url-specification.md
@@ -126,7 +126,7 @@ The rules for each component are:
 - The version is prefixed by a at-sign `@` separator when not empty.
 - This at-sign `@` is not part of the version.
 - A version must be a percent-encoded string.
-- A version is a plain and opaque string. Some package types use versioning conventions such as semver for NPMs or nevra conventions for RPMS. A type may define a procedure to compare and sort versions, but there is no reliable and uniform way to do such comparison consistently.
+- A version is a plain and opaque string. Some package types use versioning conventions such as SemVer for NPMs or NEVRA conventions for RPMS. A type may define a procedure to compare and sort versions, but there is no reliable and uniform way to do such comparison consistently.
 
 ### Rules for qualifiers
 
@@ -194,7 +194,7 @@ The current list of known types is:
 The list, with definitions for each type,
 is maintained in the file named `PURL-TYPES.rst`
 in the online repository
-https://github.com/package-url/purl-spec.
+<https://github.com/package-url/purl-spec>.
 
 ## Known qualifiers key/value pairs
 
@@ -351,7 +351,7 @@ The following list includes some valid _purl_ examples:
 ## Original license
 
 This specification is based on the texts published
-in the https://github.com/package-url/purl-spec online repository.
+in the <https://github.com/package-url/purl-spec> online repository.
 The original license and attribution are reproduced below:
 
 Copyright (c) the purl authors
@@ -372,4 +372,3 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-

--- a/docs/annexes/spdx-license-expressions.md
+++ b/docs/annexes/spdx-license-expressions.md
@@ -6,7 +6,9 @@ Often a single license can be used to represent the licensing terms of a source 
 
 SPDX License Expressions provide a way for one to construct expressions that more accurately represent the licensing terms typically found in open source software source code. A license expression could be a single license identifier found on the SPDX License List; a user defined license reference denoted by the LicenseRef-`[idString]`; a license identifier combined with an SPDX exception; or some combination of license identifiers, license references and exceptions constructed using a small set of defined operators (e.g., `AND`, `OR`, `WITH` and `+`). We provide the definition of what constitutes a valid SPDX License Expression in this section.
 
-The exact syntax of license expressions is described below in ABNF, as defined in [RFC5234](http://tools.ietf.org/html/rfc5234) and expanded in [RFC7405](http://tools.ietf.org/html/rfc7405).
+The exact syntax of license expressions is described below in ABNF, as defined
+in [RFC 5234](https://datatracker.ietf.org/doc/rfc5234/) and expanded
+in [RFC 7405](https://datatracker.ietf.org/doc/rfc7405/).
 
 ```text
 idstring = 1*(ALPHA / DIGIT / "-" / "." )
@@ -64,9 +66,9 @@ The same applies to `AdditionRef-` user defined identifiers.
 
 A simple `<license-expression>` is composed one of the following:
 
-* An SPDX License List Short Form Identifier. For example: CDDL-1.0
-* An SPDX License List Short Form Identifier with a unary "+" operator suffix to represent the current version of the license or any later version. For example: CDDL-1.0+
-* An SPDX user defined license reference: ["DocumentRef-"1\*(idstring)":"]"LicenseRef-"1*(idstring)
+- An SPDX License List Short Form Identifier. For example: CDDL-1.0
+- An SPDX License List Short Form Identifier with a unary "+" operator suffix to represent the current version of the license or any later version. For example: CDDL-1.0+
+- An SPDX user defined license reference: ["DocumentRef-"1\*(idstring)":"]"LicenseRef-"1*(idstring)
 
 Some examples:
 
@@ -234,12 +236,12 @@ A disjunctive license can be expressed in RDF via a `<spdx:DisjunctiveLicenseSet
 
 A License Exception can be expressed in RDF via a `<spdx:LicenseException>` element. This element has the following unique mandatory (unless specified otherwise) attributes:
 
-* `comment` - An `rdfs:comment` element describing the nature of the exception.
-* `seeAlso` (optional, one or more)- An `rdfs:seeAlso` element referencing external sources of information on the exception.
-* `example` (optional) - Text describing examples of this exception.
-* `name` - The full human readable name of the item.
-* `licenseExceptionId` -  The identifier of an exception in the SPDX License List to which the exception applies.
-* `licenseExceptionText` - Full text of the license exception.
+- `comment` - An `rdfs:comment` element describing the nature of the exception.
+- `seeAlso` (optional, one or more)- An `rdfs:seeAlso` element referencing external sources of information on the exception.
+- `example` (optional) - Text describing examples of this exception.
+- `name` - The full human readable name of the item.
+- `licenseExceptionId` -  The identifier of an exception in the SPDX License List to which the exception applies.
+- `licenseExceptionText` - Full text of the license exception.
 
 ```text
 <rdf:Description rdf:about


### PR DESCRIPTION
- In License Expression
  - Use https://datatracker.ietf.org/doc/rfcXXX for RFC links -- to resolve #1012
  - Use `-` instead of `*` for bullets (like the rest of the spec) to avoid Markdown warnings
- In Package URL spec
  - Fix casing: semver -> SemVer; nevra -> NEVRA -- according to casing found in project docs
    - https://semver.org/
    - https://docs.fedoraproject.org/en-US/modularity/core-concepts/nsvca/
  - Fix unclickable links