### PR TITLE
[2.3] Use alias-type = redirect

### DIFF
--- a/.github/workflows/publish_common.yml
+++ b/.github/workflows/publish_common.yml
@@ -45,4 +45,4 @@ jobs:
     - name: Build docs
       working-directory: spdx-spec
       run: |
-        mike deploy --update-aliases --push $REF_NAME ${{ github.event.inputs.aliases }}
+        mike deploy --update-aliases --alias-type=redirect --push $REF_NAME ${{ github.event.inputs.aliases }}


### PR DESCRIPTION
Make https://spdx.github.io/spdx-spec/v2-latest/SPDX-license-expressions/ redirected to https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/

Currently it uses mike default behaviour, which is `symlink`. The content of `v2-latest` is already `v2.3`, but the URL is not.

This PR will make the alias behaviour of v2.x the same as v3.x by setting alias type as `redirect`.