### PR TITLE
[2.3] Enable syntax highlighting for ABNF and XML

### DIFF
--- a/chapters/RDF-object-model-and-identifier-syntax.md
+++ b/chapters/RDF-object-model-and-identifier-syntax.md
@@ -20,7 +20,7 @@ Fields that identify entities that have acted in relation to the SPDX document a
 tool and, optionally, provide contact information. For example, "Person: Jane Doe (jane.doe@example.com)",
 "Organization: ExampleCodeInspect (contact@example.com)" and "Tool: LicenseFind - 1.0". The exact syntax of agent and tool identifications is described below in [ABNF](http://tools.ietf.org/html/rfc5234).
 
-```text
+```ABNF
 agent            = person / organization
 
 tool             = "Tool: " name 0*1( " " DASH " " version)

--- a/chapters/SPDX-license-expressions.md
+++ b/chapters/SPDX-license-expressions.md
@@ -216,12 +216,12 @@ A License Exception can be expressed in RDF via a `<spdx:LicenseException>` elem
 * `seeAlso` (optional, one or more)- An `rdfs:seeAlso` element referencing external sources of information on the exception.
 * `example` (optional) - Text describing examples of this exception.
 * `name` - The full human readable name of the item.
-* `licenseExceptionId` -  The identifier of an exception in the SPDX License List to which the exception applies.
+* `licenseExceptionId` - The identifier of an exception in the SPDX License List to which the exception applies.
 * `licenseExceptionText` - Full text of the license exception.
 
 ```XML
 <rdf:Description rdf:about
-  ="http://example.org#SPDXRef-ButIdDontWantToException">
+  ="http://example.org#SPDXRef-ButIDontWantToException">
     <rdfs:comment>This exception may be invalid in some
       jurisdictions.</rdfs:comment>
     <rdfs:seeAlso>http://dilbert.com/strip/1997-01-15</rdfs:seeAlso>
@@ -233,7 +233,7 @@ A License Exception can be expressed in RDF via a `<spdx:LicenseException>` elem
         unfavorable.
     </spdx:licenseExceptionText>
     <spdx:name>&quot;But I Don&apos;t Want To&quot; Exception</spdx:name>
-    <spdx:licenseExceptionId>SPDXRef-ButIdDontWantToException</spdx:licenseExceptionId>
+    <spdx:licenseExceptionId>SPDXRef-ButIDontWantToException</spdx:licenseExceptionId>
     <rdf:type rdf:resource
       ="http://spdx.org/rdf/terms#LicenseException"/>
 </rdf:Description>

--- a/chapters/SPDX-license-expressions.md
+++ b/chapters/SPDX-license-expressions.md
@@ -8,7 +8,7 @@ SPDX License Expressions provide a way for one to construct expressions that mor
 
 The exact syntax of license expressions is described below in [ABNF](http://tools.ietf.org/html/rfc5234).
 
-```text
+```ABNF
 idstring = 1*(ALPHA / DIGIT / "-" / "." )
 
 license-id = <short form license identifier in Annex A.1>
@@ -21,8 +21,7 @@ simple-expression = license-id / license-id"+" / license-ref
 
 compound-expression = (simple-expression /
 
-
-simple-expression "WITH" license-exception-id /
+  simple-expression "WITH" license-exception-id /
 
   compound-expression "AND" compound-expression /
 
@@ -172,7 +171,7 @@ states the OR operator should be applied before the AND operator. That is, one s
 
 A conjunctive license can be expressed in RDF via a `<spdx:ConjunctiveLicenseSet>` element, with an spdx:member property for each element in the conjunctive license. Two or more members are required.
 
-```text
+```XML
 <spdx:ConjunctiveLicenseSet>
     <spdx:member rdf:resource="http://spdx.org/licenses/GPL-2.0-only"/>
     <spdx:ExtractedLicensingInfo rdf:about
@@ -191,7 +190,7 @@ A conjunctive license can be expressed in RDF via a `<spdx:ConjunctiveLicenseSet
 
 A disjunctive license can be expressed in RDF via a `<spdx:DisjunctiveLicenseSet>` element, with an spdx:member property for each element in the disjunctive license. Two or more members are required.
 
-```text
+```XML
 <spdx:DisjunctiveLicenseSet>
     <spdx:member rdf:resource="http://spdx.org/licenses/GPL-2.0-only"/>
     <spdx:member>
@@ -220,7 +219,7 @@ A License Exception can be expressed in RDF via a `<spdx:LicenseException>` elem
 * `licenseExceptionId` -  The identifier of an exception in the SPDX License List to which the exception applies.
 * `licenseExceptionText` - Full text of the license exception.
 
-```text
+```XML
 <rdf:Description rdf:about
   ="http://example.org#SPDXRef-ButIdDontWantToException">
     <rdfs:comment>This exception may be invalid in some

--- a/chapters/SPDX-license-expressions.md
+++ b/chapters/SPDX-license-expressions.md
@@ -138,7 +138,7 @@ The current set of valid exceptions can be found in Annex [A.2](SPDX-license-lis
 
 ### D.4.5 Order of precedence and parentheses <a name="D.4.5"></a>
 
-The order of application of the operators in an expression matters (similar to mathematical operators). The default operator order of precedence of a `<license-expression>` a is:
+The order of application of the operators in an expression matters (similar to mathematical operators). The default operator order of precedence of a `<license-expression>` is:
 
 ```text
 +

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,10 @@
 site_name: SPDX Specification 2.3.0
 copyright: Copyright &copy; 2010 - 2022 Linux Foundation and its Contributors.
 docs_dir: chapters
-theme: readthedocs
+theme:
+  name: readthedocs
+  hljs_languages:
+  - abnf
 extra_css:
 - css/style.css
 markdown_extensions:


### PR DESCRIPTION
> This PR targets `support/2.3` branch

- Enable syntax highlighting for ABNF and XML
- Fix indent inside the ABNF

See example of ABNF and XML syntax highlighting here:
https://spdx.github.io/spdx-spec/v3.1-dev/annexes/spdx-license-expressions/