### PR TITLE
Update publish CI for support/2.3 branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,17 +1,17 @@
 on: 
   push:
-    branches: [master, development/v2.3]
+    branches: [support/2.3]
 
 jobs:
   build_current:
-    name: Build current
-    if: github.ref == 'refs/heads/master'
+    name: Build v2.3
+    if: github.ref == 'refs/heads/support/2.3'
     runs-on: ubuntu-latest
     container: python:3
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  #v4.2.2
       with:
-        ref: 'master'
+        ref: 'support/2.3'
     - name: Install pre-requisites
       run: pip install -r requirements.txt
     - name: Build
@@ -19,19 +19,19 @@ jobs:
     - name: Schema
       run: generate-schema-doc schemas/spdx-schema.json site/spdx-json-schema.html
     - name: Upload
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b  # v4.5.0
       with:
-        name: site-current
+        name: site-v2.3
         path: ./site
   build_v2-draft:
-    name: Build v2-draft
-    if: github.ref == 'refs/heads/development/v2.3'
+    name: Build v2.3.1-draft
+    if: github.ref == 'refs/heads/support/2.3.1'
     runs-on: ubuntu-latest
     container: python:3
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  #v4.2.2
       with:
-        ref: 'development/v2.3'
+        ref: 'support/2.3.1'
     - name: Install pre-requisites
       run: pip install -r requirements.txt
     - name: Build
@@ -39,27 +39,27 @@ jobs:
     - name: Schema
       run: generate-schema-doc schemas/spdx-schema.json site/spdx-json-schema.html
     - name: Upload
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b  #v4.5.0
       with:
-        name: site-v2-draft
+        name: site-v2.3.1-draft
         path: ./site
   publish:
     name: Publish
     runs-on: ubuntu-latest
     needs: [build_current, build_v2-draft]
     steps:
-    - name: Download current
-      uses: actions/download-artifact@v1
+    - name: Download v2.3
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  #v4.1.8
       with:
-        name: site-current
-        path: ./site
-    - name: Download v2-draft
-      uses: actions/download-artifact@v1
+        name: site-v2.3
+        path: ./site/v2.3
+    - name: Download v2.3.1-draft
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  #v4.1.8
       with:
-        name: site-v2-draft
-        path: ./site/v2-draft
+        name: site-v2.3.1-draft
+        path: ./site/v2.3.1-draft
     - name: Deploy
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e  #v4.0.0
       with:
         DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
         PUBLISH_BRANCH: gh-pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 on: 
   push:
-    branches: [support/2.3]
+    branches: [support/2.3, support/2.3.1]
+  workflow_dispatch:
 
 jobs:
   build_current:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,15 +16,15 @@ jobs:
     - name: Install pre-requisites
       run: pip install -r requirements.txt
     - name: Build
-      run: mkdocs build -v --clean
+      run: mkdocs build --verbose --clean
     - name: Schema
       run: generate-schema-doc schemas/spdx-schema.json site/spdx-json-schema.html
     - name: Upload
-      uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b  # v4.5.0
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  #v4.6.2
       with:
         name: site-v2.3
         path: ./site
-  build_v2-draft:
+  build_draft:
     name: Build v2.3.1-draft
     if: github.ref == 'refs/heads/support/2.3.1'
     runs-on: ubuntu-latest
@@ -36,26 +36,26 @@ jobs:
     - name: Install pre-requisites
       run: pip install -r requirements.txt
     - name: Build
-      run: mkdocs build -v --clean
+      run: mkdocs build --verbose --clean
     - name: Schema
       run: generate-schema-doc schemas/spdx-schema.json site/spdx-json-schema.html
     - name: Upload
-      uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b  #v4.5.0
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  #v4.6.2
       with:
         name: site-v2.3.1-draft
         path: ./site
   publish:
     name: Publish
     runs-on: ubuntu-latest
-    needs: [build_current, build_v2-draft]
+    needs: [build_current, build_draft]
     steps:
     - name: Download v2.3
-      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  #v4.1.8
+      uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  #v4.2.1
       with:
         name: site-v2.3
         path: ./site/v2.3
     - name: Download v2.3.1-draft
-      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  #v4.1.8
+      uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  #v4.2.1
       with:
         name: site-v2.3.1-draft
         path: ./site/v2.3.1-draft

--- a/.github/workflows/publish_common.yml
+++ b/.github/workflows/publish_common.yml
@@ -5,9 +5,9 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: Branch or tag to publish (e.g. refs/heads/development/v2).
+        description: Branch or tag to publish (e.g. refs/heads/support/2.3).
         required: true
-        default: refs/heads/master
+        default: refs/heads/support/2.3
       aliases:
         description: Space-delimited aliases to publish (e.g. latest v2-latest).
         required: false
@@ -16,14 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     container: python:3.9
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  #v4.2.2
       with:
         ref: ${{ github.event.client_payload.ref || github.event.inputs.ref }}
         fetch-depth: 0 # Because we will be pushing the gh-pages branch
     - name: Install pre-requisites
       run: pip install -r requirements.txt
     - name: Install mike
-      run: pip install mike==1.1.2
+      run: pip install mike==2.1.3
     - name: Extract branch or tag name
       id: extract-branch-or-tag-name
       run: echo "::set-output name=ref_name::${REF##*/}"

--- a/.github/workflows/publish_common.yml
+++ b/.github/workflows/publish_common.yml
@@ -26,7 +26,7 @@ jobs:
       run: pip install mike==2.1.3
     - name: Extract branch or tag name
       id: extract-branch-or-tag-name
-      run: echo "::set-output name=ref_name::${REF##*/}"
+      run: echo "::set-output name=ref_name::v${REF##*/}"
       env:
         REF: ${{ github.event.client_payload.ref || github.event.inputs.ref }}
     - name: Set Git identity
@@ -34,4 +34,4 @@ jobs:
         git config user.name github-actions
         git config user.email github-actions@github.com
     - name: Build docs
-      run: mike deploy -p ${{ steps.extract-branch-or-tag-name.outputs.ref_name }} ${{ github.event.inputs.aliases }}
+      run: mike deploy --update-aliases --push ${{ steps.extract-branch-or-tag-name.outputs.ref_name }} ${{ github.event.inputs.aliases }}

--- a/.github/workflows/validate_pull_request.yml
+++ b/.github/workflows/validate_pull_request.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     container: python:3
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  #v4.2.2
       with:
         fetch-depth: 1
     - name: Install pre-requisites

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: specification v2.3.0
+site_name: SPDX Specification 2.3.0
 docs_dir: chapters
 theme: readthedocs
 extra_css:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-mkdocs==1.3.1
-json-schema-for-humans==0.39.5
-
+json-schema-for-humans==1.3.4
+mkdocs==1.6.1


### PR DESCRIPTION
- To merge a PR like #1114, we need to make sure that the publishing CI for v2.3 (and v2.3.1) is working for new `support/2.3` branch name
- `support/2.3.1` here is considered a development branch for `support/2.3` (which should be eventually merged to the `support/2.3`)