### PR TITLE
Conformance: Use "only entails support for"

### DIFF
--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -74,9 +74,8 @@ compliance point shall be able to import and export serialized documents that
 conform with one of the SPDX serialization formats defined SPDX serialization
 formats.
 
-Conformance to the Software profile compliance point does not entail support
-for the Licensing, Dataset, AI, Build, Lite, or Extension profiles of the
-SPDX.
+Conformance to the Software profile compliance point
+only entails support for the Core profile.
 
 This compliance point, in combination with the Core profile compliance point,
 provides a baseline of functionality that facilitates interchange of the bills
@@ -96,9 +95,8 @@ vulnerabilities that may exist, the severity of those vulnerabilities, and a
 mechanism to express how a vulnerability may affect a specific software element
 including if a fix is available.
 
-Conformance to the Security profile compliance point does not entail support
-for the Licensing, Dataset, AI, Build, Lite, or Extension profiles of the
-SPDX.
+Conformance to the Security profile compliance point
+only entails support for the Core profile.
 
 This compliance point facilitates interchange of the security information
 produced by tools supporting SPDX.
@@ -119,9 +117,8 @@ and the ExpandedLicensing profile.
 Both allow expression of the same information,
 albeit in different ways.
 
-Conformance to the Licensing profile compliance point does not entail support
-for the Software, Security, Dataset, AI, Build, Lite, or Extension profiles of
-the SPDX.
+Conformance to the Licensing profile compliance point
+only entails support for the Core profile.
 
 This compliance point facilitates interchange of the licensing documents
 expressing which licenses and copyright notices are determined by persons or
@@ -144,9 +141,8 @@ The Dataset profile can convey insights into the structure, format, content,
 and properties of a dataset, helping users understand and analyze the data more
 effectively.
 
-Conformance to the Dataset profile compliance point does not entail support
-for the Software, Licensing, Security, AI, Build, Lite, or Extension profiles
-of the SPDX.
+Conformance to the Dataset profile compliance point
+only entails support for the Core profile.
 
 This compliance point facilitates interchange of the information about
 datasets produced by tools supporting SPDX.
@@ -167,9 +163,8 @@ components used to build or deploy the AI system, along with relevant
 information about their versions, licenses, and useful security references
 including ethical and security information.
 
-Conformance to the AI profile compliance point does not entail support for the
-Software, Licensing, Security, Dataset, Build, Lite, or Extension profiles of
-the SPDX.
+Conformance to the AI profile compliance point
+only entails support for the Core profile.
 
 This compliance point facilitates interchange of the AI model related
 information produced by tools supporting SPDX.
@@ -187,9 +182,8 @@ generated and transformed. This includes encoding the inputs, outputs,
 procedures/instructions, environments and actors from the build process along
 with the associated evidence.
 
-Conformance to the Build profile compliance point does not entail support for
-the Software, Licensing, Security, Dataset, AI, Lite, or Extension profiles of
-the SPDX.
+Conformance to the Build profile compliance point
+only entails support for the Core profile.
 
 This compliance point facilitates interchange of the build information produced
 by tools supporting SPDX.
@@ -206,9 +200,8 @@ conform with one of the SPDX serialization formats defined SPDX serialization
 formats, including creation of the SBOM, package lists with licensing and other
 related items, and their relationships.
 
-Conformance to the Lite profile compliance point does not entail support for
-the Software, Licensing, Security, Dataset, AI, Build, or Extension profiles
-of the SPDX.
+Conformance to the Lite profile compliance point
+only entails support for the Core profile.
 
 This compliance point facilitates interchange of minimal licensing information
 when produced by tools supporting SPDX.
@@ -247,9 +240,8 @@ conform with one of the SPDX serialization formats defined SPDX serialization
 formats, including the abstract Extension class serving as the base for all
 defined Extension subclasses.
 
-Conformance to the Extension profile compliance point does not entail support
-for the Licensing, Security, Dataset, AI, Build, or profiles of the SPDX but
-is expected to be used in combination with the other profiles to extend them.
+Conformance to the Extension profile compliance point
+only entails support for the Core profile.
 
 This compliance point facilitates interchange of extended information that goes
 beyond the standard SPDX produced by tools supporting SPDX and is used between

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -75,7 +75,7 @@ conform with one of the SPDX serialization formats defined SPDX serialization
 formats.
 
 Conformance to the Software profile compliance point
-only entails support for the Core profile.
+only entails support for the Software and Core profile.
 
 This compliance point, in combination with the Core profile compliance point,
 provides a baseline of functionality that facilitates interchange of the bills

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -183,7 +183,7 @@ procedures/instructions, environments and actors from the build process along
 with the associated evidence.
 
 Conformance to the Build profile compliance point
-only entails support for the Core profile.
+only entails support for the Build and Core profile.
 
 This compliance point facilitates interchange of the build information produced
 by tools supporting SPDX.

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -142,7 +142,7 @@ and properties of a dataset, helping users understand and analyze the data more
 effectively.
 
 Conformance to the Dataset profile compliance point
-only entails support for the Core profile.
+only entails support for the Dataset and Core profile.
 
 This compliance point facilitates interchange of the information about
 datasets produced by tools supporting SPDX.

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -164,7 +164,7 @@ information about their versions, licenses, and useful security references
 including ethical and security information.
 
 Conformance to the AI profile compliance point
-only entails support for the Core profile.
+only entails support for the AI and Core profile.
 
 This compliance point facilitates interchange of the AI model related
 information produced by tools supporting SPDX.

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -241,7 +241,7 @@ formats, including the abstract Extension class serving as the base for all
 defined Extension subclasses.
 
 Conformance to the Extension profile compliance point
-only entails support for the Core profile.
+only entails support for the Extension and Core profile.
 
 This compliance point facilitates interchange of extended information that goes
 beyond the standard SPDX produced by tools supporting SPDX and is used between

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -118,7 +118,7 @@ Both allow expression of the same information,
 albeit in different ways.
 
 Conformance to the Licensing profile compliance point
-only entails support for the Core profile.
+only entails support for the Licensing and Core profile.
 
 This compliance point facilitates interchange of the licensing documents
 expressing which licenses and copyright notices are determined by persons or

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -96,7 +96,7 @@ mechanism to express how a vulnerability may affect a specific software element
 including if a fix is available.
 
 Conformance to the Security profile compliance point
-only entails support for the Core profile.
+only entails support for the Security and Core profile.
 
 This compliance point facilitates interchange of the security information
 produced by tools supporting SPDX.

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -201,7 +201,7 @@ formats, including creation of the SBOM, package lists with licensing and other
 related items, and their relationships.
 
 Conformance to the Lite profile compliance point
-only entails support for the Core profile.
+only entails support for the Lite and Core profile.
 
 This compliance point facilitates interchange of minimal licensing information
 when produced by tools supporting SPDX.


### PR DESCRIPTION
> [!NOTE]
> This PR targets `develop` branch.
> For similar fix that targets `support/3.0` branch, see PR #1401.

Standardise languages about support entailment the conformance points, as reported in #1400.