### PR TITLE
Use ISO shall: spdx-lite

### DIFF
--- a/docs/annexes/spdx-lite.md
+++ b/docs/annexes/spdx-lite.md
@@ -133,7 +133,7 @@ Additionally:
 - Mandatory
     1. created
     1. createdBy (may be multiple), should be objects of type /Core/Agent
-    1. specVersion, shall be a fixed string, “3.1.*” - where \* is
+    1. specVersion, shall be a fixed string, “3.1.n” - where n is
        any supported patch version of the SPDX specification
 - Recommended
     1. comment

--- a/docs/annexes/spdx-lite.md
+++ b/docs/annexes/spdx-lite.md
@@ -2,8 +2,10 @@
 
 ## Explanation of the Lite profile
 
-The Lite profile is designed to make it quick and easy to start a Software Bill of Materials
-in situations where a company may have limited capacity for introducing new items into their processes.
+The Lite profile is designed to make it quick and easy to start a
+Software Bill of Materials in situations where a company may have limited
+capacity for introducing new items into their processes.
+
 The Lite profile captures the minimum set of information required
 for license compliance in the software supply chain.
 It contains information about the creation of the SBOM,
@@ -11,17 +13,19 @@ package lists with licensing and other related information,
 and their relationships.
 
 All elements in Lite profile are essential for complying with licenses.
-It is easy to use a SPDX document with the Lite profile
+It is easy to use an SPDX document with the Lite profile
 for anyone who does not have enough knowledge about licensing information
-and easy to import license information from former versions of SPDX Lite format files.
+and easy to import license information from former versions of SPDX Lite format
+files.
+
 The Lite profile offers the flexibility to be used either alone
 or in combination with other SPDX profiles
-as a SPDX document in the software supply chain.
+as an SPDX document in the software supply chain.
 
 ## Mandatory and recommended properties
 
-The Lite profile specifies that some properties MUST be present
-and some others SHOULD be present, as much as possible.
+The Lite profile specifies that some properties shall be present
+and some others should be present, as much as possible.
 
 The following lists collect and present this information
 for every class present in the SPDX data,
@@ -32,22 +36,22 @@ The lists of properties are in alphabetical order, for easy reference.
 
 - Mandatory
     1. creationInfo
-    1. element (may be multiple), MUST have at least one /Software/Sbom object
-    1. rootElement (may be multiple), SHOULD be objects of type /Software/Sbom
+    1. element (may be multiple), shall have at least one /Software/Sbom object
+    1. rootElement (may be multiple), should be objects of type /Software/Sbom
     1. spdxId
 - Recommended
     1. comment
     1. dataLicense
     1. name
     1. namespaceMap (may be multiple)
-    1. verifiedUsing (may be multiple), SHOULD be objects of type /Core/Hash
+    1. verifiedUsing (may be multiple), should be objects of type /Core/Hash
 
 ### /Software/Sbom
 
 - Mandatory
     1. creationInfo
-    1. element (may be multiple), MUST have at least one /Software/Package object
-    1. rootElement (may be multiple), SHOULD be objects of type /Software/Package
+    1. element (may be multiple), shall have at least one /Software/Package object
+    1. rootElement (may be multiple), should be objects of type /Software/Package
     1. spdxId
 - Recommended
     1. sbomType (may be multiple)
@@ -60,26 +64,34 @@ The lists of properties are in alphabetical order, for easy reference.
     1. name
     1. packageVersion
     1. spdxId
-    1. suppliedBy, SHOULD be an object of type /Core/Agent
+    1. suppliedBy, should be an object of type /Core/Agent
 - Recommended
     1. attributionText (may be multiple)
     1. builtTime
     1. comment
     1. downloadLocation
     1. homepage
-    1. originatedBy (may be multiple), SHOULD be objects of type /Core/Agent
+    1. originatedBy (may be multiple), should be objects of type /Core/Agent
     1. packageUrl
     1. releaseTime
     1. supportLevel (may be multiple)
     1. validUntilTime
-    1. verifiedUsing (may be multiple), SHOULD be objects of type /Core/Hash
+    1. verifiedUsing (may be multiple), should be objects of type /Core/Hash
 
-However, there MUST be at least a “downloadLocation” or “packageUrl” property.
+However, there shall be at least a “downloadLocation” or “packageUrl” property.
 
 Additionally:
 
-1. for every /Software/Package object MUST exist exactly one /Core/Relationship object of type `hasConcludedLicense` having that element as its `from` property and an /SimpleLicensing/AnyLicenseInfo as its `to` property.
-1. for every /Software/Package object MUST exist exactly one /Core/Relationship object of type `hasDeclaredLicense` having that element as its `from` property and  /SimpleLicensing/AnyLicenseInfo object as its `to` property.
+1. for every `/Software/Package` object shall exist
+   exactly one `/Core/Relationship` object
+   of type `hasConcludedLicense`
+   having that element as its `from` property and
+   a `/SimpleLicensing/AnyLicenseInfo` object as its `to` property.
+1. for every `/Software/Package` object shall exist
+   exactly one `/Core/Relationship` object
+   of type `hasDeclaredLicense`
+   having that element as its `from` property and
+   a `/SimpleLicensing/AnyLicenseInfo` object as its `to` property.
 
 ### /Core/Hash
 
@@ -110,7 +122,7 @@ Additionally:
 ### /Core/Agent (createdBy, suppliedBy, originatedBy)
 
 - Mandatory
-    1. creationInfo, SHOULD be “BlankNode”
+    1. creationInfo, should be “BlankNode”
     1. name
     1. spdxId
 - Recommended
@@ -120,8 +132,9 @@ Additionally:
 
 - Mandatory
     1. created
-    1. createdBy (may be multiple), SHOULD be objects of type /Core/Agent
-    1. specVersion, MUST be a fixed string, “3.0.*” - where * is any supported patch version of the SPDX specification
+    1. createdBy (may be multiple), should be objects of type /Core/Agent
+    1. specVersion, shall be a fixed string, “3.1.*” - where \* is
+       any supported patch version of the SPDX specification
 - Recommended
     1. comment
 


### PR DESCRIPTION
> This PR targets `develop` branch.
> For its counterpart targeting `support/3.0` branch, see #1288

Use "shall" instead of "must, for SPDX Lite.

To address issue in #1236.

Also fix few typos and missing words