### PR TITLE
Conformance: fix typo: refering -> referring

### DIFF
--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -61,7 +61,7 @@ bills of materials information produced by tools supporting SPDX.
 ## Software Profile compliance point
 
 The Software Profile includes the definitions of classes, properties and
-vocabularies for refering to and conveying information about software and is
+vocabularies for referring to and conveying information about software and is
 usable by all SPDX profiles when producing or consuming SPDX content.
 
 Software that conforms to the SPDX specification at the Software Profile


### PR DESCRIPTION
One minor typo in Conformance chapter.

- validation failed because https://github.com/spdx/spdx-spec/issues/1135
- please apply https://github.com/spdx/spdx-spec/pull/1133 first