### PR TITLE
Adds trademark symbol on "System Package Data Exchange"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The System Package Data Exchange (SPDX®) Specification
+# The System Package Data Exchange™ (SPDX®) Specification
 
 The System Package Data Exchange (SPDX®) specification is an open standard
 designed to represent systems containing software components as

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# The System Package Data Exchange® (SPDX®) Specification Version 3.0.1
+# The System Package Data Exchange™ (SPDX®) Specification Version 3.0.1
 
 Copyright © 2010-2024, The Linux Foundation and its Contributors,
 including SPDX Model contributions from OMG and its Contributors.

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -1,6 +1,6 @@
 # Scope
 
-The System Package Data Exchange (SPDX®) specification defines an open standard
+The System Package Data Exchange™ (SPDX®) specification defines an open standard
 for communicating bill of materials (BOM) information for different topic
 areas.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: SPDX Specification 3.0.1
-site_description: The System Package Data Exchange (SPDX) Specification Version 3.0.1 - Open standard for creating Software Bills of Materials (SBOMs)
+site_description: The System Package Data Exchange™ (SPDX®) Specification Version 3.0.1 - Open standard for creating Software Bills of Materials (SBOMs)
 site_author: The Linux Foundation and its Contributors, including SPDX Model contributions from OMG and its Contributors.
 site_url: https://spdx.github.io/spdx-spec/  # set to the "root" of the site, to be combined with canonical_version
 repo_url: https://github.com/spdx/spdx-spec/

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     version = "3.0.1",
     author = "The Linux Foundation and SPDX Contributors",
     author_email = "spdx-tech@lists.spdx.org",
-    description = ("The System Package Data Exchange (SPDX®) specification is an open standard capable of representing systems with software components in as SBOMs (Software Bill of Materials) and other AI, data and security references supporting a range of risk management use cases."),
+    description = ("The System Package Data Exchange™ (SPDX®) specification is an open standard capable of representing systems with software components in as SBOMs (Software Bill of Materials) and other AI, data and security references supporting a range of risk management use cases."),
     license = "Community-Spec-1.0 AND CC-BY-3.0 AND MIT",
     keywords = "SPDX SBOM Software System Package Data Exchange SPDX-License-Identifier specification licenses license",
     url = "https://spdx.org",

--- a/submissions/OMG/front/cover.md
+++ b/submissions/OMG/front/cover.md
@@ -1,2 +1,1 @@
-
 # The System Package Data Exchange™ (SPDX®) Specification Version 3.0.1

--- a/submissions/OMG/front/cover.md
+++ b/submissions/OMG/front/cover.md
@@ -1,3 +1,2 @@
 
-# The System Package Data Exchange (SPDX) Specification Version 3.0.1
-
+# The System Package Data Exchange™ (SPDX®) Specification Version 3.0.1

--- a/submissions/OMG/front/second-page.md
+++ b/submissions/OMG/front/second-page.md
@@ -1,4 +1,4 @@
-# The System Package Data Exchange® (SPDX®) Specification Version 3.0.1
+# The System Package Data Exchange™ (SPDX®) Specification Version 3.0.1
 
 Copyright © 2010-2024, The Linux Foundation and its Contributors,
 including SPDX Model contributions from OMG and its Contributors.


### PR DESCRIPTION
Adds trademark symbol on instances of the phrase "System Package Data Exchange".

(similar to #1193 but for `support/3.0` branch)