### PR TITLE
Add term: interface

### DIFF
--- a/docs/terms-and-definitions.md
+++ b/docs/terms-and-definitions.md
@@ -49,6 +49,13 @@ from CNSSI 4009-2015,
 *leveraged* from IETF RFC 4949 Ver 2 at
 <https://datatracker.ietf.org/doc/rfc4949/>)
 
+**interface**
+
+Point at which two or more logical, physical, or both,
+system elements or software system elements meet and act on or communicate with each other
+(From ISO/IEC/IEEE 12207:2026 Systems and software engineering--Software life cycle processes, 3.1.33.
+From ISO/IEC/IEEE 15288:2023 Systems and software engineering--System life cycle processes, 3.20)
+
 **persona**
 
 Representation of a type of user that includes


### PR DESCRIPTION
Add definition for term 'interface'. This definition is proposed by the spdx-hardware special interest group on 6/26/2026. 

Note: https://csrc.nist.gov/glossary/term/interface leverages their definition from [ISO/IEC/IEEE 15288:2015](https://www.iso.org/standard/63711.html), which has been superseded by the standards referenced in this PR.