### PR TITLE
[2.3.1] Fix primaryPackagePurpose enum to use dash

### DIFF
--- a/schemas/spdx-schema.json
+++ b/schemas/spdx-schema.json
@@ -417,7 +417,7 @@
           "primaryPackagePurpose" : {
             "description" : "This field provides information about the primary purpose of the identified package. Package Purpose is intrinsic to how the package is being used rather than the content of the package.",
             "type" : "string",
-            "enum" : [ "OTHER", "INSTALL", "ARCHIVE", "FIRMWARE", "APPLICATION", "FRAMEWORK", "LIBRARY", "CONTAINER", "SOURCE", "DEVICE", "OPERATING_SYSTEM", "FILE" ]
+            "enum" : [ "OTHER", "INSTALL", "ARCHIVE", "FIRMWARE", "APPLICATION", "FRAMEWORK", "LIBRARY", "CONTAINER", "SOURCE", "DEVICE", "OPERATING-SYSTEM", "FILE" ]
           },
           "releaseDate" : {
             "description" : "This field provides a place for recording the date the package was released.",


### PR DESCRIPTION
It should be "OPERATING-SYSTEM" (with dash) instead of "OPERATING_SYSTEM" (with underscore)

Same as #1216 / created to test CI