### PR TITLE
[2.3] Set mike alias_type to "redirect"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,10 @@ docs_dir: chapters
 theme: readthedocs
 extra_css:
 - css/style.css
+plugins:
+- search
+- mike:
+    alias_type: redirect
 markdown_extensions:
 - codehilite:
    guess_lang: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 json-schema-for-humans==1.3.4
+mike==2.1.3
 mkdocs==1.6.1


### PR DESCRIPTION
> This PR targets `support/2.3` branch

## Background

Current v3.0 URL redirection behaviour is URL aliases will be redirected to a URL with a specific version number (a URL with a version number of the latest stable release of that major version):
  - Go to https://spdx.github.io/spdx-spec/latest/ -> URL changes to https://spdx.github.io/spdx-spec/v3.0.1/
  - Go to https://spdx.github.io/spdx-spec/3.0/ -> URL changes to https://spdx.github.io/spdx-spec/v3.0.1/

v2.3 URL redirection currently does not follow that behavior:
  - Go to https://spdx.github.io/spdx-spec/v2-latest/ -> URL not change

## What this PR does

This PR makes v2.3 redirects behave the same as v3.0 redirects by set `plugins.mike.alias_type` to "redirect". Expected new behaviour:
  - Go to https://spdx.github.io/spdx-spec/v2-latest/ -> URL changes to https://spdx.github.io/spdx-spec/v2.3/
