### PR TITLE
Drop "v" from the 3.0.1 tag name in a link in change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,11 @@ All notable changes to this project will be documented in this file.
   * [SPDX License List matching guidelines and templates](./docs/annexes/license-matching-guidelines-and-templates.md)
 * [SPDX Lite](./docs/annexes/spdx-lite.md) has been updated with more explicit
   sections on "Mandatory" and "Recommended" properties.
-* See the fixes in the model from
+* See changes in the model from
   [the model change log](https://github.com/spdx/spdx-3-model/blob/main/CHANGELOG.md).
 
-See the v3.0.1 GitHub release notes for changes
-[in the spec](https://github.com/spdx/spdx-spec/releases/tag/v3.0.1) and
+See the 3.0.1 GitHub release notes for changes
+[in the spec](https://github.com/spdx/spdx-spec/releases/tag/3.0.1) and
 [in the model](https://github.com/spdx/spdx-3-model/releases/tag/3.0.1).
 
 ## 3.0 (2024-04-15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## 3.0.1 (2024-10-04)
+## 3.0.1 (2024-11-13)
 
 * Changes in document structure and location.
   The following documents are now located in the


### PR DESCRIPTION
Tech Team Meeting 2024-11-05 agrees to drop "v" from the branch name.

Should this also be applied to the tag name as well?

If so, this PR is to update a link to 3.0.1 release notes,
from this: https://github.com/spdx/spdx-spec/releases/tag/v3.0.1
to this: https://github.com/spdx/spdx-spec/releases/tag/3.0.1

(Note that the page is not exist yet, until we have the tag.
The latest release notes that we have is at this URL:
https://github.com/spdx/spdx-spec/releases/tag/v3.0  )


Also update the date to the date of the latest merge.