### PR TITLE
Fix indent in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,9 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
-    open-pull-requests-limit: 10
+  open-pull-requests-limit: 10
 - package-ecosystem: "pip"
   directory: "/"
   schedule:
     interval: "weekly"
-    open-pull-requests-limit: 10
+  open-pull-requests-limit: 10


### PR DESCRIPTION
To fix breaking dependabot workflow.

Sorry @goneall, I made a wrong indent.