### PR TITLE
Add class hierarchy annex

### DIFF
--- a/.github/workflows/publish_v3.yml
+++ b/.github/workflows/publish_v3.yml
@@ -194,11 +194,9 @@ jobs:
       - name: Build model files
         # Generates model documents and RDFs
         # Move the model file list to spdx-spec/
-        # Move Class hierarchy annex to spdx-spec/docs/annexes/
         run: |
           python3 spec-parser/main.py --force --generate-rdf --output-rdf spdx-spec/docs/rdf --generate-mkdocs --output-mkdocs spdx-spec/docs/model --generate-plantuml --output-plantuml spdx-spec/docs/diagram --generate-jsondump --output-jsondump spdx-spec/docs/jsondump spdx-3-model/model
           mv spdx-spec/docs/model/$MKDOCS_MODEL_YML spdx-spec/
-          mv spdx-spec/docs/model/class-hierarchy.md spdx-spec/docs/annexes/
       - name: Copy JSON annotations
         # JSON annotations URL will be redirected
         # from https://spdx.org/rdf/<version>/spdx-json-serialize-annotations.ttl
@@ -273,6 +271,10 @@ jobs:
           echo "--------------------"
           cat "$MKDOCS_FULL_YML"
           echo "===================="
+      - name: Move generated documents
+        working-directory: spdx-spec
+        run: |
+          mv docs/model/class-hierarchy.md docs/annexes/
       - name: Deploy and set aliases
         # mike is used here to manage multiple versions of MkDocs-powered documentation
         # This step does 2 things:

--- a/.github/workflows/publish_v3.yml
+++ b/.github/workflows/publish_v3.yml
@@ -193,10 +193,12 @@ jobs:
         run: pip install -r spec-parser/requirements.txt
       - name: Build model files
         # Generates model documents and RDFs
-        # Move the model file list to spdx-spec/
+        # Move the model file list to spdx-spec/ root
+        # Move the generated class hierarchy document to annexes directory
         run: |
           python3 spec-parser/main.py --force --generate-rdf --output-rdf spdx-spec/docs/rdf --generate-mkdocs --output-mkdocs spdx-spec/docs/model --generate-plantuml --output-plantuml spdx-spec/docs/diagram --generate-jsondump --output-jsondump spdx-spec/docs/jsondump spdx-3-model/model
           mv spdx-spec/docs/model/$MKDOCS_MODEL_YML spdx-spec/
+          mv spdx-spec/docs/model/class-hierarchy.md spdx-spec/docs/annexes/
       - name: Copy JSON annotations
         # JSON annotations URL will be redirected
         # from https://spdx.org/rdf/<version>/spdx-json-serialize-annotations.ttl
@@ -271,10 +273,6 @@ jobs:
           echo "--------------------"
           cat "$MKDOCS_FULL_YML"
           echo "===================="
-      - name: Move generated documents
-        working-directory: spdx-spec
-        run: |
-          mv docs/model/class-hierarchy.md docs/annexes/
       - name: Deploy and set aliases
         # mike is used here to manage multiple versions of MkDocs-powered documentation
         # This step does 2 things:

--- a/.github/workflows/publish_v3.yml
+++ b/.github/workflows/publish_v3.yml
@@ -192,11 +192,13 @@ jobs:
       - name: Install pre-requisites for spec-parser
         run: pip install -r spec-parser/requirements.txt
       - name: Build model files
-        # Also move the model file list to spdx-spec/ directory,
-        # as it should not be part of the publicly accessible website.
+        # Generates model documents and RDFs
+        # Move the model file list to spdx-spec/
+        # Move Class hierarchy annex to spdx-spec/annexes/
         run: |
           python3 spec-parser/main.py --force --generate-rdf --output-rdf spdx-spec/docs/rdf --generate-mkdocs --output-mkdocs spdx-spec/docs/model --generate-plantuml --output-plantuml spdx-spec/docs/diagram --generate-jsondump --output-jsondump spdx-spec/docs/jsondump spdx-3-model/model
           mv spdx-spec/docs/model/$MKDOCS_MODEL_YML spdx-spec/
+          mv spdx-spec/docs/model/class-hierarchy.md spdx-spec/annexes/
       - name: Copy JSON annotations
         # JSON annotations URL will be redirected
         # from https://spdx.org/rdf/<version>/spdx-json-serialize-annotations.ttl

--- a/.github/workflows/publish_v3.yml
+++ b/.github/workflows/publish_v3.yml
@@ -194,11 +194,11 @@ jobs:
       - name: Build model files
         # Generates model documents and RDFs
         # Move the model file list to spdx-spec/
-        # Move Class hierarchy annex to spdx-spec/annexes/
+        # Move Class hierarchy annex to spdx-spec/docs/annexes/
         run: |
           python3 spec-parser/main.py --force --generate-rdf --output-rdf spdx-spec/docs/rdf --generate-mkdocs --output-mkdocs spdx-spec/docs/model --generate-plantuml --output-plantuml spdx-spec/docs/diagram --generate-jsondump --output-jsondump spdx-spec/docs/jsondump spdx-3-model/model
           mv spdx-spec/docs/model/$MKDOCS_MODEL_YML spdx-spec/
-          mv spdx-spec/docs/model/class-hierarchy.md spdx-spec/annexes/
+          mv spdx-spec/docs/model/class-hierarchy.md spdx-spec/docs/annexes/
       - name: Copy JSON annotations
         # JSON annotations URL will be redirected
         # from https://spdx.org/rdf/<version>/spdx-json-serialize-annotations.ttl

--- a/docs/annexes/class-hierarchy.md
+++ b/docs/annexes/class-hierarchy.md
@@ -1,0 +1,1 @@
+# Class hierarchy (Informational)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,11 +50,12 @@ nav:
 - model:  # __MODEL_PLACEHOLDER__, to be replaced by content from model-files.yml. Please do not edit this line.
   - "__MODEL_PLACEHOLDER__": "https://example.com"  # allows mkdocs.yml to be build/tested without full model list. Please do not edit this line.
 - annexes:
-  - 'A. RDF model definition and diagrams': annexes/rdf-model.md
-  - 'B. SPDX license expressions': annexes/spdx-license-expressions.md
-  - 'C. SPDX License List matching guidelines': annexes/license-matching-guidelines-and-templates.md
-  - 'D. SPDX Lite': annexes/spdx-lite.md
-  - 'E. Package URL specification': annexes/pkg-url-specification.md
+  - 'A. Class hierarchy': annexes/class-hierarchy.md
+  - 'B. RDF model definition and diagrams': annexes/rdf-model.md
+  - 'C. SPDX license expressions': annexes/spdx-license-expressions.md
+  - 'D. SPDX License List matching guidelines': annexes/license-matching-guidelines-and-templates.md
+  - 'E. SPDX Lite': annexes/spdx-lite.md
+  - 'F. Package URL specification': annexes/pkg-url-specification.md
 - licenses:
   - 'Community Specification License 1.0': licenses/Community-Spec-1.0.md
   - 'Creative Commons Attribution License 3.0 Unported': licenses/CC-BY-3.0.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,12 +50,12 @@ nav:
 - model:  # __MODEL_PLACEHOLDER__, to be replaced by content from model-files.yml. Please do not edit this line.
   - "__MODEL_PLACEHOLDER__": "https://example.com"  # allows mkdocs.yml to be build/tested without full model list. Please do not edit this line.
 - annexes:
-  - 'A. Class hierarchy': annexes/class-hierarchy.md
-  - 'B. RDF model definition and diagrams': annexes/rdf-model.md
-  - 'C. SPDX license expressions': annexes/spdx-license-expressions.md
-  - 'D. SPDX License List matching guidelines': annexes/license-matching-guidelines-and-templates.md
-  - 'E. SPDX Lite': annexes/spdx-lite.md
-  - 'F. Package URL specification': annexes/pkg-url-specification.md
+  - 'A. RDF model definition and diagrams': annexes/rdf-model.md
+  - 'B. SPDX license expressions': annexes/spdx-license-expressions.md
+  - 'C. SPDX License List matching guidelines': annexes/license-matching-guidelines-and-templates.md
+  - 'D. SPDX Lite': annexes/spdx-lite.md
+  - 'E. Package URL specification': annexes/pkg-url-specification.md
+  - 'F. Class hierarchy': annexes/class-hierarchy.md
 - licenses:
   - 'Community Specification License 1.0': licenses/Community-Spec-1.0.md
   - 'Creative Commons Attribution License 3.0 Unported': licenses/CC-BY-3.0.md


### PR DESCRIPTION
As part of an effort to address https://github.com/spdx/spdx-spec/issues/1190, spec-parser now generates class hierarchy page (with https://github.com/spdx/spec-parser/pull/209 merged).

This PR adds the class hierarchy page as an annex to the website navigation bar and fix the currently failed publish CI (resolve #1370).

Note that the casing of the page title ("Class Hierarchy") is currently inconsistent with the rest of the specification ("Terms and definitions", "Model and serializations", etc).
- Need https://github.com/spdx/spec-parser/pull/210 to fix that.

An empty `docs/annexes/class-hierarchy.md` is added to make validation PR workflow pass.

<img width="867" height="777" alt="Screenshot 2569-03-18 at 23 45 46" src="https://github.com/user-attachments/assets/176f8208-2855-4516-837f-de829e955fc5" />
