### PR TITLE
[2.3.1] Publish schema doc

### DIFF
--- a/.github/workflows/publish_common.yml
+++ b/.github/workflows/publish_common.yml
@@ -41,8 +41,9 @@ jobs:
         fetch-depth: 0  # Because we will be pushing the gh-pages branch
     - name: Install pre-requisites
       run: pip install -r spdx-spec/requirements.txt
-    - name: Install mike
-      run: pip install mike==2.1.3
+    - name: Generate schema doc
+      working-directory: spdx-spec
+      run: generate-schema-doc schemas/spdx-schema.json chapters/spdx-json-schema.html
     - name: Extract branch or tag name
       id: extract-branch-or-tag-name
       env:

--- a/.github/workflows/publish_common.yml
+++ b/.github/workflows/publish_common.yml
@@ -41,6 +41,8 @@ jobs:
         fetch-depth: 0  # Because we will be pushing the gh-pages branch
     - name: Install pre-requisites
       run: pip install -r spdx-spec/requirements.txt
+    - name: Install mike
+      run: pip install mike==2.1.3
     - name: Generate schema doc
       working-directory: spdx-spec
       run: generate-schema-doc schemas/spdx-schema.json chapters/spdx-json-schema.html


### PR DESCRIPTION
> This PR targets `support/2.3.1` branch.

- Generate schema doc and put it in chapters directory so mkdocs/mike can copy it and make it available in generated website.
  - The v2.2 schema doc is at: https://spdx.github.io/spdx-spec/spdx-json-schema.html
  - The v2.3 schema doc is at: https://spdx.github.io/spdx-spec/v2.3/spdx-json-schema.html
  - This PR will put v2.3.1-dev schema doc to https://spdx.github.io/spdx-spec/v2.3.1-dev/spdx-json-schema.html
  - This generation step was previously run inside https://github.com/spdx/spdx-spec/blob/support/2.3.1/.github/workflows/publish.yml but that workflow is no longer in use because it is a workflow for single version publication (using mkdocs only and not using mike).

The similar PR for `support/2.3` has already been merged:
- #1221