### PR TITLE
schema: Add pattern constraints for SPDXID and checksumValue

### DIFF
--- a/schemas/spdx-schema.json
+++ b/schemas/spdx-schema.json
@@ -93,6 +93,7 @@
               },
               "checksumValue" : {
                 "description" : "The checksumValue property provides a lower case hexadecimal encoded digest value produced using a specific algorithm.",
+                "pattern" : "^[0-9a-f]+$",
                 "type" : "string"
               }
             },
@@ -243,6 +244,7 @@
         "properties" : {
           "SPDXID" : {
             "type" : "string",
+            "pattern" : "^SPDXRef-[a-zA-Z0-9.-]+$",
             "description" : "Uniquely identify any element in an SPDX document which may be referenced by other elements."
           },
           "annotations" : {
@@ -300,6 +302,7 @@
                 },
                 "checksumValue" : {
                   "description" : "The checksumValue property provides a lower case hexadecimal encoded digest value produced using a specific algorithm.",
+                  "pattern" : "^[0-9a-f]+$",
                   "type" : "string"
                 }
               },
@@ -464,6 +467,7 @@
         "properties" : {
           "SPDXID" : {
             "type" : "string",
+            "pattern" : "^SPDXRef-[a-zA-Z0-9.-]+$",
             "description" : "Uniquely identify any element in an SPDX document which may be referenced by other elements."
           },
           "annotations" : {
@@ -524,6 +528,7 @@
                 },
                 "checksumValue" : {
                   "description" : "The checksumValue property provides a lower case hexadecimal encoded digest value produced using a specific algorithm.",
+                  "pattern" : "^[0-9a-f]+$",
                   "type" : "string"
                 }
               },
@@ -602,6 +607,7 @@
         "properties" : {
           "SPDXID" : {
             "type" : "string",
+            "pattern" : "^SPDXRef-[a-zA-Z0-9.-]+$",
             "description" : "Uniquely identify any element in an SPDX document which may be referenced by other elements."
           },
           "annotations" : {


### PR DESCRIPTION
The SPDX v2.3 specification defines the idstring grammar for element identifiers as letters, numbers, '.' and '-' (Annex D), and requires checksumValue to be a lowercase hexadecimal string (Section 8.4.1). However, the JSON schema does not enforce either constraint, allowing invalid documents to pass schema validation.

Add pattern constraints:
- SPDXID: '^SPDXRef-[a-zA-Z0-9.-]+$' on Package, File and Snippet elements (the Document SPDXID has no such restriction per Section 6.3)
- checksumValue: '^[0-9a-f]+$' on all three checksum definitions

These patterns match what the spdx-tools Python validator already enforces programmatically.

References:
- SPDXID restrictions for Packages: https://spdx.github.io/spdx-spec/v2.3/package-information/#7.2
- SPDXID restrictions for Files: https://spdx.github.io/spdx-spec/v2.3/file-information/#8.2
- SPDXID restrictions for Snippets: https://spdx.github.io/spdx-spec/v2.3/snippet-information/
- No SPDXID restrictions for Document: https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#6.3
- checksumValue hex format: https://spdx.github.io/spdx-spec/v2.3/file-information/#841-description

#### Testing Done

Verification:
- The existing examples/SPDXJSONExample-v2.3.spdx.json passes validation with the updated schema
- Invalid values (e.g., SPDXID with underscores, uppercase hex in checksumValue) are now correctly rejected