### PR TITLE
Remove unused symbol

### DIFF
--- a/docs/symbols.md
+++ b/docs/symbols.md
@@ -4,7 +4,6 @@ The following symbols and abbreviations are used throughout this document:
 
 | | |
 |-|-|
-| 3T-SBOM | Tool-to-Tool Software Bill of Materials Exchange |
 | ABNF | Augmented Backus–Naur form |
 | AI | Artificial Intelligence |
 | BNF | Backus–Naur form |

--- a/submissions/OMG/symbols.md
+++ b/submissions/OMG/symbols.md
@@ -1,0 +1,42 @@
+# Symbols
+
+The following symbols and abbreviations are used throughout this document:
+
+| | |
+|-|-|
+| 3T-SBOM | Tool-to-Tool Software Bill of Materials Exchange |
+| ABNF | Augmented Backus–Naur form |
+| AI | Artificial Intelligence |
+| BNF | Backus–Naur form |
+| BOM | Bill of Materials |
+| CISA | Cybersecurity and Infrastructure Security Agency |
+| CISQ | Consortium for Information & Software Quality |
+| CPE | Common Platform Enumeration |
+| CVE | Common Vulnerabilities and Exposures |
+| CVSS | Common Vulnerability Scoring System |
+| EPSS | Exploit Prediction Scoring System |
+| ISO | International Organization for Standardization |
+| JSON-LD | JavaScript Object Notation for Linking Data |
+| KEV | Known Exploited Vulnerabilities |
+| ML | Machine Learning |
+| NIST | National Institute of Standards and Technology |
+| NISTIR | NIST Internal or Interagency Report |
+| NTIA | National Telecommunications and Information Administration |
+| OSI | Open Source Initiative |
+| OWL | Web Ontology Language |
+| PAS | Publicly Available Specification |
+| POSIX | Portable Operating System Interface |
+| PTF | Platform Task Force |
+| PURL | Package URL |
+| RDF | Resource Description Framework |
+| RFC | Request For Comments |
+| SBOM | Software Bill of Materials |
+| SHA | Secure Hash Algorithms |
+| SHACL | Shapes Constraint Language |
+| SPDX | System Package Data Exchange (previously Software Package Data Exchange) |
+| SSVC | Stakeholder-Specific Vulnerability Categorization |
+| SWHID | SoftWare Hash IDentifier |
+| URI | Uniform Resource Identifier |
+| URL | Uniform Resource Locator |
+| VEX | Vulnerability Exploitability eXchange |
+| XML | Extensible Markup Language |


### PR DESCRIPTION
**3T-SBOM** is not used anywhere in the specification, so it should not be in the table of symbols.

It *is* used in the explanatory text for the OMG submission, so it should appear there.