### PR TITLE
[2.3] Publish schema doc

### DIFF
--- a/.github/workflows/publish_common.yml
+++ b/.github/workflows/publish_common.yml
@@ -1,7 +1,8 @@
 # Publish pre-3.0 specs (spec versions that do not require spec-parser)
 # This workflow can be triggered manually or by a repository dispatch event.
-# It has two parameters:
+# It has three parameters:
 # - ref: The branch or tag to publish
+# - as_version: The version to publish as
 # - aliases: Space-delimited aliases
 
 on:
@@ -14,13 +15,17 @@ on:
         description: Branch or tag to publish (e.g. refs/heads/support/2.3).
         required: true
         default: refs/heads/support/2.3
+      as_version:
+        description: Version to publish as (e.g. v2.3).
+        required: true
+        default: v2.3
       aliases:
         description: Space-delimited aliases to publish (e.g. v2-latest v2-draft).
         required: false
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: python:3.9
+    container: python:3.12
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  #v4.2.2
       with:
@@ -29,8 +34,9 @@ jobs:
         fetch-depth: 0  # Because we will be pushing the gh-pages branch
     - name: Install pre-requisites
       run: pip install -r spdx-spec/requirements.txt
-    - name: Install mike
-      run: pip install mike==2.1.3
+    - name: Generate schema doc
+      working-directory: spdx-spec
+      run: generate-schema-doc schemas/spdx-schema.json chapters/spdx-json-schema.html
     - name: Extract branch or tag name
       id: extract-branch-or-tag-name
       env:
@@ -44,5 +50,7 @@ jobs:
         git config user.email github-actions@github.com
     - name: Build docs
       working-directory: spdx-spec
+      env:
+        AS_VERSION: ${{ github.event.client_payload.as_version || github.event.inputs.as_version }}
       run: |
-        mike deploy --update-aliases --push $REF_NAME ${{ github.event.inputs.aliases }}
+        mike deploy --update-aliases --push $AS_VERSION ${{ github.event.inputs.aliases }}


### PR DESCRIPTION
> This PR targets `support/2.3` branch.

- Generate schema doc and put it in chapters directory so mkdocs/mike can copy it and make it available in generated website.
  - The schema doc for v2.2 looks like this: https://spdx.github.io/spdx-spec/spdx-json-schema.html
  - This PR will put the schema doc to https://spdx.github.io/spdx-spec/VERSION/spdx-json-schema.html - for example, https://spdx.github.io/spdx-spec/v2.3/spdx-json-schema.html
  - This generation step was previously run inside https://github.com/spdx/spdx-spec/blob/support/2.3/.github/workflows/publish.yml but that workflow is no longer in use because it is a workflow for single version publication (using mkdocs only and not using mike).

- Also remove mike installation (redundant with pip install -r requirements.txt)