### PR TITLE
Create dependabot.yml for GitHub Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Setup Dependabot alert similar to what [spdx-3-model repo is having](https://github.com/spdx/spdx-3-model/blob/main/.github/dependabot.yaml).

"GitHub sends Dependabot alerts when we detect that your repository uses a vulnerable dependency."
https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts