### PR TITLE
Remove the pyshacl check for the examples

### DIFF
--- a/.github/workflows/validate_examples.yml
+++ b/.github/workflows/validate_examples.yml
@@ -21,7 +21,7 @@ jobs:
           cache: "pip"
       - name: Install Python dependencies
         run: |
-          python3 -m pip install check-jsonschema==0.31.0 pyshacl==0.30.0 spdx3-validate==0.0.5
+          python3 -m pip install check-jsonschema==0.31.0 spdx3-validate==0.0.5
       - name: Install dependencies
         run: |
           sudo apt install -y gawk

--- a/.github/workflows/validate_examples.yml
+++ b/.github/workflows/validate_examples.yml
@@ -21,7 +21,7 @@ jobs:
           cache: "pip"
       - name: Install Python dependencies
         run: |
-          python3 -m pip install check-jsonschema==0.31.0 spdx3-validate==0.0.5
+          python3 -m pip install check-jsonschema==0.34.1 spdx3-validate==0.0.5
       - name: Install dependencies
         run: |
           sudo apt install -y gawk

--- a/bin/check-examples.sh
+++ b/bin/check-examples.sh
@@ -29,7 +29,6 @@ echo "RDF resolved     : $(curl -I "$RDF_URL" 2>/dev/null | grep -i "location:" 
 echo "Context          : $CONTEXT_URL"
 echo "Context resolved : $(curl -I "$CONTEXT_URL" 2>/dev/null | grep -i "location:" | awk '{print $2}')"
 echo "$(check-jsonschema --version)"
-echo -n "$(pyshacl --version)"
 echo "spdx3-validate version: $(spdx3-validate --version)"
 echo ""
 
@@ -38,14 +37,6 @@ check_schema() {
     check-jsonschema \
         --verbose \
         --schemafile $SCHEMA_URL \
-        "$1"
-}
-
-check_model() {
-    echo "Checking model (pyschacl): $1"
-    pyshacl \
-        --shacl $RDF_URL \
-        --ont-graph $RDF_URL \
         "$1"
 }
 
@@ -58,8 +49,6 @@ check_spdx() {
 if [ "$(ls $THIS_DIR/../$JSON_DIR/*.json 2>/dev/null)" ]; then
     for f in $THIS_DIR/../$JSON_DIR/*.json; do
         check_schema $f
-        echo ""
-        check_model $f
         echo ""
         check_spdx $f
         echo ""
@@ -117,9 +106,6 @@ HEREDOC
     done
 
     echo "{}]" >> $COMBINED_JSON
-
-    check_model $COMBINED_JSON
-    echo ""
     check_spdx $COMBINED_JSON
     echo ""
 done


### PR DESCRIPTION
PyShacl doesn't support external elements which will soon be added in one of the examples.

It looks like spdx3-validate should be sufficient.

Reference: https://github.com/spdx/spdx-spec/pull/1299#issuecomment-3471615629