### PR TITLE
[3.0] Use MAJOR.MINOR version JSON-LD context URL in example

### DIFF
--- a/bin/check-examples.sh
+++ b/bin/check-examples.sh
@@ -4,6 +4,12 @@
 # documentation
 #
 # SPDX-License-Identifier: MIT
+#
+# It was the case that we use MAJOR.MINOR.PATCH (3-part) version number
+# (e.g., "3.0.1") in IRI of terms and RDF files.
+# With ISO submission of SPDX 3.0 in December 2025, we decided to use MAJOR.MINOR
+# (2-part) version number (e.g., "3.0") instead.
+# This needs update in RDF files, tools, publication CI, and IRI redirections.
 
 set -e
 

--- a/bin/check-examples.sh
+++ b/bin/check-examples.sh
@@ -4,6 +4,7 @@
 # documentation
 #
 # SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: Copyright 2024-2026 The SPDX Contributors
 #
 # It was the case that we use MAJOR.MINOR.PATCH (3-part) version number
 # (e.g., "3.0.1") in IRI of terms and RDF files.
@@ -13,44 +14,63 @@
 
 set -e
 
-THIS_DIR="$(dirname "$0")"
 SPDX_VERSION="3.0.1"
+
+THIS_DIR="$(dirname "$0")"
+MD_DIR=docs/annexes
+JSON_DIR=examples/jsonld
+
 SPDX_VERSION_MAJOR_MINOR="$(echo "$SPDX_VERSION" | cut -d. -f1,2)"  # 3.0.1 -> 3.0; 3.0 -> 3.0
 SCHEMA_URL="https://spdx.org/schema/${SPDX_VERSION_MAJOR_MINOR}/spdx-json-schema.json"
 RDF_URL="https://spdx.org/rdf/${SPDX_VERSION_MAJOR_MINOR}/spdx-model.ttl"
 CONTEXT_URL="https://spdx.org/rdf/${SPDX_VERSION_MAJOR_MINOR}/spdx-context.jsonld"
 
+# print validation setup
+echo "Checking examples in"
+echo "Snippets         : $MD_DIR"
+echo "Files            : $JSON_DIR"
+echo "SPDX version     : $SPDX_VERSION"
+echo "(major.minor)    : $SPDX_VERSION_MAJOR_MINOR"
+echo "Schema           : $SCHEMA_URL"
+echo "Schema resolved  : $(curl -I "$SCHEMA_URL" 2>/dev/null | grep -i "location:" | awk '{print $2}')"
+echo "RDF              : $RDF_URL"
+echo "RDF resolved     : $(curl -I "$RDF_URL" 2>/dev/null | grep -i "location:" | awk '{print $2}')"
+echo "Context          : $CONTEXT_URL"
+echo "Context resolved : $(curl -I "$CONTEXT_URL" 2>/dev/null | grep -i "location:" | awk '{print $2}')"
+echo "$(check-jsonschema --version)"
+echo "spdx3-validate version: $(spdx3-validate --version)"
+echo ""
+
 check_schema() {
+    echo "Checking schema (check-jsonschema): $1"
     check-jsonschema \
-        -v \
+        --verbose \
         --schemafile $SCHEMA_URL \
         "$1"
 }
 
-check_model() {
-    pyshacl \
-        -s $RDF_URL \
-        -e $RDF_URL \
-        "$1"
+check_spdx() {
+    echo "SPDX 3 Validating (spdx3-validate): $1"
+    spdx3-validate --json $1
 }
 
 # Check examples in JSON files in examples/jsonld/
-if [ "$(ls $THIS_DIR/../examples/jsonld/*.json 2>/dev/null)" ]; then
-    for f in $THIS_DIR/../examples/jsonld/*.json; do
-        echo "Checking $f"
+if [ "$(ls $THIS_DIR/../$JSON_DIR/*.json 2>/dev/null)" ]; then
+    for f in $THIS_DIR/../$JSON_DIR/*.json; do
         check_schema $f
-        check_model $f
+        echo ""
+        check_spdx $f
+        echo ""
     done
 fi
 
-TEMP=$(mktemp -d)
-
 # Check examples in inline code snippets in Markdown files in docs/annexes/
-for f in $THIS_DIR/../docs/annexes/*.md; do
+TEMP=$(mktemp -d)
+for f in $THIS_DIR/../$MD_DIR/*.md; do
     if ! grep -q '^```json' $f; then
         continue
     fi
-    echo "Checking $f"
+    echo "Extract snippets from $f"
     DEST=$TEMP/$(basename $f)
     mkdir -p $DEST
 
@@ -58,7 +78,8 @@ for f in $THIS_DIR/../docs/annexes/*.md; do
     cat $f | awk -v DEST="$DEST" 'BEGIN{flag=0} /^```json/, $0=="```" { if (/^---$/){flag++} else if ($0 !~ /^```.*/ ) print $0 > DEST "/doc-" flag ".spdx.json"}'
 
     # Combine all JSON code snippets into a single file, with SPDX context and creation info.
-    echo "[" > $DEST/combined.json
+    COMBINED_JSON = $DEST/__combined.jso
+    echo "[" > $COMBINED_JSON
 
     for doc in $DEST/*.spdx.json; do
         if ! grep -q '@context' $doc; then
@@ -88,11 +109,12 @@ HEREDOC
 HEREDOC
         fi
         check_schema $doc
-        cat $doc >> $DEST/combined.json
-        echo "," >> $DEST/combined.json
+        echo ""
+        cat $doc >> $COMBINED_JSON
+        echo "," >> $COMBINED_JSON
     done
 
-    echo "{}]" >> $DEST/combined.json
-
-    check_model $DEST/combined.json
+    echo "{}]" >> $COMBINED_JSON
+    check_spdx $COMBINED_JSON
+    echo ""
 done

--- a/bin/check-examples.sh
+++ b/bin/check-examples.sh
@@ -9,7 +9,7 @@ set -e
 
 THIS_DIR="$(dirname "$0")"
 SPDX_VERSION="3.0.1"
-SPDX_VERSION_MAJOR_MINOR="$(echo "$SPDX_VERSION" | cut -d. -f1,2)"  # "3.0" for 3.0.1; "3.0" for 3.0
+SPDX_VERSION_MAJOR_MINOR="$(echo "$SPDX_VERSION" | cut -d. -f1,2)"  # 3.0.1 -> 3.0; 3.0 -> 3.0
 SCHEMA_URL="https://spdx.org/schema/${SPDX_VERSION_MAJOR_MINOR}/spdx-json-schema.json"
 RDF_URL="https://spdx.org/rdf/${SPDX_VERSION_MAJOR_MINOR}/spdx-model.ttl"
 CONTEXT_URL="https://spdx.org/rdf/${SPDX_VERSION_MAJOR_MINOR}/spdx-context.jsonld"

--- a/bin/check-examples.sh
+++ b/bin/check-examples.sh
@@ -9,9 +9,10 @@ set -e
 
 THIS_DIR="$(dirname "$0")"
 SPDX_VERSION="3.0.1"
-SCHEMA_URL="https://spdx.org/schema/${SPDX_VERSION}/spdx-json-schema.json"
-RDF_URL="https://spdx.org/rdf/${SPDX_VERSION}/spdx-model.ttl"
-CONTEXT_URL="https://spdx.org/rdf/${SPDX_VERSION}/spdx-context.jsonld"
+SPDX_VERSION_MAJOR_MINOR="$(echo "$SPDX_VERSION" | cut -d. -f1,2)"  # "3.0" for 3.0.1; "3.0" for 3.0
+SCHEMA_URL="https://spdx.org/schema/${SPDX_VERSION_MAJOR_MINOR}/spdx-json-schema.json"
+RDF_URL="https://spdx.org/rdf/${SPDX_VERSION_MAJOR_MINOR}/spdx-model.ttl"
+CONTEXT_URL="https://spdx.org/rdf/${SPDX_VERSION_MAJOR_MINOR}/spdx-context.jsonld"
 
 check_schema() {
     check-jsonschema \

--- a/examples/jsonld/package_sbom.json
+++ b/examples/jsonld/package_sbom.json
@@ -1,5 +1,5 @@
 {
-    "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+    "@context": "https://spdx.org/rdf/3.0/spdx-context.jsonld",
     "@graph": [
         {
             "type": "CreationInfo",

--- a/serialization/jsonld/annotations.ttl
+++ b/serialization/jsonld/annotations.ttl
@@ -1,4 +1,4 @@
-@base <https://spdx.org/rdf/3.0.1/terms/> .
+@base <https://spdx.org/rdf/3/terms/> .
 @prefix sh-to-code: <https://jpewdev.github.io/shacl2code/schema#> .
 
 <Core/Element> ;


### PR DESCRIPTION
> This PR targets `support/3.0` branch.
> A similar PR for `develop` is at #1244

To use "3.0" RDF URLs (version without patch version), as required by https://github.com/spdx/spdx-3-model/issues/1046, we need to verify if new RDF URLs are working.

We may check that with an SBOM example (`examples/jsonld/package_sbom.json`) and the example validation workflow in this repo.

This issue may not directly affect the texts in the ISO publication but without the fix the texts in ISO publication may not back with relevant working URLs.

- See https://github.com/spdx/spdx-3-model/issues/1046 (ISO issue)
