### PR TITLE
Add back publish_common workflow for 2.3 publication

### DIFF
--- a/.github/workflows/publish_common.yml
+++ b/.github/workflows/publish_common.yml
@@ -1,0 +1,37 @@
+on:
+  repository_dispatch:
+    types:
+      - publish_spec
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch or tag to publish (e.g. refs/heads/support/2.3).
+        required: true
+        default: refs/heads/support/2.3
+      aliases:
+        description: Space-delimited aliases to publish (e.g. latest v2-latest v2-draft).
+        required: false
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: python:3.12
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  #v4.2.2
+      with:
+        ref: ${{ github.event.client_payload.ref || github.event.inputs.ref }}
+        fetch-depth: 0  # Because we will be pushing the gh-pages branch
+    - name: Install pre-requisites
+      run: pip install -r requirements.txt
+    - name: Install mike
+      run: pip install mike==2.1.3
+    - name: Extract branch or tag name
+      id: extract-branch-or-tag-name
+      run: echo "::set-output name=ref_name::v${REF##*/}"
+      env:
+        REF: ${{ github.event.client_payload.ref || github.event.inputs.ref }}
+    - name: Set Git identity
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+    - name: Build docs
+      run: mike deploy --update-aliases --push ${{ steps.extract-branch-or-tag-name.outputs.ref_name }} ${{ github.event.inputs.aliases }}


### PR DESCRIPTION
- A workflow needs to be in the default branch in order to appear on Actions tab on GitHub UI (or be available via GitHub API) and can be triggered through workflow_dispatch.
- This PR adds back `publish_common.yml` workflow to `develop` branch (the default branch of this repo). The workflow [is originally from](https://github.com/spdx/spdx-spec/blob/support/2.3/.github/workflows/publish_common.yml) `support/2.3` branch.
- The `publish_common.yml` workflow is needed for the publication of v2.3 (and v2.3.1 draft) in the multiversion environment (using mike).