### PR TITLE
[2.3] publish_common workflow: Specify working dir + Fix MkDocs warning

### DIFF
--- a/.github/workflows/publish_common.yml
+++ b/.github/workflows/publish_common.yml
@@ -28,7 +28,7 @@ jobs:
         path: spdx-spec
         fetch-depth: 0  # Because we will be pushing the gh-pages branch
     - name: Install pre-requisites
-      run: pip install -r requirements.txt
+      run: pip install -r spdx-spec/requirements.txt
     - name: Install mike
       run: pip install mike==2.1.3
     - name: Extract branch or tag name

--- a/.github/workflows/publish_common.yml
+++ b/.github/workflows/publish_common.yml
@@ -1,3 +1,9 @@
+# Publish pre-3.0 specs (spec versions that do not require spec-parser)
+# This workflow can be triggered manually or by a repository dispatch event.
+# It has two parameters:
+# - ref: The branch or tag to publish
+# - aliases: Space-delimited aliases
+
 on:
   repository_dispatch:
     types:
@@ -9,7 +15,7 @@ on:
         required: true
         default: refs/heads/support/2.3
       aliases:
-        description: Space-delimited aliases to publish (e.g. latest v2-latest).
+        description: Space-delimited aliases to publish (e.g. v2-latest v2-draft).
         required: false
 jobs:
   build:
@@ -19,19 +25,24 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  #v4.2.2
       with:
         ref: ${{ github.event.client_payload.ref || github.event.inputs.ref }}
-        fetch-depth: 0 # Because we will be pushing the gh-pages branch
+        path: spdx-spec
+        fetch-depth: 0  # Because we will be pushing the gh-pages branch
     - name: Install pre-requisites
       run: pip install -r requirements.txt
     - name: Install mike
       run: pip install mike==2.1.3
     - name: Extract branch or tag name
       id: extract-branch-or-tag-name
-      run: echo "::set-output name=ref_name::v${REF##*/}"
       env:
         REF: ${{ github.event.client_payload.ref || github.event.inputs.ref }}
+      run: |
+        echo "REF_NAME=v${REF##*/}" >> $GITHUB_ENV
     - name: Set Git identity
+      working-directory: spdx-spec
       run: |
         git config user.name github-actions
         git config user.email github-actions@github.com
     - name: Build docs
-      run: mike deploy --update-aliases --push ${{ steps.extract-branch-or-tag-name.outputs.ref_name }} ${{ github.event.inputs.aliases }}
+      working-directory: spdx-spec
+      run: |
+        mike deploy --update-aliases --push $REF_NAME ${{ github.event.inputs.aliases }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,12 @@
 site_name: SPDX Specification 2.3.0
+copyright: Copyright &copy; 2010 - 2022 Linux Foundation and its Contributors.
 docs_dir: chapters
 theme: readthedocs
 extra_css:
 - css/style.css
+markdown_extensions:
+- codehilite:
+   guess_lang: false
 use_directory_urls: true
 nav:
 - 'Copyright': index.md
@@ -32,8 +36,5 @@ nav:
 - 'Annex J: Creative Commons Attribution License 3.0 Unported': creative-commons-attribution-license-3.0-unported.md
 - 'Annex K: How To Use SPDX in Different Scenarios': how-to-use.md
 - 'Bibliography': bibliography.md
-copyright: Copyright &copy; 2010 - 2022 Linux Foundation and its Contributors.
-
-markdown_extensions:
-- codehilite:
-   guess_lang: false
+exclude_docs: |
+  foreword.md  # Used for ISO-submitted version only


### PR DESCRIPTION
> This PR targets `support/2.3` branch.

<!-- > For similar PR that targets `develop` branch, see #1206 -->

- Specify working-directory to fix error when set Git identity (see [run](https://github.com/spdx/spdx-spec/actions/runs/14681319300/job/41204330746#step:7:6))
- Replace the deprecated `::set-output` with environment file output
- Fix MkDocs warning that `foreword.md` is not in 'nav' in mkdocs.yml.
  - The file is intentionally not included in 'nav' because it is used for ISO-submitted version only. (v2.3 is not)
  - Suppress the warning by mark it in 'exclude_docs'