### PR TITLE
Add English as normative notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,12 @@ as well as a model documentation generated from Markdown files within the
 
 Contributions, including translations, are welcome.
 Contributions to this repository are made pursuant to the
-[SPDX Community Specification Contributor License Agreement 1.0](https://github.com/spdx/governance/blob/main/0._SPDX_Contributor_License_Agreement.md).
+[SPDX Community Specification Contributor License Agreement 1.0][cla].
 Please see the contributing guidelines, governance practices,
 and build instructions in the
 [related documents](#related-documents-and-repositories) section.
+
+[cla]: https://github.com/spdx/governance/blob/main/0._SPDX_Contributor_License_Agreement.md
 
 ## Repository structure
 
@@ -71,7 +73,9 @@ This repository consists of these files and directories (partial):
 
 ## Branch structure
 
-The SPDX spec repo follows the [Gitflow](https://gist.github.com/HeratPatel/271b5d2304de2e2cd1823b9b62bf43e0) workflow with the addition of support branches.
+The SPDX spec repo follows the [Gitflow][gitflow] workflow with the addition of support branches.
+
+[gitflow]: https://gist.github.com/HeratPatel/271b5d2304de2e2cd1823b9b62bf43e0
 
 The branches in use are:
 
@@ -81,7 +85,6 @@ The branches in use are:
   Once released, the `develop` branch will be merged into the `main` branch.
 - `support/x.y` - These branches will be long-lived and contain any updates to
   a minor version of the specification.
-  Additions such as translations can be added to the support branch.
   `x.y` represents the MAJOR.MINOR version, following Semantic Versioning
   (SemVer) conventions.
   Once any changes are accepted and released, the support branch will be tagged

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ This repository consists of these files and directories (partial):
     `spdx/spdx-3-model` repo (see the [build instructions](./build.md)).
 - `examples/` - Examples of various SPDX serializations for the current version
   of the spec.
-- `rdf/` - Model RDF files. These ontology files are to be generated from model
-   Markdown files in the `spdx/spdx-3-model` repo and manually copied here.
+- `rdf/` - Model RDF files. These ontology files are generated from model
+  Markdown files in the `spdx/spdx-3-model` repo and manually copied here.
 - `mkdocs.yml` - MkDocs recipe for the spec documentation generation. The
   inclusion of model files and the order of chapters are defined here.
 
@@ -97,7 +97,6 @@ The branches in use are:
 
 | Documentation | Link |
 |---------|------|
-| Past release notes | [spdx/spdx-spec/releases](https://github.com/spdx/spdx-spec/releases) |
 | Changes between versions | [CHANGELOG.md](./CHANGELOG.md) |
 | Contributing guidelines | [CONTRIBUTING.md](./CONTRIBUTING.md) |
 | Building the specification website (for testing purpose) | [build.md](build.md) |

--- a/README.md
+++ b/README.md
@@ -12,24 +12,31 @@ the software supply chain. SPDX reduces redundant work by providing a common
 format for companies and communities to share important data about software
 licenses and copyrights, thereby streamlining and improving compliance.
 
+Current stable version:
+
+- The current stable specification is available at:
+  <https://spdx.github.io/spdx-spec/>
+
+Next version (work in progress):
+
+- A preview of the next version, currently under active development, is
+  available at:
+  <https://spdx.github.io/spdx-spec/develop/>
+  (This website is automatically updated with each commit to the `develop`
+  branch).
+
+Translations of the specification may be available.
+English remains the normative language in all cases.
+
 ## Specification development
 
-The specification is comprised of documents located in the `docs/` directory
-of this `spdx/spdx-spec` repository, as well as a model documentation
-generated from Markdown files within the
+The specification comprised of documents located in the [`docs/`](./docs/)
+directory of this `spdx/spdx-spec` repository,
+as well as a model documentation generated from Markdown files within the
 [spdx/spdx-3-model](https://github.com/spdx/spdx-3-model/) repository.
 
-This `spdx/spdx-spec` repository holds under active development version
-of the specification as:
-
-- Markdown:
-  [`development/v3.0.1`](https://github.com/spdx/spdx-spec/tree/development/v3.0.1/docs)
-  branch
-- HTML: `gh-pages` branch, built on every commit to the development branch
-  - Current stable (v3.0.1): <https://spdx.github.io/spdx-spec/v3.0.1/>
-<!--  - Development (v3.1): <https://spdx.github.io/spdx-spec/v3.1-draft/> -->
-
-Contributions are welcome. Contributions to this repository are made pursuant to the
+Contributions, including translations, are welcome.
+Contributions to this repository are made pursuant to the
 [SPDX Community Specification Contributor License Agreement 1.0](https://github.com/spdx/governance/blob/main/0._SPDX_Contributor_License_Agreement.md).
 Please see the contributing guidelines, governance practices,
 and build instructions in the
@@ -49,14 +56,16 @@ This repository consists of these files and directories (partial):
   - `front/` - Front matter.
   - `images/` - Model diagrams. These image files are to be generated from a
     diagram description file
-    [model.drawio](https://github.com/spdx/spdx-3-model/blob/main/model.drawio)
-    in `spdx/spdx-3-model` repo and manually copied here.
+    [model.drawio](https://github.com/spdx/spdx-3-model/blob/develop/docs/model.drawio)
+    in the `spdx/spdx-3-model` repo and manually copied here.
   - `licenses/` - Licenses that used by the SPDX specifications.
   - `model/` - Model files. This subdirectory _is to be created_ by a script
     from `spdx/spec-parser` repo, using model information from
-    `spdx/spdx-3-model` repo (see the build instructions below).
+    `spdx/spdx-3-model` repo (see the [build instructions](./build.md)).
 - `examples/` - Examples of various SPDX serializations for the current version
   of the spec.
+- `rdf/` - Model RDF files. These ontology files are to be generated from model
+   Markdown files in the `spdx/spdx-3-model` repo and manually copied here.
 - `mkdocs.yml` - MkDocs recipe for the spec documentation generation. The
   inclusion of model files and the order of chapters are defined here.
 
@@ -67,14 +76,28 @@ The SPDX spec repo follows the [Gitflow](https://gist.github.com/HeratPatel/271b
 The branches in use are:
 
 - `main` - This will always be the latest released specification.
-- `develop` - This branch will be where the active development for the next major or minor version takes place.  Once released, the `develop` branch will be merged into the `main` branch.
-- `support/x.y` - These branches will be long lived and contain any updates to a minor version of the specification.  Additions such as translations can be added to the support branch.  `x.y` represents the major.minor version.  Once any changes are accepted and released, the support branch will be tagged and merged into both the develop and main branches.
-- General feature or fix branches - there may be feature branches made for specific enhancements or fixes to the spec.  These will be short lived and merged into either a support branch or the develop branch.
+- `develop` - This branch will be where the active development for the next
+  major or minor version takes place.
+  Once released, the `develop` branch will be merged into the `main` branch.
+- `support/x.y` - These branches will be long-lived and contain any updates to
+  a minor version of the specification.
+  Additions such as translations can be added to the support branch.
+  `x.y` represents the MAJOR.MINOR version, following Semantic Versioning
+  (SemVer) conventions.
+  Once any changes are accepted and released, the support branch will be tagged
+  and merged into both `develop` and `main` branches.
+- General feature or fix branches - there may be feature branches made for
+  specific enhancements or fixes to the spec.
+  These will be short-lived and merged into either a `support` branch or the
+  `develop` branch.
+- `gh-pages` - This branch hosts generated HTML websites for all versions of
+  the specification. It is primarily managed by an automated workflow.
 
 ## Related documents and repositories
 
 | Documentation | Link |
 |---------|------|
+| Past release notes | [spdx/spdx-spec/releases](https://github.com/spdx/spdx-spec/releases) |
 | Changes between versions | [CHANGELOG.md](./CHANGELOG.md) |
 | Contributing guidelines | [CONTRIBUTING.md](./CONTRIBUTING.md) |
 | Building the specification website (for testing purpose) | [build.md](build.md) |


### PR DESCRIPTION
- Add "English remains the normative language in all cases" notes (addressing one todo in #1169)
- Update branch mentions to current branch names
- Move `gh-pages` branch description to "Branch structure" section
- Add `rdf/` directory description