### PR TITLE
Update build doc for new spec-parser options

### DIFF
--- a/build.md
+++ b/build.md
@@ -6,6 +6,9 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 # Building the specification website
 
+You may like to build the specification website locally to test your additions
+and edits.
+
 The specification website building flow looks like this:
 
 ```text
@@ -29,7 +32,7 @@ The specification website building flow looks like this:
   | +- mkdocs.yml     |
   +-------------------+
           |
-       mkdocs
+       MkDocs
           |
           v
   +-------------------+
@@ -40,6 +43,19 @@ The specification website building flow looks like this:
   | +- index.html     |
   +-------------------+
 ```
+
+## Table of contents
+
+1. [Prerequisites](#1-prerequisites)
+1. [Getting input files](#2-getting-input-files)
+1. [Processing model files (Markdown and RDF)](#3-processing-model-files-markdown-and-rdf)
+
+    - [Generating model files with spec-parser](#31-generating-model-files-with-spec-parser)
+    - [Generating a complete MkDocs configuration file](#32-generating-a-complete-mkdocs-configuration-file)
+
+1. [Building HTML](#4-building-html)
+1. [Configuring the website](#5-configuring-the-website)
+1. [Specification versions on spdx.github.io](#6-specification-versions-on-spdxgithubio)
 
 ## 1. Prerequisites
 
@@ -106,7 +122,8 @@ python3 spec-parser/main.py --force \
   spdx-3-model/model
 ```
 
-The command will read the input from `spdx-3-model/model` and generate:
+The command will ask the spec-parser to read the input from
+`spdx-3-model/model` and generate:
 
 - Ontology (RDF) files, including
   `spdx-context.jsonld`, `spdx-model.json-ld`, `spdx-model.ttl`, etc.
@@ -126,10 +143,10 @@ later use:
 mv spdx-spec/docs/model/model-files.yml spdx-spec/
 ```
 
-### 3.2 Generate a complete MkDocs configuration file
+### 3.2 Generating a complete MkDocs configuration file
 
 To ensure MkDocs recognizes the new Markdown files,
-insert the model file list from `spdx-spec/model-files.yml`
+insert the model file list from `model-files.yml`
 into the MkDocs configuration file in `spdx-spec/mkdocs.yml`,
 by using this command:
 
@@ -149,7 +166,7 @@ we will use MkDocs to assemble them into a website.
 
 *Note: all the commands below use the configuration file*
 *with the model file list, `mkdocs-full.yml`,*
-*generated in [step 3.2](#32-generate-a-complete-mkdocs-configuration-file).*
+*generated in [step 3.2](#32-generating-a-complete-mkdocs-configuration-file).*
 *If you only want to review the non-model part of the specification*
 *(have skipped step 3), please use `mkdocs.yml` instead.*
 
@@ -186,7 +203,7 @@ section. The order of filenames in this section determines the order of the
 page in the navigation bar.
 
 After you have modified the configuration file, you may need to rerun
-[step 3.2](#32-generate-a-complete-mkdocs-configuration-file)
+[step 3.2](#32-generating-a-complete-mkdocs-configuration-file)
 to incorporate the changes into the complete configuration file.
 
 ## 6. Specification versions on spdx.github.io

--- a/build.md
+++ b/build.md
@@ -100,7 +100,7 @@ pip3 install -r spec-parser/requirements.txt
 *(e.g., chapters and annexes), you can skip to [step 4](#4-building-html).*
 
 Model files in `spdx/spdx-3-model` repository are written in a constrained
-Markdown format, with [a limited set of allowed headings][format].
+Markdown format, with [a predefined set of section headings][format].
 The `spec-parser` processes these model files to generate both ontology files
 and final Markdown files suitable for MkDocs.
 

--- a/build.md
+++ b/build.md
@@ -125,7 +125,7 @@ placing them in the `spdx-spec/docs/model/` directory.
 These files will then be used by MkDocs.
 
 An `spdx-spec/docs/model/model-files.yml` file will also be generated.
-This file contains a list of the files within `spdx-spec/docs/model`
+This file contains a list of the files within `spdx-spec/docs/model/`
 and will be used later for MkDocs configuration.
 We will move this `model-files.yml` file to the `spdx-spec/` directory
 for subsequent use:

--- a/build.md
+++ b/build.md
@@ -6,10 +6,8 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 # Building the specification website
 
-You may like to build the specification website locally to test your additions
-and edits.
-
-The specification website building flow looks like this:
+You may want to build the specification website locally to test your additions
+and edits and review if they render as intended.
 
 ```text
   +-------------------+
@@ -117,27 +115,20 @@ prepare them for MkDocs, run the following command:
 
 ```shell
 python3 spec-parser/main.py --force \
-  --generate-rdf --output-rdf spdx-spec/docs/rdf \
-  --generate-mkdocs --output-mkdocs spdx-spec/docs/model \
-  spdx-3-model/model
+  --generate-mkdocs --output-mkdocs spdx-spec/docs/model/ \
+  spdx-3-model/model/
 ```
 
-The command will ask the spec-parser to read the input from
-`spdx-3-model/model` and generate:
-
-- Ontology (RDF) files, including
-  `spdx-context.jsonld`, `spdx-model.json-ld`, `spdx-model.ttl`, etc.
-  and put them in `spdx-spec/docs/rdf` directory.
-  These files are ready for immediate use.
-- Processed Markdown files (`.md`)
-  and put them in `spdx-spec/docs/model` directory.
-  These files will be used by MkDocs in the next step.
+The command will instruct the spec-parser to read the input from 
+`spdx-3-model/model/` and generate processed Markdown files (`.md`),
+placing them in the `spdx-spec/docs/model/` directory.
+These files will then be used by MkDocs.
 
 An `spdx-spec/docs/model/model-files.yml` file will also be generated.
-It contains a list of the files within `spdx-spec/docs/model`
-and will be used for MkDocs configuration later.
-We will move this `model-files.yml` to `spdx-spec/` root directory for
-later use:
+This file contains a list of the files within `spdx-spec/docs/model`
+and will be used later for MkDocs configuration.
+We will move this `model-files.yml` file to the `spdx-spec/` directory
+for subsequent use:
 
 ```shell
 mv spdx-spec/docs/model/model-files.yml spdx-spec/

--- a/build.md
+++ b/build.md
@@ -1,6 +1,7 @@
 ---
+SPDX-FileCopyrightText: Copyright 2024-2025 The SPDX Contributors
+SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: Community-Spec-1.0
-SPDX-FileCopyrightText: Copyright 2024 The SPDX Contributors
 ---
 
 # Building the specification website

--- a/build.md
+++ b/build.md
@@ -114,7 +114,7 @@ To verify the formatting of pre-processed model files and
 prepare them for MkDocs, run the following command:
 
 ```shell
-python3 spec-parser/main.py --force \
+python3 spec-parser/main.py \
   --generate-mkdocs --output-mkdocs spdx-spec/docs/model/ \
   spdx-3-model/model/
 ```

--- a/build.md
+++ b/build.md
@@ -1,5 +1,4 @@
 ---
-SPDX-FileCopyrightText: Copyright 2024-2025 The SPDX Contributors
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: Community-Spec-1.0
 ---

--- a/build.md
+++ b/build.md
@@ -83,7 +83,7 @@ pip3 install -r spec-parser/requirements.txt
 *(e.g., chapters and annexes), you can skip to [step 4](#4-building-html).*
 
 Model files in `spdx/spdx-3-model` repository are written in a constrained
-Markdown format, with a limited set of allowed headings.
+Markdown format, with [a limited set of allowed headings][format].
 The `spec-parser` processes these model files to generate both ontology files
 and final Markdown files suitable for MkDocs.
 
@@ -91,59 +91,47 @@ The `spec-parser` also performs automatic formatting on the resulting Markdown
 files. For instance, it converts a list under the "Properties" heading into a
 table.
 
+[format]: https://github.com/spdx/spdx-3-model/blob/develop/docs/format.md
+
 ### 3.1 Generating model files with spec-parser
 
 To verify the formatting of pre-processed model files and
 prepare them for MkDocs, run the following command:
 
 ```shell
-python3 spec-parser/main.py spdx-3-model/model parser_output
+python3 spec-parser/main.py --force --generate-rdf --output-rdf spdx-spec/docs/rdf --generate-mkdocs --output-mkdocs spdx-spec/docs/model spdx-3-model/model
 ```
 
-*(If `parser_output` already exists, the `spec-parser` will not overwrite it.)*
+The command will generate:
 
-The command will create files in the `parser_output` directory.
-Among its subdirectories, we're particularly interested in:
-
-- `parser_output/mkdocs` - Processed Markdown files for MkDocs:
-  These files (`.md` extension) are located in various
-  subdirectories and are intended for processing by MkDocs in the next step.
-- `parser_output/rdf` - Ontology (RDF) files:
-  These files (`spdx-context.jsonld`, `spdx-model.json-ld`, `spdx-model.n3`,
-  `spdx-model.pretty-xml`,`spdx-model.ttl`, `spdx-model.xml`, etc.)
-  are ready for immediate use.
-
-- `parser_output/mkdocs`: Processed Markdown files (`.md`) for MkDocs.
-  These files will be used by MkDocs in the next step.
-- `parser_output/rdf`: Ontology (RDF) files, including
+- Ontology (RDF) files, including
   `spdx-context.jsonld`, `spdx-model.json-ld`, `spdx-model.ttl`, etc.
+  and put them in `spdx-spec/docs/rdf` directory.
   These files are ready for immediate use.
+- Processed Markdown files (`.md`)
+  and put them in `spdx-spec/docs/model` directory.
+  These files will be used by MkDocs in the next step.
 
-Additionally, a `parser_output/model-files.yml` file will be generated.
-It contains a list of the files within `parser_output/mkdocs`
+An `spdx-spec/docs/model/model-files.yml` file will also be generated.
+It contains a list of the files within `spdx-spec/docs/model`
 and will be used for MkDocs configuration later.
-
-### 3.2 Copying the generated files
-
-Copy the processed Markdown files and ontology files to the `docs/` directory:
+We will move this `model-files.yml` to `spdx-spec/` root directory for
+later use:
 
 ```shell
-mkdir -p spdx-spec/docs/model
-mkdir -p spdx-spec/docs/rdf
-cp -R parser_output/mkdocs/* spdx-spec/docs/model 
-cp -R parser_output/rdf/* spdx-spec/docs/rdf
+mv spdx-spec/docs/model/model-files.yml spdx-spec/
 ```
 
-### 3.3 Generate a complete MkDocs configuration file
+### 3.2 Generate a complete MkDocs configuration file
 
 To ensure MkDocs recognizes the new Markdown files,
-insert the model file list from `parser_output/model-files.yml`
+insert the model file list from `spdx-spec/model-files.yml`
 into the MkDocs configuration file in `spdx-spec/mkdocs.yml`.
 
 ```shell
 spdx-spec/bin/make-mkdocs-config.sh \
   -b spdx-spec/mkdocs.yml \
-  -m parser_output/model-files.yml \
+  -m spdx-spec/model-files.yml \
   -f spdx-spec/mkdocs-full.yml
 ```
 

--- a/build.md
+++ b/build.md
@@ -99,10 +99,13 @@ To verify the formatting of pre-processed model files and
 prepare them for MkDocs, run the following command:
 
 ```shell
-python3 spec-parser/main.py --force --generate-rdf --output-rdf spdx-spec/docs/rdf --generate-mkdocs --output-mkdocs spdx-spec/docs/model spdx-3-model/model
+python3 spec-parser/main.py --force \
+  --generate-rdf --output-rdf spdx-spec/docs/rdf \
+  --generate-mkdocs --output-mkdocs spdx-spec/docs/model \
+  spdx-3-model/model
 ```
 
-The command will generate:
+The command will read the input from `spdx-3-model/model` and generate:
 
 - Ontology (RDF) files, including
   `spdx-context.jsonld`, `spdx-model.json-ld`, `spdx-model.ttl`, etc.
@@ -126,7 +129,8 @@ mv spdx-spec/docs/model/model-files.yml spdx-spec/
 
 To ensure MkDocs recognizes the new Markdown files,
 insert the model file list from `spdx-spec/model-files.yml`
-into the MkDocs configuration file in `spdx-spec/mkdocs.yml`.
+into the MkDocs configuration file in `spdx-spec/mkdocs.yml`,
+by using this command:
 
 ```shell
 spdx-spec/bin/make-mkdocs-config.sh \

--- a/build.md
+++ b/build.md
@@ -144,7 +144,7 @@ we will use MkDocs to assemble them into a website.
 
 *Note: all the commands below use the configuration file*
 *with the model file list, `mkdocs-full.yml`,*
-*generated in [step 3.3](#33-generate-a-complete-mkdocs-configuration-file).*
+*generated in [step 3.2](#32-generate-a-complete-mkdocs-configuration-file).*
 *If you only want to review the non-model part of the specification*
 *(have skipped step 3), please use `mkdocs.yml` instead.*
 
@@ -181,7 +181,7 @@ section. The order of filenames in this section determines the order of the
 page in the navigation bar.
 
 After you have modified the configuration file, you may need to rerun
-[step 3.3](#33-generate-a-complete-mkdocs-configuration-file)
+[step 3.2](#32-generate-a-complete-mkdocs-configuration-file)
 to incorporate the changes into the complete configuration file.
 
 ## 6. Specification versions on spdx.github.io

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,7 +44,7 @@ nav:
 - '4. Terms and definitions': terms-and-definitions.md
 - '5. Conformance': conformance.md
 - '6. Model and serializations': serializations.md
-- model:  # __MODEL_PLACEHOLDER__, to be replaced by content from mkdocs-files.yml. Please do not edit this line.
+- model:  # __MODEL_PLACEHOLDER__, to be replaced by content from model-files.yml. Please do not edit this line.
   - "__MODEL_PLACEHOLDER__": "https://example.com"  # allows mkdocs.yml to be build/tested without full model list. Please do not edit this line.
 - annexes:
   - 'A. RDF model definition and diagrams': annexes/rdf-model.md


### PR DESCRIPTION
- Refresh command line examples and related build steps to reflect the new spec-parser command line options and changing location of `model-files.yml`
- To resolve #1182