### PR TITLE
Publish lastest support/3.0 to 3.0-dev

### DIFF
--- a/.github/workflows/publish_v3.yml
+++ b/.github/workflows/publish_v3.yml
@@ -70,7 +70,7 @@ jobs:
                                             #   redirected to the release version later.
                                             #   For example, v3.0-RC1 was redirected to v3.0 and
                                             #   will be redirected to v3.0.1 later.
-      VERSION_ALIASES: ""
+      VERSION_ALIASES: "v3.0.2"
                                             # VERSION_ALIASES are names that will be redirected to VERSION
                                             # - Can be empty, can be multiple; separated by space
                                             # - "latest" should be reserved for the latest version

--- a/.github/workflows/publish_v3.yml
+++ b/.github/workflows/publish_v3.yml
@@ -28,7 +28,7 @@
 on:
   push:
     branches:
-      - develop          # This should match with REF_SPEC,
+      - support/3.0      # This should match with REF_SPEC,
                          # to automatically publish from a correct branch
   repository_dispatch:
     types:
@@ -38,12 +38,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      REF_SPEC: "develop"                   # spdx-spec branch: "main" or "develop" or "support/x.y"
-      REF_MODEL: "main"                     # spdx-3-model branch: "main" or "develop" or "support/x.y"
+      REF_SPEC: "support/3.0"               # spdx-spec branch: "main" or "develop" or "support/x.y"
+      REF_MODEL: "support/3.0"              # spdx-3-model branch: "main" or "develop" or "support/x.y"
       REF_PARSER: "main"                    # spdx-3-model branch: "main" or "develop" or "support/x.y"
                                             # (now we have only "main" for spdx-3-model and spec-parser)
       GH_PAGES_BRANCH: "gh-pages"           # spdx-spec branch to publish HTML to
-      VERSION_DEFAULT: "v3.0.1"             # Default version:
+      VERSION_DEFAULT: "v3.0.2-dev"         # Default version:
                                             # - A version to be redirected to from the URL without
                                             #   a version number specified
                                             # - Should be a latest stable version from "main" branch
@@ -51,7 +51,7 @@ jobs:
                                             #   across all branches/tags
                                             # - VERSION_DEFAULT should also match with the
                                             #   mike's canonical_version in mkdocs.yml
-      VERSION: "v3.0.1"                     # Publishing version, to be publish by this workflow:
+      VERSION: "v3.0.2-dev"                 # Publishing version, to be publish by this workflow:
                                             # - VERSION can be different from VERSION_DEFAULT;
                                             #   For example, if VERSION is a draft/release candidate,
                                             #   or if VERSION is a stable version that is behind the
@@ -70,7 +70,7 @@ jobs:
                                             #   redirected to the release version later.
                                             #   For example, v3.0-RC1 was redirected to v3.0 and
                                             #   will be redirected to v3.0.1 later.
-      VERSION_ALIASES: "latest v3.0 v3.0.1-dev v3.0.1-draft v3-draft v3.0-RC1 v3.0-RC2"
+      VERSION_ALIASES: ""
                                             # VERSION_ALIASES are names that will be redirected to VERSION
                                             # - Can be empty, can be multiple; separated by space
                                             # - "latest" should be reserved for the latest version

--- a/.github/workflows/publish_v3.yml
+++ b/.github/workflows/publish_v3.yml
@@ -43,7 +43,7 @@ jobs:
       REF_PARSER: "main"                    # spdx-3-model branch: "main" or "develop" or "support/x.y"
                                             # (now we have only "main" for spdx-3-model and spec-parser)
       GH_PAGES_BRANCH: "gh-pages"           # spdx-spec branch to publish HTML to
-      VERSION_DEFAULT: "v3.0.2-dev"         # Default version:
+      VERSION_DEFAULT: "v3.0.1"             # Default version:
                                             # - A version to be redirected to from the URL without
                                             #   a version number specified
                                             # - Should be a latest stable version from "main" branch
@@ -51,7 +51,7 @@ jobs:
                                             #   across all branches/tags
                                             # - VERSION_DEFAULT should also match with the
                                             #   mike's canonical_version in mkdocs.yml
-      VERSION: "v3.0.2-dev"                 # Publishing version, to be publish by this workflow:
+      VERSION: "v3.0-dev"                   # Publishing version, to be publish by this workflow:
                                             # - VERSION can be different from VERSION_DEFAULT;
                                             #   For example, if VERSION is a draft/release candidate,
                                             #   or if VERSION is a stable version that is behind the
@@ -112,25 +112,25 @@ jobs:
         run: |
           echo Expanded VERSION_ALIASES: $VERSION_ALIASES
       - name: Checkout spdx-spec
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  #v5.0.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  #v6.0.1
         with:
           ref: ${{ env.REF_SPEC }}
           path: spdx-spec
           fetch-depth: 0  # Because we will be pushing the gh-pages branch
       - name: Checkout spdx-3-model
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  #v5.0.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  #v6.0.1
         with:
           repository: spdx/spdx-3-model
           ref: ${{ env.REF_MODEL }}
           path: spdx-3-model
       - name: Checkout spec-parser
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  #v5.0.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  #v6.0.1
         with:
           repository: spdx/spec-parser
           ref: ${{ env.REF_PARSER }}
           path: spec-parser
       - name: Set up specific Python version
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  #v6.0.0
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548  #v6.1.0
         with:
           python-version: "3.12"
           cache: "pip"


### PR DESCRIPTION
Fetch
- `support/3.0` branch from spdx-spec; and
- `support/3.0` branch from spdx-3-model

then generate the website and publish to https://spdx.github.io/spdx-spec/v3.0.2-dev/

So we can see all the changes submitting to ISO.

--

This PR implements https://github.com/spdx/spdx-spec/issues/1274#issuecomment-3576670293 and a follow up of PR #1316 to correct the name of the branch to fetch from.

(Without this PR, the `develop` branch from spdx-spec will be publish as "v3.0.1")

Note, for constants in the workflow: `REF_SPEC` is reference to the branch in spdx-spec repo,   `REF_MODEL` is to the branch in spdx-3-model.


To fix #1315
