### PR TITLE
primaryPackagePurpose in 2.3 defines OPERATING-SYSTEM not OPERATING_SYSTEM

### DIFF
--- a/schemas/spdx-schema.json
+++ b/schemas/spdx-schema.json
@@ -417,7 +417,7 @@
           "primaryPackagePurpose" : {
             "description" : "This field provides information about the primary purpose of the identified package. Package Purpose is intrinsic to how the package is being used rather than the content of the package.",
             "type" : "string",
-            "enum" : [ "OTHER", "INSTALL", "ARCHIVE", "FIRMWARE", "APPLICATION", "FRAMEWORK", "LIBRARY", "CONTAINER", "SOURCE", "DEVICE", "OPERATING_SYSTEM", "FILE" ]
+            "enum" : [ "OTHER", "INSTALL", "ARCHIVE", "FIRMWARE", "APPLICATION", "FRAMEWORK", "LIBRARY", "CONTAINER", "SOURCE", "DEVICE", "OPERATING-SYSTEM", "FILE" ]
           },
           "releaseDate" : {
             "description" : "This field provides a place for recording the date the package was released.",


### PR DESCRIPTION
Per the specification in https://spdx.github.io/spdx-spec/v2.3/package-information/#724-primary-package-purpose-field the `primaryPackagePurpose` enum should contain `OPERATING-SYSTEM` not `OPERATING_SYSTEM`.