### PR TITLE
Fix typos: license expression and serialization

### DIFF
--- a/docs/annexes/spdx-license-expressions.md
+++ b/docs/annexes/spdx-license-expressions.md
@@ -119,7 +119,7 @@ It is allowed to use the operator in lower case form `or`.
 
 If required to simultaneously comply with two or more licenses, use the conjunctive binary "AND" operator to construct a new license expression, where both the left and right operands are valid license expression values.
 
-For example, when one is required to comply with both the LGPL-2.1-only or MIT licenses, a valid expression would be:
+For example, when one is required to comply with both the LGPL-2.1-only and MIT licenses, a valid expression would be:
 
 ```text
 LGPL-2.1-only AND MIT

--- a/docs/serializations.md
+++ b/docs/serializations.md
@@ -52,7 +52,7 @@ with the following additional characteristics:
 - Integers: represented in base 10 using decimal digits. This designates an
   integer component that may be prefixed with an optional minus sign.
   Leading zeros are not allowed.
-- Strings: UTF-8 representation without specific canonicalization. A string
+- Strings: UTF-8 representation without specific normalization. A string
   begins and ends with quotation marks (%x22). Any Unicode characters may be
   placed within the quotation marks, except for the two characters that MUST be
   escaped by a reverse solidus: quotation mark, reverse solidus, and the


### PR DESCRIPTION
> **This PR targets `develop` branch.**

- UTF-8 representation without "canonicalization" -> "normalization" (from https://github.com/spdx/spdx-spec/pull/1199#discussion_r2049210853 )
- "both the LGPL-2.1-only **or** MIT" -> "both the LGPL-2.1-only **and** MIT" (change 'or' to 'and') (from https://github.com/spdx/spdx-spec/pull/1201 )
