### PR TITLE
Make publish_common workflow to work with both v2.2.2 and v2.3.x

### DIFF
--- a/.github/workflows/publish_common.yml
+++ b/.github/workflows/publish_common.yml
@@ -19,15 +19,15 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: Branch or tag to publish (e.g. refs/heads/support/2.3.1).
+        description: Branch or tag to publish (e.g. refs/heads/support/2.3).
         required: true
-        default: refs/heads/support/2.3.1
+        default: refs/heads/support/2.3
       as_version:
-        description: Version to publish as (e.g. v2.3.1).
+        description: Version to publish as (e.g. v2.3).
         required: true
-        default: v2.3.1
+        default: v2.3
       aliases:
-        description: Space-delimited aliases to publish (e.g. v2-latest v2-draft v2.3.1-dev).
+        description: Space-delimited aliases to publish (e.g. v2-latest v2-draft).
         required: false
 jobs:
   build:

--- a/.github/workflows/publish_common.yml
+++ b/.github/workflows/publish_common.yml
@@ -4,6 +4,13 @@
 # - ref: The branch or tag to publish
 # - as_version: The version to publish as
 # - aliases: Space-delimited aliases
+#
+# For example, to publish the "support/2.3.1" branch (under development)
+# as "v2.3.1-dev" with aliases "v2.3.1", "2.3.1", and "2.3.1-dev",
+# you can trigger the workflow with:
+# - ref = "refs/heads/support/2.3.1"
+# - as_version = "v2.3.1-dev"
+# - aliases = "v2.3.1 2.3.1 2.3.1-dev"
 
 on:
   repository_dispatch:
@@ -34,6 +41,8 @@ jobs:
         fetch-depth: 0  # Because we will be pushing the gh-pages branch
     - name: Install pre-requisites
       run: pip install -r spdx-spec/requirements.txt
+    - name: Install mike
+      run: pip install mike==2.1.3
     - name: Generate schema doc
       working-directory: spdx-spec
       run: generate-schema-doc schemas/spdx-schema.json chapters/spdx-json-schema.html

--- a/.github/workflows/publish_common.yml
+++ b/.github/workflows/publish_common.yml
@@ -54,4 +54,4 @@ jobs:
       env:
         AS_VERSION: ${{ github.event.client_payload.as_version || github.event.inputs.as_version }}
       run: |
-        mike deploy --update-aliases --push $AS_VERSION ${{ github.event.inputs.aliases }}
+        mike deploy --update-aliases --push $AS_VERSION ${{ github.event.client_payload.as_version || github.event.inputs.as_version }}

--- a/.github/workflows/publish_common.yml
+++ b/.github/workflows/publish_common.yml
@@ -40,9 +40,7 @@ jobs:
         path: spdx-spec
         fetch-depth: 0  # Because we will be pushing the gh-pages branch
     - name: Install pre-requisites
-      run: pip install -r spdx-spec/requirements.txt
-    - name: Install mike
-      run: pip install mike==2.1.3
+      run: pip install json-schema-for-humans==1.4.1 mike==2.1.3 mkdocs==1.6.1
     - name: Generate schema doc
       working-directory: spdx-spec
       run: generate-schema-doc schemas/spdx-schema.json chapters/spdx-json-schema.html

--- a/.github/workflows/publish_common.yml
+++ b/.github/workflows/publish_common.yml
@@ -33,10 +33,10 @@ jobs:
       run: pip install mike==2.1.3
     - name: Extract branch or tag name
       id: extract-branch-or-tag-name
-      run: |
-        echo "REF_NAME=v${REF##*/}" >> $GITHUB_ENV
       env:
         REF: ${{ github.event.client_payload.ref || github.event.inputs.ref }}
+      run: |
+        echo "REF_NAME=v${REF##*/}" >> $GITHUB_ENV
     - name: Set Git identity
       working-directory: spdx-spec
       run: |

--- a/.github/workflows/publish_common.yml
+++ b/.github/workflows/publish_common.yml
@@ -1,7 +1,8 @@
 # Publish pre-3.0 specs (spec versions that do not require spec-parser)
 # This workflow can be triggered manually or by a repository dispatch event.
-# It has two parameters:
+# It has three parameters:
 # - ref: The branch or tag to publish
+# - as_version: The version to publish as
 # - aliases: Space-delimited aliases
 
 on:
@@ -11,11 +12,15 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: Branch or tag to publish (e.g. refs/heads/support/2.3).
+        description: Branch or tag to publish (e.g. refs/heads/support/2.3.1).
         required: true
-        default: refs/heads/support/2.3
+        default: refs/heads/support/2.3.1
+      as_version:
+        description: Version to publish as (e.g. v2.3.1).
+        required: true
+        default: v2.3.1
       aliases:
-        description: Space-delimited aliases to publish (e.g. v2-latest v2-draft).
+        description: Space-delimited aliases to publish (e.g. v2-latest v2-draft v2.3.1-dev).
         required: false
 jobs:
   build:
@@ -44,5 +49,7 @@ jobs:
         git config user.email github-actions@github.com
     - name: Build docs
       working-directory: spdx-spec
+      env:
+        AS_VERSION: ${{ github.event.client_payload.as_version || github.event.inputs.as_version }}
       run: |
-        mike deploy --update-aliases --push $REF_NAME ${{ github.event.inputs.aliases }}
+        mike deploy --update-aliases --push $AS_VERSION ${{ github.event.inputs.aliases }}

--- a/.github/workflows/publish_common.yml
+++ b/.github/workflows/publish_common.yml
@@ -34,8 +34,9 @@ jobs:
         fetch-depth: 0  # Because we will be pushing the gh-pages branch
     - name: Install pre-requisites
       run: pip install -r spdx-spec/requirements.txt
-    - name: Install mike
-      run: pip install mike==2.1.3
+    - name: Generate schema doc
+      working-directory: spdx-spec
+      run: generate-schema-doc schemas/spdx-schema.json chapters/spdx-json-schema.html
     - name: Extract branch or tag name
       id: extract-branch-or-tag-name
       env:

--- a/.github/workflows/publish_common.yml
+++ b/.github/workflows/publish_common.yml
@@ -44,12 +44,6 @@ jobs:
     - name: Generate schema doc
       working-directory: spdx-spec
       run: generate-schema-doc schemas/spdx-schema.json chapters/spdx-json-schema.html
-    - name: Extract branch or tag name
-      id: extract-branch-or-tag-name
-      env:
-        REF: ${{ github.event.client_payload.ref || github.event.inputs.ref }}
-      run: |
-        echo "REF_NAME=v${REF##*/}" >> $GITHUB_ENV
     - name: Set Git identity
       working-directory: spdx-spec
       run: |

--- a/.github/workflows/publish_common.yml
+++ b/.github/workflows/publish_common.yml
@@ -1,3 +1,9 @@
+# Publish pre-3.0 specs (spec versions that do not require spec-parser)
+# This workflow can be triggered manually or by a repository dispatch event.
+# It has two parameters:
+# - ref: The branch or tag to publish
+# - aliases: Space-delimited aliases
+
 on:
   repository_dispatch:
     types:
@@ -9,7 +15,7 @@ on:
         required: true
         default: refs/heads/support/2.3
       aliases:
-        description: Space-delimited aliases to publish (e.g. latest v2-latest v2-draft).
+        description: Space-delimited aliases to publish (e.g. v2-latest v2-draft).
         required: false
 jobs:
   build:
@@ -19,19 +25,24 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  #v4.2.2
       with:
         ref: ${{ github.event.client_payload.ref || github.event.inputs.ref }}
+        path: spdx-spec
         fetch-depth: 0  # Because we will be pushing the gh-pages branch
     - name: Install pre-requisites
-      run: pip install -r requirements.txt
+      run: pip install -r spdx-spec/requirements.txt
     - name: Install mike
       run: pip install mike==2.1.3
     - name: Extract branch or tag name
       id: extract-branch-or-tag-name
-      run: echo "::set-output name=ref_name::v${REF##*/}"
+      run: |
+        echo "REF_NAME=v${REF##*/}" >> $GITHUB_ENV
       env:
         REF: ${{ github.event.client_payload.ref || github.event.inputs.ref }}
     - name: Set Git identity
+      working-directory: spdx-spec
       run: |
         git config user.name github-actions
         git config user.email github-actions@github.com
     - name: Build docs
-      run: mike deploy --update-aliases --push ${{ steps.extract-branch-or-tag-name.outputs.ref_name }} ${{ github.event.inputs.aliases }}
+      working-directory: spdx-spec
+      run: |
+        mike deploy --update-aliases --push $REF_NAME ${{ github.event.inputs.aliases }}


### PR DESCRIPTION
> This PR targets `develop` branch, which is the default branch - so the workflow can be available in GitHub web interface. The workflow itself is used for the publication of v2.x branches. See a [similar workflow](https://github.com/spdx/spdx-spec/blob/support/2.3/.github/workflows/publish_common.yml) in `support/2.3` branch.

- Specify working-directory to fix error when set Git identity (see [run](https://github.com/spdx/spdx-spec/actions/runs/14681319300/job/41204330746#step:7:6))
- Retain the schema doc generation (was previously in publish.yml for 2.x)
- Specify Python dependencies from within the workflow (not `requirements.txt`)
  - Package versions in local `requirements.txt` can be outdated and no longer works with current version of Python.
  - For example, `development/v2.2.2` branch's requirements.txt has mkdocs==1.3.1 which its dependencies no longer installable in more recent versions of Python. 
- The updated workflow should work for the publication of content in `development/v2.2.2`, `support/2.3` and `support/2.3.1` branches.
