### PR TITLE
SPDX 3 JSON format is a strict subset of JSON-LD

### DIFF
--- a/docs/serializations.md
+++ b/docs/serializations.md
@@ -93,9 +93,8 @@ element.
 ## Serialization in SPDX 3 JSON
 
 The SPDX 3 JSON format is a strict subset of JSON-LD.
-Instances of SPDX 3 JSON shall be serialized in strict accordance with the
-defined serialization specification and validated against the provided
-SPDX 3 JSON Schema.
+It requires data to be serialized according to the defined serialization
+specification and validated against the SPDX 3 JSON Schema.
 It may be parsed – not serialized – using standard JSON-LD libraries.
 
 ### JSON-LD context file

--- a/docs/serializations.md
+++ b/docs/serializations.md
@@ -52,7 +52,7 @@ with the following additional characteristics:
 - Integers: represented in base 10 using decimal digits. This designates an
   integer component that may be prefixed with an optional minus sign.
   Leading zeros are not allowed.
-- Strings: UTF-8 representation without specific canonicalisation. A string
+- Strings: UTF-8 representation without specific canonicalization. A string
   begins and ends with quotation marks (%x22). Any Unicode characters may be
   placed within the quotation marks, except for the two characters that MUST be
   escaped by a reverse solidus: quotation mark, reverse solidus, and the
@@ -90,7 +90,13 @@ A serialization must not contain more than one SpdxDocument.
 A given instance of serialization must not define more than one SpdxDocument
 element.
 
-## Serialization in JSON-LD
+## Serialization in SPDX 3 JSON
+
+The SPDX 3 JSON format is a strict subset of JSON-LD.
+Instances of SPDX 3 JSON shall be serialized in strict accordance with the
+defined serialization specification and validated against the provided
+SPDX 3 JSON Schema.
+It may be parsed – not serialized – using standard JSON-LD libraries.
 
 ### JSON-LD context file
 
@@ -126,16 +132,16 @@ An SPDX serialization in JSON-LD format is considered conformant to the SPDX
 specification if it adheres to the following two validation criteria:
 
 - Structural validation: The JSON-LD document must structurally validate
-  against the SPDX JSON Schema. This schema defines the expected structure of
+  against the SPDX 3 JSON Schema. This schema defines the expected structure of
   the JSON-LD document, including the required elements, data types, and
   permissible values.
 - Semantic validation: The JSON-LD document must successfully validate against
-  the SPDX OWL ontology. This ontology defines the expected relationships and
-  constraints between SPDX elements. The SPDX OWL ontology also incorporates
+  the SPDX 3 OWL ontology. This ontology defines the expected relationships and
+  constraints between SPDX elements. The SPDX 3 OWL ontology also incorporates
   SHACL shape restrictions to further specify these constraints.
 
-The SPDX JSON Schema is available at:
+The SPDX 3 JSON Schema is available at:
 [https://spdx.org/schema/3.0.1/spdx-json-schema.json](https://spdx.org/schema/3.0.1/spdx-json-schema.json)
 
-The SPDX OWL ontology is available at:
+The SPDX 3 OWL ontology is available at:
 [https://spdx.org/rdf/3.0.1/spdx-model.ttl](https://spdx.org/rdf/3.0.1/spdx-model.ttl)


### PR DESCRIPTION
A work item from 15 Apr 2025 Tech Team meeting
Will fix https://github.com/spdx/spdx-3-model/issues/1008

- Change a section heading from "Serialization in JSON-LD" to "Serialization in SPDX 3 JSON"
- Add SPDX 3 JSON format description, based on an agreed description in https://github.com/spdx/spdx-3-model/issues/1008#issuecomment-2755093934 with a revision for formality.

The original description contains the word "our". While it is good for documents like tutorials, it is not recommended in general to be used in a formal specification as it can create a sense of inclusion/exclusion, our/them.

Original description:

> SPDX 3 JSON is a strict subset of JSON-LD, meaning it must be serialized according to our strict specification and validated using the provided JSON schema, but it may be parsed — not serialized — using standard JSON-LD libraries.

Revised, removing "our":

> The SPDX 3 JSON format is a strict subset of JSON-LD. It requires data to be serialized according to the defined serialization specification and validated against the SPDX 3 JSON Schema. It may be parsed – not serialized – using standard JSON-LD libraries.

