### PR TITLE
[2.3] Fix: remove 'name' from required properties for Snippet in schema file

### DIFF
--- a/schemas/spdx-schema.json
+++ b/schemas/spdx-schema.json
@@ -703,7 +703,7 @@
             "type" : "string"
           }
         },
-        "required" : [ "SPDXID", "name", "ranges", "snippetFromFile" ],
+        "required" : [ "SPDXID", "ranges", "snippetFromFile" ],
         "additionalProperties" : false
       }
     },


### PR DESCRIPTION
> This PR targets `support/2.3` branch.
> See #1020, for a similar PR for `support/2.3.1` branch.
> See #1021, for a similar PR for `development/2.2.2` branch.

Originally reported by @ammend - according to the [v2.3 spec](https://spdx.github.io/spdx-spec/v2.3.1-dev/snippet-information/#910-snippet-name-field), `name` is not required for a snippet.

This PR removed it from "required" in the schema.

