### PR TITLE
[develop] "this standard/specification" -> "this document"

### DIFF
--- a/docs/annexes/pkg-url-specification.md
+++ b/docs/annexes/pkg-url-specification.md
@@ -27,7 +27,7 @@ A _purl_ is a URL composed of seven components:
 
 Components are separated by a specific character for unambiguous parsing.
 
-The definition for each components is:
+The definition for each component is:
 
 - **scheme**: this is the URL scheme with the constant value of "`pkg`". One of the primary reason for this single scheme is to facilitate the future official registration of the "`pkg`" scheme for package URLs. Required.
 - **type**: the package type or package protocol such as maven, npm, nuget, gem, pypi, etc. Required.
@@ -258,7 +258,7 @@ To build a _purl_ string from its components:
     1. Append `?` to the _purl_
     1. Discard any pair where the value is empty
     1. Encode each value in UTF-8-encoding
-    1. If the key is `checksum` and there are more than one checksums, join the list with `,` to create the qualifier value
+    1. If the key is `checksum` and there are more than one checksum, join the list with `,` to create the qualifier value
     1. Create each qualifier string by joining the lowercased key, the equal `=` sign, and the percent-encoded value
     1. Sort this list of qualifier strings lexicographically
     1. Join this list of sorted qualifier strings with `&`

--- a/docs/annexes/pkg-url-specification.md
+++ b/docs/annexes/pkg-url-specification.md
@@ -41,7 +41,7 @@ Components are designed such that they form a hierarchy from the most
 significant on the left to the least significant components on the right.
 
 A _purl_ is a valid URL and URI that conforms to the URL definitions
-and specifications in RFC 3986 <https://datatracker.ietf.org/doc/rfc3986>.
+and specifications in RFC 3986 <https://datatracker.ietf.org/doc/rfc3986/>.
 
 A _purl_ must not contain a URL Authority i.e. there is no
 support for username, password, host and port components.
@@ -60,7 +60,7 @@ The _purl_ components are mapped to the following URL components:
 For clarity and simplicity a _purl_ is always an ASCII string.
 To ensure that there is no ambiguity when parsing a _purl_,
 separator characters and non-ASCII characters must be encoded in UTF-8,
-and then percent-encoded as defined in RFC 3986 <https://datatracker.ietf.org/doc/rfc3986>.
+and then percent-encoded as defined in RFC 3986 <https://datatracker.ietf.org/doc/rfc3986/>.
 
 Use these rules for percent-encoding and decoding _purl_ components:
 

--- a/docs/annexes/pkg-url-specification.md
+++ b/docs/annexes/pkg-url-specification.md
@@ -350,7 +350,7 @@ The following list includes some valid _purl_ examples:
 
 ## Original license
 
-This specification is based on the texts published
+This document is based on the texts published
 in the <https://github.com/package-url/purl-spec> online repository.
 The original license and attribution are reproduced below:
 

--- a/docs/annexes/pkg-url-specification.md
+++ b/docs/annexes/pkg-url-specification.md
@@ -258,7 +258,7 @@ To build a _purl_ string from its components:
     1. Append `?` to the _purl_
     1. Discard any pair where the value is empty
     1. Encode each value in UTF-8-encoding
-    1. If the key is `checksum` and there are more than one checksum, join the list with `,` to create the qualifier value
+    1. If the key is `checksum` and there is more than one checksum, join the list with `,` to create the qualifier value
     1. Create each qualifier string by joining the lowercased key, the equal `=` sign, and the percent-encoded value
     1. Sort this list of qualifier strings lexicographically
     1. Join this list of sorted qualifier strings with `&`

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -2,7 +2,7 @@
 
 ## Alternate notation for some conformance requirements
 
-This standard contains more than a few cardinality assertions, each of which
+This document contains more than a few cardinality assertions, each of which
 indicates the minimum and maximum number of times a property may appear.
 These are represented by using "minCount" and "maxCount" respectively.
 The absolute minimum number of occurrences is zero (0),
@@ -20,7 +20,7 @@ Here are some examples:
 Each of these assertions can easily be understood as to whether a feature is
 required, and if so, how many occurrences are required; also, whether a feature
 is permitted, and if so, in what number. As this is the format long familiar to
-the SPDX community, it has been preserved in this specification.
+the SPDX community, it has been preserved in this document.
 
 ## Introduction to Profiles
 

--- a/docs/serializations.md
+++ b/docs/serializations.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This specification defines the data model of the SPDX standard, describing
+This document defines the data model of the SPDX standard, describing
 every piece of information about systems with software components. The data
 model is based on the Resource Description Framework (RDF) extensible
 knowledge representation data model, which provides a flexible and extensible

--- a/submissions/ISO/annexes/changes-from-previous-iso.md
+++ b/submissions/ISO/annexes/changes-from-previous-iso.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The previous published version of this standard was ISO/IEC 5962:2021(E),
+The previous published version of this document was ISO/IEC 5962:2021(E),
 titled "Information technology -- SPDX® Specification V2.2.1"
 published by ISO (the International Organization for Standardization)
 and IEC (the International Electrotechnical Commission)
@@ -10,5 +10,3 @@ in 2021.
 
 The present chapter outlines the changes that the current version
 introduces related to that previous edition.
-
-

--- a/submissions/OMG/annexes/omg-history.md
+++ b/submissions/OMG/annexes/omg-history.md
@@ -1,6 +1,6 @@
 # History with OMG, Motivation and Rational (Informative)
 
-The OMG and CISQ involvement in developing this specification had its start due
+The OMG and CISQ involvement in developing this document had its start due
 to a need that came from the several years of work in the Department of
 Commerce’s National Telecommunications and Information Administration (NTIA) in
 creating an Initiative to Improve Software Component Transparency in July of

--- a/submissions/OMG/people.md
+++ b/submissions/OMG/people.md
@@ -2,7 +2,7 @@
 
 ## Author acknowledgements
 
-The following people authored this specification:
+The following people authored this document:
 
 Adam Cohn,
 Adolfo García Veytia,


### PR DESCRIPTION
> This PR targets `develop` branch.
> For a similar PR that targets `support/3.0`, see #1238 

- To fix https://github.com/spdx/spdx-spec/issues/1234 (ISO issue)