### PR TITLE
[2.3.1] Update build dependencies and GitHub Actions

### DIFF
--- a/.github/workflows/publish_common.yml
+++ b/.github/workflows/publish_common.yml
@@ -1,9 +1,16 @@
 # Publish pre-3.0 specs (spec versions that do not require spec-parser)
 # This workflow can be triggered manually or by a repository dispatch event.
-# It has two parameters:
+# It has three parameters:
 # - ref: The branch or tag to publish
 # - as_version: The version to publish as
 # - aliases: Space-delimited aliases
+#
+# For example, to publish the "support/2.3.1" branch (under development)
+# as "v2.3.1-dev" with aliases "v2.3.1" and "2.3.1",
+# you can trigger the workflow with:
+# - ref = "refs/heads/support/2.3.1"
+# - as_version = "v2.3.1-dev"
+# - aliases = "v2.3.1 2.3.1"
 
 on:
   repository_dispatch:

--- a/.github/workflows/publish_common.yml
+++ b/.github/workflows/publish_common.yml
@@ -1,3 +1,10 @@
+# Publish pre-3.0 specs (spec versions that do not require spec-parser)
+# This workflow can be triggered manually or by a repository dispatch event.
+# It has two parameters:
+# - ref: The branch or tag to publish
+# - as_version: The version to publish as
+# - aliases: Space-delimited aliases
+
 on:
   repository_dispatch:
     types:
@@ -5,31 +12,44 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: Branch or tag to publish (e.g. refs/heads/development/v2).
+        description: Branch or tag to publish (e.g. refs/heads/support/2.3.1).
         required: true
-        default: refs/heads/master
+        default: refs/heads/support/2.3.1
+      as_version:
+        description: Version to publish as (e.g. v2.3.1).
+        required: true
+        default: v2.3.1-dev
       aliases:
-        description: Space-delimited aliases to publish (e.g. latest v2-latest).
+        description: Space-delimited aliases to publish (e.g. v2.3.1 2.3.1)
         required: false
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: python:3
+    container: python:3.12
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  #v4.2.2
       with:
         ref: ${{ github.event.client_payload.ref || github.event.inputs.ref }}
-        fetch-depth: 0 # Because we will be pushing the gh-pages branch
-        token: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        path: spdx-spec
+        fetch-depth: 0  # Because we will be pushing the gh-pages branch
     - name: Install pre-requisites
-      run: pip install -r requirements.txt
+      run: pip install -r spdx-spec/requirements.txt
     - name: Install mike
-      run: pip install mike==1.2.0
+      run: pip install mike==2.1.3
     - name: Extract branch or tag name
       id: extract-branch-or-tag-name
-      run: echo "::set-output name=ref_name::${REF##*/}"
-      with:
-        ref: ${{ github.event.client_payload.ref || github.event.inputs.ref }}
+      env:
+        REF: ${{ github.event.client_payload.ref || github.event.inputs.ref }}
+      run: |
+        echo "REF_NAME=v${REF##*/}" >> $GITHUB_ENV
+    - name: Set Git identity
+      working-directory: spdx-spec
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
     - name: Build docs
-      run: mike deploy ${{ steps.outputs.extract-branch-or-tag-name.name }} ${{ github.event.inputs.aliases }}
-
+      working-directory: spdx-spec
+      env:
+        AS_VERSION: ${{ github.event.client_payload.as_version || github.event.inputs.as_version }}
+      run: |
+        mike deploy --update-aliases --push $AS_VERSION ${{ github.event.inputs.aliases }}

--- a/.github/workflows/validate_pull_request.yml
+++ b/.github/workflows/validate_pull_request.yml
@@ -4,13 +4,11 @@ jobs:
   validate:
     name: Validate build
     runs-on: ubuntu-latest
-    container: python:3
+    container: python:3.12
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  #v4.2.2
       with:
         fetch-depth: 1
-    - name: Install build requirements for pre-requisites
-      run: pip install -r build-requirements.txt
     - name: Install pre-requisites
       run: pip install --no-build-isolation -r requirements.txt
     - name: Build

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,3 +1,0 @@
-setuptools
-wheel
-Cython<3.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,16 @@
-site_name: specification v2.3.0
+site_name: SPDX Specification v2.3.1-dev
+copyright: Copyright &copy; 2010 - 2025 Linux Foundation and its Contributors.
 docs_dir: chapters
 theme: readthedocs
 extra_css:
 - css/style.css
+plugins:
+- search
+- mike:
+    alias_type: redirect
+markdown_extensions:
+- codehilite:
+   guess_lang: false
 use_directory_urls: true
 nav:
 - 'Copyright': index.md
@@ -32,8 +40,5 @@ nav:
 - 'Annex J: Creative Commons Attribution License 3.0 Unported': creative-commons-attribution-license-3.0-unported.md
 - 'Annex K: How To Use SPDX in Different Scenarios': how-to-use.md
 - 'Bibliography': bibliography.md
-copyright: Copyright &copy; 2010 - 2022 Linux Foundation and its Contributors.
-
-markdown_extensions:
-- codehilite:
-   guess_lang: false
+exclude_docs: |
+  foreword.md  # Used for ISO-submitted version only

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,10 @@
 site_name: SPDX Specification v2.3.1-dev
 copyright: Copyright &copy; 2010 - 2025 Linux Foundation and its Contributors.
 docs_dir: chapters
-theme: readthedocs
+theme:
+  name: readthedocs
+  hljs_languages:
+  - abnf
 extra_css:
 - css/style.css
 plugins:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-mkdocs==1.3.0
-json-schema-for-humans==0.39.5
-
+json-schema-for-humans==1.4.1
+mike==2.1.3
+mkdocs==1.6.1

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name = "spdx_specification",
-    version = "2.3",
+    version = "2.3.1-dev",
     author = "Linux Foundation and SPDX Contributors",
     author_email = "opensource@steenbe.nl",
     description = ("The Software Package Data Exchange® (SPDX®) specification is a standard format for communicating the components, licenses and copyrights associated with software packages."),
@@ -20,7 +20,7 @@ setup(
     url = "https://spdx.org",
     long_description=read('README.md'),
     classifiers=[
-        "Topic :: Dcoumentation",
+        "Topic :: Documentation",
         "License :: Other/Proprietary License",
     ],
     python_requires='>=2.7.9,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',


### PR DESCRIPTION
Update validation and publication workflow for v2.3.1-dev

Current workflow files are outdated and break because of breaking change in Python 3.13 (see https://github.com/spdx/spdx-spec/pull/1216#issuecomment-2920204136 )

The workflow update is based on the same updated files in `support/2.3` branch.