### PR TITLE
Update "main" branch publish workflow to use source from "main" of spdx-spec & spdx-3-model

### DIFF
--- a/.github/workflows/publish_v3.yml
+++ b/.github/workflows/publish_v3.yml
@@ -1,12 +1,12 @@
 # Publish SPDX specification to https://spdx.github.io/spdx-spec/
 #
-# There will be this workflow in "main", "develop", and "support" branches.
-# Each of them publish to a different URL.
+# This workflow is configured differently for the
+# "main", "develop", and "support" branches, each publishing to a unique URL.
 #
 # For example,
-# the workflow in "main" may publish to https://spdx.github.io/spdx-spec/3.0.1/,
-# the workflow in "develop" may publish to https://spdx.github.io/spdx-spec/3.1-dev/,
-# the workflow in "support/3.0" may publish to https://spdx.github.io/spdx-spec/3.0.0/.
+# the workflow in "main" may publish to https://spdx.github.io/spdx-spec/v3.0.1/,
+# the workflow in "develop" may publish to https://spdx.github.io/spdx-spec/v3.1-dev/,
+# the workflow in "support/3.0" may publish to https://spdx.github.io/spdx-spec/v3.0.x/.
 #
 # The workflow should be configured to have an URL without a version number
 # specified be redirected to an URL published from "main" branch.
@@ -40,17 +40,17 @@ jobs:
     env:
       REF_SPEC: "main"                      # spdx-spec branch:    "main" or "develop" or "support/x.y" or tag/commit ID
       REF_MODEL: "main"                     # spdx-3-model branch: "main" or "develop" or "support/x.y" or tag/commit ID
-      REF_PARSER: "main"                    # spec-parser branch:  "main" or commit ID
+      REF_PARSER: "main"                    # spec-parser branch:  "main" or tag/commit ID
       GH_PAGES_BRANCH: "gh-pages"           # spdx-spec branch to publish HTML to
       VERSION_DEFAULT: "v3.0.1"             # Default version:
                                             # - A version to be redirected to from the URL without
                                             #   a version number specified
-                                            # - Should be a latest stable version from "main" branch
-                                            # - VERSION_DEFAULT should be the same in this workflow
-                                            #   across all branches/tags
-                                            # - VERSION_DEFAULT should also match with the
+                                            # - Should be the latest stable version from the "main" branch
+                                            # - VERSION_DEFAULT should be the same across all
+                                            #   branches/tags
+                                            # - VERSION_DEFAULT should also match the
                                             #   mike's canonical_version in mkdocs.yml
-      VERSION: "v3.0.1"                     # Publishing version, to be publish by this workflow:
+      VERSION: "v3.0.1"                     # Publishing version, to be published from this branch:
                                             # - VERSION can be different from VERSION_DEFAULT;
                                             #   For example, if VERSION is a draft/release candidate,
                                             #   or if VERSION is a stable version that is behind the
@@ -76,10 +76,6 @@ jobs:
                                             # - Versions like "v3.0" will be expanded to "v3.0 3.0"
       GIT_USER_NAME: "ci-bot"               # Username for gh-pages commit
       GIT_USER_EMAIL: "ci-bot@spdx.dev"     # E-mail for gh-pages commit
-      PARSER_OUT_BASE_DIR: "__parser_out"   # Temporary dir for output from spec-parser
-      PARSER_OUT_RDF_DIR: "rdf"             # Contains RDFs and schema; relative to PARSER_OUT_BASE_DIR
-      PARSER_OUT_MKDOCS_DIR: "mkdocs"       # Contains model Markdown files:
-                                            # - relative to PARSER_OUT_BASE_DIR
       MKDOCS_MODEL_YML: "model-files.yml"   # Contains list of model Markdown files:
                                             # - relative to PARSER_OUT_BASE_DIR
       MKDOCS_BASE_YML: "mkdocs.yml"         # Initial MkDocs configuration; from spdx-spec repo
@@ -89,9 +85,10 @@ jobs:
       REDIRECT_TEMPLATE_PATH: "etc/redirect-template.html"  # URL redirect HTML template
     steps:
       - name: Expand version aliases to include a version without 'v' prefix
-        # VERSION: "v3.0.1"
-        # Original VERSION_ALIASES: "latest v3.0"
-        # Expanded VERSION_ALIASES: "3.0.1 latest v3.0 3.0"
+        # For example, given
+        # - VERSION: "v3.0.1"; and
+        # - Original VERSION_ALIASES: "latest v3.0"
+        # the expanded VERSION_ALIASES will be "3.0.1 latest v3.0 3.0"
         run: |
           echo VERSION: $VERSION
           echo Original VERSION_ALIASES: $VERSION_ALIASES
@@ -133,7 +130,7 @@ jobs:
           ref: ${{ env.REF_PARSER }}
           path: spec-parser
       - name: Set up specific Python version
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  #v5.3.0
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  #v5.4.0
         with:
           python-version: "3.12"
           cache: "pip"
@@ -141,52 +138,41 @@ jobs:
         run: pip install -r spdx-spec/requirements.txt
       - name: Install pre-requisites for spec-parser
         run: pip install -r spec-parser/requirements.txt
-      - name: Install fake pandoc (to bypass the Tex generation by spec-parser)
-        run: |
-          echo "#!/bin/sh" > /usr/local/bin/pandoc
-          echo "exit 0" >> /usr/local/bin/pandoc
-          chmod +x /usr/local/bin/pandoc
       - name: Build model files
-        run: python3 spec-parser/main.py spdx-3-model/model $PARSER_OUT_BASE_DIR
-      - name: Create directories for model (MkDocs) and RDF files
+        # Also move the model file list to spdx-spec/ directory,
+        # as it should not be part of the publicly accessible website.
         run: |
-          mkdir -p spdx-spec/docs/rdf
-          mkdir -p spdx-spec/docs/model
+          python3 spec-parser/main.py --force --generate-rdf --output-rdf spdx-spec/docs/rdf --generate-mkdocs --output-mkdocs spdx-spec/docs/model --generate-plantuml --output-plantuml spdx-spec/docs/diagram --generate-jsondump --output-jsondump spdx-spec/docs/jsondump spdx-3-model/model
+          mv spdx-spec/docs/model/$MKDOCS_MODEL_YML spdx-spec/
       - name: Copy JSON annotations
-        # Will be redirected from https://spdx.org/rdf/3.0.x/spdx-json-serialize-annotations.ttl
-        # and available at https://spdx.github.io/spdx-spec/v3.0.x/rdf/jsonld-annotations.ttl
+        # JSON annotations URL will be redirected
+        # from https://spdx.org/rdf/<version>/spdx-json-serialize-annotations.ttl
+        # to https://spdx.github.io/spdx-spec/v<version>/rdf/jsonld-annotations.ttl
+        #
+        # To maintain availability of files at the old location at
+        # https://spdx.github.io/spdx-spec/v3.0/model/<filename>,
+        # another copy will be made into spdx-spec/docs/model/.
+        #
         # Note: When release a new version, update the content of annotations.ttl to match the version
         run: |
           cp spdx-spec/serialization/jsonld/annotations.ttl spdx-spec/docs/rdf/jsonld-annotations.ttl
           cp spdx-spec/serialization/jsonld/annotations.ttl spdx-spec/docs/model/jsonld-annotations.ttl
       - name: Copy JSON-LD context and RDFs
-        # Will be redirected from https://spdx.org/rdf/3.0.x/spdx-context.jsonld, spdx-model.ttl, etc.
-        # and available at https://spdx.github.io/spdx-spec/v3.0.x/rdf/spdx-context.jsonld
+        # JSON-LD context and RDF URLs will be redirected
+        # from https://spdx.org/rdf/<version>/spdx-context.jsonld, spdx-model.ttl, etc.
+        # to https://spdx.github.io/spdx-spec/v<version>/rdf/spdx-context.jsonld, etc.
+        #
+        # Make a copy of spdx-model.json-ld as spdx-model.jsonld,
+        # because we have spdx-context.jsonld.
         run: |
-          echo "===================="
-          echo "Source: $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR"
-          echo "--------------------"
-          ls $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR
-          echo "===================="
-          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-context.jsonld spdx-spec/docs/rdf/
-          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-model.* spdx-spec/docs/rdf/
           cp spdx-spec/docs/rdf/spdx-model.json-ld spdx-spec/docs/rdf/spdx-model.jsonld
-          echo "===================="
-          echo "Target (after copy): spdx-spec/docs/rdf"
-          echo "--------------------"
-          ls spdx-spec/docs/rdf
-          echo "===================="
-          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-context.jsonld spdx-spec/docs/model/
-          cp $PARSER_OUT_BASE_DIR/$PARSER_OUT_RDF_DIR/spdx-model.* spdx-spec/docs/model/
-          cp spdx-spec/docs/model/spdx-model.json-ld spdx-spec/docs/model/spdx-model.jsonld
-          echo "===================="
-          echo "Target (after copy): spdx-spec/docs/model"
-          echo "--------------------"
-          ls spdx-spec/docs/model
-          echo "===================="
+          cp spdx-spec/docs/rdf/spdx-context.jsonld spdx-spec/docs/model/
+          cp spdx-spec/docs/rdf/spdx-model.* spdx-spec/docs/model/
       - name: Generate JSON schema
-        # Will be redirected from https://spdx.org/schema/3.0.x/spdx-json-schema.json
-        # and available at https://spdx.github.io/spdx-spec/v3.0.x/rdf/schema.json
+        # JSON schema URL will be redirected
+        # from https://spdx.org/schema/<version>/spdx-json-schema.json
+        # to https://spdx.github.io/spdx-spec/v<version>/rdf/schema.json
+        #
         # Note: When release a new version, update URL in --context-url line to match the version 
         run: |
           shacl2code generate \
@@ -196,15 +182,6 @@ jobs:
             jsonschema \
             --output spdx-spec/docs/rdf/schema.json
           cp spdx-spec/docs/rdf/schema.json spdx-spec/docs/model/schema.json
-      - name: Copy model Markdown files and a model file list for MkDocs
-        # Will be available at https://spdx.github.io/spdx-spec/v3.0.x/model/*
-        run: |
-          cp -R $PARSER_OUT_BASE_DIR/$PARSER_OUT_MKDOCS_DIR/* spdx-spec/docs/model
-          cp $PARSER_OUT_BASE_DIR/$MKDOCS_MODEL_YML spdx-spec
-        # mkdir -p spdx-spec/docs/diagram
-        # cp $PARSER_OUT_BASE_DIR/diagram/model.plantuml spdx-spec/docs/diagram
-        # mkdir -p spdx-spec/docs/jsondump
-        # cp $PARSER_OUT_BASE_DIR/jsondump/model.json spdx-spec/docs/jsondump
       - name: Set Git identity
         working-directory: spdx-spec
         run: git config user.name $GIT_USER_NAME; git config user.email $GIT_USER_EMAIL
@@ -243,7 +220,7 @@ jobs:
           for alias in $VERSION_ALIASES; do
             mike delete --config-file "$MKDOCS_FULL_YML" --branch $GH_PAGES_BRANCH --push --allow-empty "$alias" || true
           done
-          mike deploy --update-aliase --config-file "$MKDOCS_FULL_YML" --branch $GH_PAGES_BRANCH --push $VERSION $VERSION_ALIASES
+          mike deploy --update-aliases --config-file "$MKDOCS_FULL_YML" --branch $GH_PAGES_BRANCH --push $VERSION $VERSION_ALIASES
       - name: Set default version
         # Set default version to VERSION_DEFAULT;
         # if not set, the default version will remain the same.

--- a/.github/workflows/publish_v3.yml
+++ b/.github/workflows/publish_v3.yml
@@ -245,9 +245,14 @@ jobs:
           dirs="$VERSION_ALIASES"
           for dir in $dirs; do
             mkdir -p "$dir"/rdf
+            mkdir -p "$dir"/model
             cp $VERSION/rdf/* "$dir"/rdf
             cp $VERSION/rdf/* "$dir"/model
-            git add "$dir"/rdf/* "$dir"/model/*
+            mkdir -p "$dir"/diagram
+            cp $VERSION/diagram/* "$dir"/diagram
+            mkdir -p "$dir"/jsondump
+            cp $VERSION/jsondump/* "$dir"/jsondump
+            git add "$dir"/rdf/* "$dir"/model/* "$dir"/diagram/* "$dir"/jsondump/*
           done
           git commit -m "Copy schema and RDFs to alias directories: $VERSION_ALIASES"
           git push origin $GH_PAGES_BRANCH

--- a/.github/workflows/publish_v3.yml
+++ b/.github/workflows/publish_v3.yml
@@ -38,10 +38,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      REF_SPEC: "develop"                   # spdx-spec branch: "main" or "develop" or "support/x.y"
-      REF_MODEL: "main"                     # spdx-3-model branch: "main" or "develop" or "support/x.y"
-      REF_PARSER: "main"                    # spdx-3-model branch: "main" or "develop" or "support/x.y"
-                                            # (now we have only "main" for spdx-3-model and spec-parser)
+      REF_SPEC: "main"                      # spdx-spec branch:    "main" or "develop" or "support/x.y" or tag/commit ID
+      REF_MODEL: "main"                     # spdx-3-model branch: "main" or "develop" or "support/x.y" or tag/commit ID
+      REF_PARSER: "main"                    # spec-parser branch:  "main" or commit ID
       GH_PAGES_BRANCH: "gh-pages"           # spdx-spec branch to publish HTML to
       VERSION_DEFAULT: "v3.0.1"             # Default version:
                                             # - A version to be redirected to from the URL without

--- a/.github/workflows/publish_v3.yml
+++ b/.github/workflows/publish_v3.yml
@@ -28,7 +28,7 @@
 on:
   push:
     branches:
-      - develop          # This should match with REF_SPEC,
+      - main             # This should match with REF_SPEC,
                          # to automatically publish from a correct branch
   repository_dispatch:
     types:
@@ -259,7 +259,7 @@ jobs:
         # For example,
         # - https://spdx.github.io/spdx-spec/v3.0/model/schema.json (old directory structure)
         # - https://spdx.github.io/spdx-spec/v3.0.1/rdf/schema.json (new directory structure)
-        # will all accessible and have the same content.
+        # will all be accessible and have the same content.
         # Unlike HTML files, these files have to be a copy,
         # since it cannot use the HTML refresh mechanism.
         working-directory: spdx-spec

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_description: The System Package Data Exchange (SPDX) Specification Version 
 site_author: The Linux Foundation and its Contributors, including SPDX Model contributions from OMG and its Contributors.
 site_url: https://spdx.github.io/spdx-spec/  # set to the "root" of the site, to be combined with canonical_version
 repo_url: https://github.com/spdx/spdx-spec/
-edit_uri: ""  # set to an empty string to disable edit links; to enable, set to blob/development/v3.0.1/docs/
+edit_uri: ""  # set to an empty string to disable edit links; to enable, set to blob/<branch_name>/docs/
 copyright: SPDX v3.0.1 Copyright © 2010-2024, The Linux Foundation and its Contributors, including SPDX Model contributions from OMG and its Contributors.
 use_directory_urls: true
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,8 +12,9 @@ theme:
 plugins:
 - search
 - mike:
-    canonical_version: v3.0.1  # tell search engines to prefer the URL of v3.0.1
-    alias_type: redirect  # use redirect so it can redirect every pages (not just the root of the version)
+    canonical_version: v3.0.1  # Tell search engines to prefer the URL of the default version.
+                               # This should matches with VERSION_DEFAULT in .github/workflows/publish_v3yml
+    alias_type: redirect       # use "redirect" so it can redirect every pages (not just the root of the version)
 # - pdf-export:
 #     combined: true
 #     media_type: print

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ mike==2.1.3
 mkdocs==1.6.1
 # mkdocs-pdf-export-plugin==0.5.10
 PyYAML==6.0.2
-shacl2code==0.0.16
+shacl2code==0.0.20


### PR DESCRIPTION
## Background

- "main" branch as its current form was not existed at the time of the latest publication workflow update.
- New spec-parser CLI
  - Position of input directory is changed and specifying the output directory requires an option `-o`
  - The current command line no longer works

## What this PR does?

- Updating the workflow in the "main" branch to use the source from spdx-spec "main" branch.
  - This goes according to the [current branch structure](https://github.com/spdx/spdx-spec/blob/develop/README.md#branch-structure)
- Updating command line for spec-parser
  - As we can specify output directories, some of the copy steps are no longer necessary and now removed
  - The same command line is also get updated in the build doc #1186

**This PR is targetting "main" branch.**