### PR TITLE
[3.0] Update version (3.0) and year (2025) in copyright notice

### DIFF
--- a/docs/annexes/rdf-model.md
+++ b/docs/annexes/rdf-model.md
@@ -40,11 +40,11 @@ and is published in online at
 
 [![Extension Profile diagram][fig_extension]][fig_extension]
 
-[fig_ai]: ../images/model-AI.png "SPDX 3.0.1 AI Profile diagram"
-[fig_build]: ../images/model-Build.png "SPDX 3.0.1 Build Profile diagram"
-[fig_core]: ../images/model-Core.png "SPDX 3.0.1 Core Profile diagram"
-[fig_dataset]: ../images/model-Dataset.png "SPDX 3.0.1 Dataset Profile diagram"
-[fig_extension]: ../images/model-Extension.png "SPDX 3.0.1 Extension Profile diagram"
-[fig_licensing]: ../images/model-Licensing.png "SPDX 3.0.1 Licensing Profile diagram"
-[fig_security]: ../images/model-Security.png "SPDX 3.0.1 Security Profile diagram"
-[fig_software]: ../images/model-Software.png "SPDX 3.0.1 Software Profile diagram"
+[fig_ai]: ../images/model-AI.png "SPDX 3.0 AI profile diagram"
+[fig_build]: ../images/model-Build.png "SPDX 3.0 Build profile diagram"
+[fig_core]: ../images/model-Core.png "SPDX 3.0 Core profile diagram"
+[fig_dataset]: ../images/model-Dataset.png "SPDX 3.0 Dataset profile diagram"
+[fig_extension]: ../images/model-Extension.png "SPDX 3.0 Extension profile diagram"
+[fig_licensing]: ../images/model-Licensing.png "SPDX 3.0 Licensing profile diagram"
+[fig_security]: ../images/model-Security.png "SPDX 3.0 Security profile diagram"
+[fig_software]: ../images/model-Software.png "SPDX 3.0 Software profile diagram"

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -257,17 +257,17 @@ To be designated an SPDX document, a file shall comply with the requirements of 
 License, as stated in the [SPDX Trademark Page](https://spdx.dev/trademark).
 
 The official copyright notice that shall be used with any verbatim reproduction and/or distribution of
-this SPDX Specification 3.0.1 is:
+this SPDX Specification 3.0 is:
 
-"Official SPDX® Specification 3.0.1 Copyright © 2010--2024 Linux Foundation and its Contributors.
+"Official SPDX® Specification 3.0 Copyright © 2010–2025 Linux Foundation and its Contributors.
 Licensed under the Community Specification License 1.0. All other rights are expressly reserved."
 
 The official copyright notice that shall be used with any non-verbatim reproduction and/or distribution
-of this SPDX Specification 3.0.1, including without limitation any partial use or combining this SPDX
+of this SPDX Specification 3.0, including without limitation any partial use or combining this SPDX
 Specification with another work, is:
 
 "This is not an official SPDX Specification. Portions herein have been reproduced from SPDX®
-Specification 3.0.1 found at spdx.dev. These portions are Copyright © 2010--2024 Linux Foundation and
+Specification 3.0 found at spdx.dev. These portions are Copyright © 2010–2025 Linux Foundation and
 its Contributors, and are licensed under the Community Specification License 1.0 by the
 Linux Foundation and its Contributors. All other rights are expressly reserved by Linux Foundation and
 its Contributors."

--- a/docs/front/copyright.md
+++ b/docs/front/copyright.md
@@ -1,6 +1,6 @@
 # Use of Specification - Terms, Conditions & Notices
 
-Copyright © 2010-2024, The Linux Foundation and its Contributors,
+Copyright © 2010–2025, The Linux Foundation and its Contributors,
 including SPDX Model contributions from OMG and its Contributors.
 
 This work is licensed under the

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
-# The System Package Data Exchange™ (SPDX®) Specification Version 3.0.1
+# The System Package Data Exchange™ (SPDX®) Specification Version 3.0
 
-Copyright © 2010-2024, The Linux Foundation and its Contributors,
+Copyright © 2010–2025, The Linux Foundation and its Contributors,
 including SPDX Model contributions from OMG and its Contributors.
 
 With thanks to

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,10 @@
-site_name: SPDX Specification 3.0.1
-site_description: The System Package Data Exchange™ (SPDX®) Specification Version 3.0.1 - Open standard for creating Software Bills of Materials (SBOMs)
+site_name: SPDX Specification 3.0
+site_description: The System Package Data Exchange™ (SPDX®) Specification Version 3.0 - Open standard for creating Software Bills of Materials (SBOMs)
 site_author: The Linux Foundation and its Contributors, including SPDX Model contributions from OMG and its Contributors.
 site_url: https://spdx.github.io/spdx-spec/  # set to the "root" of the site, to be combined with canonical_version
 repo_url: https://github.com/spdx/spdx-spec/
 edit_uri: ""  # set to an empty string to disable edit links; to enable, set to blob/development/v3.0.1/docs/
-copyright: SPDX v3.0.1 Copyright © 2010-2024, The Linux Foundation and its Contributors, including SPDX Model contributions from OMG and its Contributors.
+copyright: SPDX 3.0 Copyright © 2010-2025, The Linux Foundation and its Contributors, including SPDX Model contributions from OMG and its Contributors.
 use_directory_urls: true
 theme:
   name: readthedocs

--- a/submissions/ISO/front/iso-foreword.md
+++ b/submissions/ISO/front/iso-foreword.md
@@ -38,7 +38,7 @@ In the IEC, see
 This document was prepared by
 [The Linux Foundation](https://www.linuxfoundation.org/) and its Contributors
 under the [SPDX Working Group](https://spdx.dev/)
-(as SPDX® Specification v3.0.1)
+(as SPDX® Specification v3.0)
 and drafted in accordance with its editorial rules.
 Its preparation and publication has been made in coordination with related
 efforts with the [Object Management Group (OMG)](https://www.omg.org/).


### PR DESCRIPTION
> This PR targets `support/3.0` branch.
> For its counterpart that targeting `develop` branch, see #1281

- Update version reference to address https://github.com/spdx/spdx-spec/issues/1237
  > The spec should only refer to second-level numbering (never 3.0.1, for example), and in a consistent manner "SPDX 3.0".)
- Update year in copyright notice to cover 2025
- Use en dash between years, as suggested in https://github.com/spdx/spdx-spec/pull/1281#pullrequestreview-3349082316