### PR TITLE
Pause the publication workflow during the branch renaming

### DIFF
--- a/.github/workflows/publish_v3.yml
+++ b/.github/workflows/publish_v3.yml
@@ -1,11 +1,11 @@
 on:
-  push:
-    branches:
-      - development/v3.0.1
-  repository_dispatch:
-    types:
-      - publish_v3_spec
-  workflow_dispatch: {}
+  # push:
+  #   branches:
+  #     - development/v3.0.1
+  # repository_dispatch:
+  #   types:
+  #     - publish_v3_spec
+  workflow_dispatch: {}  # Manually trigger from https://github.com/spdx/spdx-spec/actions
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- A follow up from https://github.com/spdx/spdx-spec/pull/1146#issuecomment-2477602610
- This PR will pause the publication automation by commenting out events to listens (in order to trigger the workflow)
- This is a measure to make sure that the publication workflow will not automatically run during the branch renaming process
- Once branch renaming process is done, we should bring these event listening lines back.