### PR TITLE
[2.3.1] Update version in front page to 2.3.1-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ This `support/2.3.1` branch holds under development 2.3.x version of the specifi
 - HTML (gh-pages branch)
   - <https://spdx.github.io/spdx-spec/v2.3.1-dev/>
 
+For the development of the latest version, please see the
+[`develop`](https://github.com/spdx/spdx-spec/tree/develop) branch.
+
 See for the official [releases of the specification](https://spdx.org/specifications) or additional information also the [SPDX website](https://spdx.org).
 
 ## Building the specification
@@ -20,7 +23,7 @@ You have to [MkDocs](http://mkdocs.org) installed on your machine. If you don't 
 
 ## Building HTML
 
-Execute built-in dev-server that lets you preview the specification
+Execute built-in dev-server that lets you preview the specification:
 
 ```shell
 mkdocs serve

--- a/README.md
+++ b/README.md
@@ -1,20 +1,18 @@
 # The Software Package Data Exchange (SPDX®) Specification
 
-[![Build Status](https://travis-ci.org/spdx/spdx-spec.svg?branch=master)](https://travis-ci.org/spdx/spdx-spec)
-
 The Software Package Data Exchange® (SPDX®) specification is a standard format for communicating the components, licenses and copyrights associated with software packages.
 
 The SPDX standard helps facilitate compliance with free and open source software licenses by standardizing the way license information is shared across the software supply chain. SPDX reduces redundant work by providing a common format for companies and communities to share important data about software licenses and copyrights, thereby streamlining and improving compliance.
 
-This repository holds under active development version of the specification as:
+This `support/2.3.1` branch holds under development 2.3.x version of the specification as:
 
-* [MarkDown](https://github.com/spdx/spdx-spec/tree/master/chapters) (`master` branch)
-* HTML (gh-pages branch, built on every commit to `master` and `development/` branches)
-  * [Current](https://spdx.github.io/spdx-spec/v2.3/)
+- [Markdown](https://github.com/spdx/spdx-spec/tree/support/2.3.1/chapters) (`support/2.3.1` branch)
+- HTML (gh-pages branch)
+  - <https://spdx.github.io/spdx-spec/v2.3.1-dev/>
 
 See for the official [releases of the specification](https://spdx.org/specifications) or additional information also the [SPDX website](https://spdx.org).
 
-# Building the specification
+## Building the specification
 
 ## Prerequisites
 
@@ -22,8 +20,14 @@ You have to [MkDocs](http://mkdocs.org) installed on your machine. If you don't 
 
 ## Building HTML
 
-    # Execute built-in dev-server that lets you preview the specification
-    $ mkdocs serve
+Execute built-in dev-server that lets you preview the specification
 
-    # Building static HTML site
-    $ mkdocs build
+```shell
+mkdocs serve
+```
+
+Building static HTML site:
+
+```shell
+mkdocs build
+```

--- a/chapters/index.md
+++ b/chapters/index.md
@@ -1,6 +1,6 @@
-# The Software Package Data Exchange® (SPDX®) Specification Version 2.3
+# The Software Package Data Exchange® (SPDX®) Specification Version 2.3.1-dev
 
-Copyright © 2010-2022 Linux Foundation and its Contributors.
+Copyright © 2010-2025 Linux Foundation and its Contributors.
 This work is licensed under the Creative Commons Attribution License 3.0 Unported (CC-BY-3.0) reproduced in its entirety in [Annex J](creative-commons-attribution-license-3.0-unported.md) herein. All other rights are expressly reserved.
 
 With thanks to

--- a/schemas/spdx-schema.json
+++ b/schemas/spdx-schema.json
@@ -1,12 +1,12 @@
 {
   "$schema" : "https://json-schema.org/draft/2019-09/schema",
   "$id" : "http://spdx.org/rdf/terms/2.3",
-  "title" : "SPDX 2.3",
+  "title" : "SPDX 2.3.1-dev",
   "type" : "object",
   "properties" : {
     "$schema": {
       "type": "string",
-      "description": "Reference the SPDX 2.3 JSON schema."
+      "description": "Reference the SPDX 2.3.1 JSON schema."
     },
     "SPDXID" : {
       "type" : "string",


### PR DESCRIPTION
> This PR targets `support/2.3.1` branch.

Currently it shows "2.3" which may confused people.

- Update branch names and links in README (remove refs to obsolete master branch, etc)
- Also remove no longer in use Travis build status