### PR TITLE
Separate build instructions from the README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Generated files for model
 docs/model/
+docs/rdf/
 
 # GitBook directory and generated docs
 _book/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ following sentence: if applied, this commit will "Subject of the commit".
 For example :
 
 ```text
-if applied, this commit will Add chapter on Security Vunerabilities in SPDX
+if applied, this commit will Add chapter on Security Vulnerabilities in SPDX
 if applied, this commit will Delete section with deprecated SPDX attributes 
 if applied, this commit will Fix grammar in Package Version field description
 ```

--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ of the specification as:
   - Current stable (v3.0.1): <https://spdx.github.io/spdx-spec/v3.0.1/>
 <!--  - Development (v3.1): <https://spdx.github.io/spdx-spec/v3.1-draft/> -->
 
-Contributions are welcome, please see the contributing guidelines,
-governance practices, and build instructions in the
+Contributions are welcome. Contributions to this repository are made pursuant to the
+[SPDX Community Specification Contributor License Agreement 1.0](https://github.com/spdx/governance/blob/main/0._SPDX_Contributor_License_Agreement.md).
+Please see the contributing guidelines, governance practices,
+and build instructions in the
 [related documents](#related-documents-and-repositories) section.
 
 ## Repository structure
@@ -69,6 +71,6 @@ This repository consists of these files and directories (partial):
 | SPDX 3 model development | [spdx/spdx-3-model](https://github.com/spdx/spdx-3-model/) |
 | Model specification parser | [spdx/spec-parser](https://github.com/spdx/spec-parser/) |
 | How to use the specification | [spdx/using](https://github.com/spdx/using/) |
-| Use cases and scenarios | [spdx/spdx-examples](https://github.com/spdx/spdx-examples) |
-| SPDX website | <https://spdx.org> |
+| Use cases and scenarios | [spdx/spdx-examples](https://github.com/spdx/spdx-examples/) |
+| SPDX website, with more information about the specification | <https://spdx.org> |
 | Official releases of the specification, including PDFs | <https://spdx.org/specifications> |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # The System Package Data Exchange (SPDX®) Specification
 
-The System Package Data Exchange (SPDX®) specification is an open standard designed to represent systems containing software components as Software Bill of Materials (SBOMs). Additionally, SPDX supports AI, data, and security references, making it suitable for a wide range of risk management use cases.
+The System Package Data Exchange (SPDX®) specification is an open standard
+designed to represent systems containing software components as
+Software Bill of Materials (SBOMs).
+Additionally, SPDX supports AI, data, and security references,
+making it suitable for a wide range of risk management use cases.
 
 The SPDX standard helps facilitate compliance with free and open source
 software licenses by standardizing the way license information is shared across
@@ -13,38 +17,38 @@ This repository holds under active development version of the specification as:
 - Markdown:
   [`development/v3.0.1`](https://github.com/spdx/spdx-spec/tree/development/v3.0.1/docs)
   branch
-- HTML: `gh-pages` branch, built on every commit to the development branch,
-  see the workflow in
-  [`.github/workflows/publish_v3.yml`](.github/workflows/publish_v3.yml)
+- HTML: `gh-pages` branch, built on every commit to the development branch
   - Current stable (v3.0.1): <https://spdx.github.io/spdx-spec/v3.0.1/>
 <!--  - Development (v3.1): <https://spdx.github.io/spdx-spec/v3.1-draft/> -->
 
-The model itself is under active development at
-[spdx/spdx-3-model](https://github.com/spdx/spdx-3-model/)
-repo (`main` branch).
+The specification is comprised of documents located in the `docs/` directory
+of this `spdx/spdx-spec` repository, as well as a model documentation
+generated from Markdown files within the
+[spdx/spdx-3-model](https://github.com/spdx/spdx-3-model/) repository.
 
-See for the official
-[releases of the specification](https://spdx.org/specifications)
-or additional information also the SPDX website at <https://spdx.org>.
+## Related repositories and documents
 
-Information on how to use the SPDX specification is available at
-[spdx/using](https://github.com/spdx/using/) repo.
-Demonstrations of SPDX for various scenarios and use cases are available at
-[spdx/spdx-examples](https://github.com/spdx/spdx-examples).
+| Documentation | Link |
+|---------|------|
+| Changes between versions | [CHANGELOG.md](./CHANGELOG.md) |
+| Contributing guidelines | [CONTRIBUTING.md](./CONTRIBUTING.md) |
+| Building the specification website (for testing purpose) | [build.md](build.md) |
+| Governance practices | [spdx/governance](https://github.com/spdx/governance/) |
+| SPDX 3 model development | [spdx/spdx-3-model](https://github.com/spdx/spdx-3-model/) |
+| How to use the specification | [spdx/using](https://github.com/spdx/using/) |
+| Use cases and scenarios | [spdx/spdx-examples](https://github.com/spdx/spdx-examples) |
+| SPDX website | <https://spdx.org> |
+| Official releases of the specification, including PDFs | <https://spdx.org/specifications> |
 
-See [change log](./CHANGELOG.md) for changes between versions.
-Contributions are welcome,
-please see the [contributing guidelines](./CONTRIBUTING.md)
-and [governance practices](https://github.com/spdx/governance/).
+## Repository structure
 
-## Specification structure
-
-This repository consists of these files and directories:
+This repository consists of these files and directories (partial):
 
 - `bin/` - Scripts for spec generation.
 - `docs/` - Specification content:
   - `annexes/` - Annexes for the specification.
   - `css/` - Style sheets for HTML.
+  - `front/` - Front matter.
   - `images/` - Model diagrams. These image files are to be generated from a
     diagram description file
     [model.drawio](https://github.com/spdx/spdx-3-model/blob/main/model.drawio)
@@ -58,174 +62,10 @@ This repository consists of these files and directories:
 - `mkdocs.yml` - MkDocs recipe for the spec documentation generation. The
   inclusion of model files and the order of chapters are defined here.
 
-The specification consists of documents in the `docs/` directory from this
-`spdx/spdx-spec` repository and a model which is generated from Markdown files
-in the `spdx/spdx-3-model` repository.
+## Building the specification website
 
-Note: The model files in the `spdx/spdx-3-model` repository use a constrained
-format of Markdown. Only a limited set of headings are allowed to be processed
-by the spec-parser.
+The website generation workflow is defined in the
+[`.github/workflows/publish_v3.yml`](.github/workflows/publish_v3.yml) file.
 
-## Building the specification
-
-The specification building flow looks like this:
-
-```text
-  +-------------------+
-  |[spdx-3-model]     |
-  | |                 |
-  | +- model/        ---- Constrained-Markdown files -+
-  | |                 |                               |
-  | +- model.drawio  -----------------+               |
-  +-------------------+               |               |
-                                      |               |
-                                      |               |
-  +-------------------+               v               |
-  |[spdx-spec]        |            draw.io            |
-  | |                 |            (manual)           |
-  | +- docs/          |               |               |
-  |    |              |               |               |
-  |    +- annexes/    |               |               v
-  |    |              |               |         spec-parser
-  |    +- images/  <---- PNG images --+               |
-  |    |              |                               |
-  |    +- licenses/   |                               |
-  |    |              |                               |
-  |    +- model/   <----- Processed Markdown files ---+
-  |    |              |
-  |    +- index.md    |
-  |    |              |
-  |    +- *.md        |
-  +-------------------+
-          |
-    mike & mkdocs
-          |
-          v
-  +-------------------+
-  |   HTML website    |
-  +-------------------+
-```
-
-### Prerequisites
-
-Apart from Git and Python, you have to have [MkDocs](http://mkdocs.org)
-installed on your machine. If you don't have it yet installed please follow
-these [installation instructions](http://www.mkdocs.org/#installation).
-
-[WeasyPrint](https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#installation)
-is also required for generating PDF files. To enable PDF generation, set the
-`ENABLE_PDF_EXPORT` environment variable to `1`.
-
-### Preparing input files
-
-Next, you have to prepare the model files, the other specification files,
-and the model parser, by cloning these repositories:
-[`spdx/spdx-3-model`](https://github.com/spdx/spdx-3-model),
-[`spdx/spdx-spec`](https://github.com/spdx/spdx-spec), and
-[`spdx/spec-parser`](https://github.com/spdx/spec-parser)
-to these paths: `spdx-3-model`, `spdx-spec`, and `spec-parser`, respectively:
-
-```shell
-git clone https://github.com/spdx/spdx-3-model.git
-git clone https://github.com/spdx/spdx-spec.git
-git clone https://github.com/spdx/spec-parser.git
-```
-
-Install prerequisites for Python:
-
-```shell
-pip3 install -r spdx-spec/requirements.txt
-pip3 install -r spec-parser/requirements.txt
-```
-
-### Generating model and formatted Markdown files for MkDocs
-
-Model files in `spdx/spdx-3-model` repo are written in a specific format of
-Markdown, with a limited set of allowed headings. The `spec-parser` processes
-these model files to generate both ontology and final Markdown files suitable
-for MkDocs.
-
-The `spec-parser` also performs automatic formatting on the resulting Markdown
-files. For instance, it converts a list under the "Properties" heading into a
-table.
-
-To check the model files and generate formatted files for MkDocs, run the
-following command:
-
-```shell
-python3 spec-parser/main.py spdx-3-model/model spdx-spec/docs/model
-```
-
-This will create well-formatted model files in the `spdx-spec/docs/model/`
-directory. This directory contains two components:
-
-- Model ontology and diagram files: These files (`model.plantuml`,
-  `spdx-context.jsonld`, `spdx-model.dot`, `spdx-model.json-ld`,
-  `spdx-model.pretty-xml`, `spdx-model.ttl`, `spdx-model.xml`)
-  are ready for immediate use.
-- Formatted Makdown files: These files (`.md` extension) are located in various
-  subdirectories and are intended for processing by MkDocs in the next step.
-
-If the output directory already exists, the `spec-parser` will not overwrite
-it. If you edited a model file and want to regenerate the formatted files, you
-have to delete the existing `spdx-spec/docs/model` directory first:
-
-```shell
-rm -rf spdx-spec/docs/model
-```
-
-### Building HTML
-
-With all spec and model files prepared, we will use MkDocs to assemble them
-into a website.
-
-In side `spdx-spec/` directory, execute a built-in dev-server that let you
-preview the specification:
-
-These following commands should run inside the `spdx-spec/` directory.
-
-- To preview the specification in a web browser:
-
-  ```shell
-  mkdocs serve
-  ```
-
-- To build a static HTML site:
-
-  ```shell
-  mkdocs build
-  ```
-
-- To get debug messages, enables verbose output:
-
-  ```shell
-  mkdocs build --verbose
-  ```
-
-## Configuring the website
-
-Inside `spdx-spec/` directory, there is a file `mkdocs.yml`. This is a
-configuration file for MkDocs.
-
-You can customize website details like the site name and main URL (canonical
-URL) in this file.
-
-To include a page in the navigation bar, list its filename under the `nav:`
-section. The order of filenames in this section determines the order of the
-page in the navigation bar.
-
-## Specification versions on spdx.github.io/spdx-spec/
-
-The SPDX specifications on <https://spdx.github.io/spdx-spec/> are built
-by using a workflow in
-[`.github/workflows/publish_v3.yml`](.github/workflows/publish_v3.yml).
-This workflow uses [mike](https://github.com/jimporter/mike) to publish
-multiple versions of MkDocs-powered documentation.
-
-The published versions, their titles, and aliases are listed in the file
-[versions.json](https://github.com/spdx/spdx-spec/blob/gh-pages/versions.json)
-located in the `gh-pages` branch. These versions populate the version selector
-dropdown on the website. The line `run: mike deploy` in the GitHub workflow
-file determines the title and alias.
-
-mike is not needed for local testing of a specific spec version.
+For local testing and review,
+refer to the build instructions in the [build.md](./build.md) file.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,15 @@ the software supply chain. SPDX reduces redundant work by providing a common
 format for companies and communities to share important data about software
 licenses and copyrights, thereby streamlining and improving compliance.
 
-This repository holds under active development version of the specification as:
+## Specification development
+
+The specification is comprised of documents located in the `docs/` directory
+of this `spdx/spdx-spec` repository, as well as a model documentation
+generated from Markdown files within the
+[spdx/spdx-3-model](https://github.com/spdx/spdx-3-model/) repository.
+
+This `spdx/spdx-spec` repository holds under active development version
+of the specification as:
 
 - Markdown:
   [`development/v3.0.1`](https://github.com/spdx/spdx-spec/tree/development/v3.0.1/docs)
@@ -21,29 +29,17 @@ This repository holds under active development version of the specification as:
   - Current stable (v3.0.1): <https://spdx.github.io/spdx-spec/v3.0.1/>
 <!--  - Development (v3.1): <https://spdx.github.io/spdx-spec/v3.1-draft/> -->
 
-The specification is comprised of documents located in the `docs/` directory
-of this `spdx/spdx-spec` repository, as well as a model documentation
-generated from Markdown files within the
-[spdx/spdx-3-model](https://github.com/spdx/spdx-3-model/) repository.
-
-## Related repositories and documents
-
-| Documentation | Link |
-|---------|------|
-| Changes between versions | [CHANGELOG.md](./CHANGELOG.md) |
-| Contributing guidelines | [CONTRIBUTING.md](./CONTRIBUTING.md) |
-| Building the specification website (for testing purpose) | [build.md](build.md) |
-| Governance practices | [spdx/governance](https://github.com/spdx/governance/) |
-| SPDX 3 model development | [spdx/spdx-3-model](https://github.com/spdx/spdx-3-model/) |
-| How to use the specification | [spdx/using](https://github.com/spdx/using/) |
-| Use cases and scenarios | [spdx/spdx-examples](https://github.com/spdx/spdx-examples) |
-| SPDX website | <https://spdx.org> |
-| Official releases of the specification, including PDFs | <https://spdx.org/specifications> |
+Contributions are welcome, please see the contributing guidelines,
+governance practices, and build instructions in the
+[related documents](#related-documents-and-repositories) section.
 
 ## Repository structure
 
 This repository consists of these files and directories (partial):
 
+- `.github/workflow` - Workflow definitions.
+  - [`publish_v3.yml`](.github/workflows/publish_v3.yml)
+    The website (HTML) generation workflow.
 - `bin/` - Scripts for spec generation.
 - `docs/` - Specification content:
   - `annexes/` - Annexes for the specification.
@@ -62,10 +58,17 @@ This repository consists of these files and directories (partial):
 - `mkdocs.yml` - MkDocs recipe for the spec documentation generation. The
   inclusion of model files and the order of chapters are defined here.
 
-## Building the specification website
+## Related documents and repositories
 
-The website generation workflow is defined in the
-[`.github/workflows/publish_v3.yml`](.github/workflows/publish_v3.yml) file.
-
-For local testing and review,
-refer to the build instructions in the [build.md](./build.md) file.
+| Documentation | Link |
+|---------|------|
+| Changes between versions | [CHANGELOG.md](./CHANGELOG.md) |
+| Contributing guidelines | [CONTRIBUTING.md](./CONTRIBUTING.md) |
+| Building the specification website (for testing purpose) | [build.md](build.md) |
+| Governance practices | [spdx/governance](https://github.com/spdx/governance/) |
+| SPDX 3 model development | [spdx/spdx-3-model](https://github.com/spdx/spdx-3-model/) |
+| Model specification parser | [spdx/spec-parser](https://github.com/spdx/spec-parser/) |
+| How to use the specification | [spdx/using](https://github.com/spdx/using/) |
+| Use cases and scenarios | [spdx/spdx-examples](https://github.com/spdx/spdx-examples) |
+| SPDX website | <https://spdx.org> |
+| Official releases of the specification, including PDFs | <https://spdx.org/specifications> |

--- a/build.md
+++ b/build.md
@@ -1,0 +1,209 @@
+---
+SPDX-License-Identifier: Community-Spec-1.0
+SPDX-FileCopyrightText: Copyright 2024 The SPDX Contributors
+---
+
+# Building the specification website
+
+The specification website building flow looks like this:
+
+```text
+  +-------------------+
+  |[spdx-3-model]     |
+  | +- model/        ---- Constrained-Markdown files -+
+  | +- model.drawio  -----------------+               |
+  +-------------------+               |               |
+                                      |               |
+  +-------------------+               v               |
+  |[spdx-spec]        |            draw.io            |
+  | +- docs/          |            (manual)           v
+  | |  +- annexes/    |               |          spec-parser
+  | |  +- front/      |               |               |
+  | |  +- images/  <---- PNG images --+               |
+  | |  +- licenses/   |                               |
+  | |  +- model/   <----- Processed Markdown files ---+
+  | |  +- rdf/     <----- RDF files ------------------+
+  | |  +- *.md        |
+  | |  +- index.md    |
+  | +- mkdocs.yml     |
+  +-------------------+
+          |
+       mkdocs
+          |
+          v
+  +-------------------+
+  | HTML website      |
+  | +- annexes/       |
+  | +- ...            |
+  | +- *.md           |
+  | +- index.html     |
+  +-------------------+
+```
+
+## 1. Prerequisites
+
+Apart from Git and Python, you have to have [MkDocs](http://mkdocs.org)
+installed on your machine. If you don't have it yet installed please follow
+these [installation instructions](http://www.mkdocs.org/#installation).
+
+`mkdocs.yml` is the configuration file for MkDocs.
+
+<!--
+[WeasyPrint](https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#installation)
+is also required for generating PDF files. To enable PDF generation, set the
+`ENABLE_PDF_EXPORT` environment variable to `1`.
+-->
+
+## 2. Getting input files
+
+Next, you have to get the model files, the other specification files
+(main chapters, annexes, front matter, and licenses),
+and the model parser, by cloning these repositories:
+[`spdx/spdx-3-model`](https://github.com/spdx/spdx-3-model),
+[`spdx/spdx-spec`](https://github.com/spdx/spdx-spec), and
+[`spdx/spec-parser`](https://github.com/spdx/spec-parser)
+to these paths: `spdx-3-model`, `spdx-spec`, and `spec-parser`, respectively:
+
+```shell
+git clone https://github.com/spdx/spdx-3-model.git
+git clone https://github.com/spdx/spdx-spec.git
+git clone https://github.com/spdx/spec-parser.git
+```
+
+Install their Python prerequisites:
+
+```shell
+pip3 install -r spdx-spec/requirements.txt
+pip3 install -r spec-parser/requirements.txt
+```
+
+## 3. Processing model files (Markdown and RDF)
+
+*If you only want to review the non-model parts of the specification*
+*(e.g., chapters and annexes), you can skip to [step 4](#4-building-html).*
+
+Model files in `spdx/spdx-3-model` repository are written in a constrained
+Markdown format, with a limited set of allowed headings.
+The `spec-parser` processes these model files to generate both ontology files
+and final Markdown files suitable for MkDocs.
+
+The `spec-parser` also performs automatic formatting on the resulting Markdown
+files. For instance, it converts a list under the "Properties" heading into a
+table.
+
+### 3.1 Generating model files with spec-parser
+
+To verify the formatting of pre-processed model files and
+prepare them for MkDocs, run the following command:
+
+```shell
+python3 spec-parser/main.py spdx-3-model/model parser_output
+```
+
+*(If `parser_output` already exists, the `spec-parser` will not overwrite it.)*
+
+The command will create files in the `parser_output` directory.
+Among its subdirectories, we're particularly interested in:
+
+- `parser_output/mkdocs` - Processed Markdown files for MkDocs:
+  These files (`.md` extension) are located in various
+  subdirectories and are intended for processing by MkDocs in the next step.
+- `parser_output/rdf` - Ontology (RDF) files:
+  These files (`spdx-context.jsonld`, `spdx-model.json-ld`, `spdx-model.n3`,
+  `spdx-model.pretty-xml`,`spdx-model.ttl`, `spdx-model.xml`, etc.)
+  are ready for immediate use.
+
+- `parser_output/mkdocs`: Processed Markdown files (`.md`) for MkDocs.
+  These files will be used by MkDocs in the next step.
+- `parser_output/rdf`: Ontology (RDF) files, including
+  `spdx-context.jsonld`, `spdx-model.json-ld`, `spdx-model.ttl`, etc.
+  These files are ready for immediate use.
+
+Additionally, a `parser_output/model-files.yml` file will be generated.
+It contains a list of the files within `parser_output/mkdocs`
+and will be used for MkDocs configuration later.
+
+### 3.2 Copying the generated files
+
+Copy the processed Markdown files and ontology files to the `docs/` directory:
+
+```shell
+cp -R parser_output/mkdocs spdx-spec/docs/model 
+cp -R parser_output/rdf spdx-spec/docs/rdf
+```
+
+To ensure MkDocs recognizes the new Markdown files,
+insert the model file list from `parser_output/model-files.yml`
+into the MkDocs configuration file in `spdx-spec/mkdocs.yml`.
+
+```shell
+spdx-spec/bin/make-mkdocs-config.sh \
+  -b spdx-spec/mkdocs.yml \
+  -m parser_output/model-files.yml \
+  -f spdx-spec/mkdocs-full.yml
+```
+
+The complete MkDocs configuration will be at `spdx-spec/mkdocs-full.yml`.
+
+### 4. Building HTML
+
+With all specification and model files prepared,
+we will use MkDocs to assemble them into a website.
+
+*Note: all the commands below use the configuration file*
+*with the model file list, `mkdocs-full.yml`,*
+*generated in the [step 3.2](#32-copying-the-generated-files).*
+*If you only want to review the non-model part of the specification*
+*(have skipped step 3), please use `mkdocs.yml` instead.*
+
+These following commands should run inside the `spdx-spec/` directory.
+
+- To preview the specification in a web browser:
+
+  ```shell
+  mkdocs serve --config-file mkdocs-full.yml
+  ```
+
+- To build a static HTML site:
+
+  ```shell
+  mkdocs build --config-file mkdocs-full.yml
+  ```
+
+- To get debug messages, enables verbose output:
+
+  ```shell
+  mkdocs build --verbose --config-file mkdocs-full.yml
+  ```
+
+## 5. Configuring the website
+
+To make additional adjustments to the website,
+you can modify its configuration.
+
+Inside `spdx-spec/` directory, there is a file `mkdocs.yml`.
+This is a configuration file for MkDocs.
+
+For example, you can customize website details like the site name
+and main URL (canonical URL) in this file.
+
+To include a page in the navigation bar, list its filename under the `nav:`
+section. The order of filenames in this section determines the order of the
+page in the navigation bar.
+
+## 6. Specification versions on spdx.github.io
+
+The SPDX specifications on <https://spdx.github.io/spdx-spec/> are built
+by using a workflow in
+[`.github/workflows/publish_v3.yml`](.github/workflows/publish_v3.yml).
+This workflow uses [mike](https://github.com/jimporter/mike) to publish
+multiple versions of MkDocs-powered documentation.
+
+The published versions, their titles, and aliases are listed in the file
+[versions.json](https://github.com/spdx/spdx-spec/blob/gh-pages/versions.json)
+located in the `gh-pages` branch.
+These versions populate the version selector dropdown on the website.
+The step `name: Deploy and set aliases` in the GitHub workflow file
+determines the title and alias.
+
+mike is not needed for local testing of a specific spec version.

--- a/build.md
+++ b/build.md
@@ -145,7 +145,7 @@ spdx-spec/bin/make-mkdocs-config.sh \
 
 The complete MkDocs configuration will be at `spdx-spec/mkdocs-full.yml`.
 
-### 4. Building HTML
+## 4. Building HTML
 
 With all specification and model files prepared,
 we will use MkDocs to assemble them into a website.


### PR DESCRIPTION
- For a smaller and more focused README, this PR move build instructions out of the README to a separated file
  - Old README: 231 lines; New README: 76 lines
  - As suggested in https://github.com/spdx/spdx-spec/pull/971#issuecomment-2161225024
  - Put the build instructions in `build.md`
    - With updates to command lines to reflect new output directory structure of new `spec-parser`
  - To fix #1105
- Also add `docs/rdf` (and not `rdf/`) to `.gitignore`,
  to ensure that generated files from local testing will not be included in the commit.